### PR TITLE
Add Linux build support for slugsocial CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,16 @@ jobs:
             plat: darwin
             arch: x64
             ext: ""
+          - os: ubuntu-22.04
+            target: x86_64-unknown-linux-musl
+            plat: linux
+            arch: x64
+            ext: ""
+          - os: ubuntu-22.04-arm
+            target: aarch64-unknown-linux-musl
+            plat: linux
+            arch: arm64
+            ext: ""
 
     steps:
       - uses: actions/checkout@v4
@@ -35,6 +45,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+
+      - name: Install musl tools (Linux only)
+        if: matrix.plat == 'linux'
+        run: sudo apt-get install -y musl-tools
 
       - name: Build Rust CLI
         run: cargo build --release -p slugsocial --target ${{ matrix.target }}

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -17,7 +17,9 @@
   ],
   "optionalDependencies": {
     "@sortersocial/slugsocial-darwin-arm64": "0.0.1",
-    "@sortersocial/slugsocial-darwin-x64": "0.0.1"
+    "@sortersocial/slugsocial-darwin-x64": "0.0.1",
+    "@sortersocial/slugsocial-linux-arm64": "0.0.1",
+    "@sortersocial/slugsocial-linux-x64": "0.0.1"
   },
   "engines": {
     "node": ">=18"

--- a/packages/npm/platforms/linux-arm64/package.json
+++ b/packages/npm/platforms/linux-arm64/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@sortersocial/slugsocial-linux-arm64",
+  "version": "0.0.1",
+  "description": "Platform binary for slugsocial (linux arm64)",
+  "license": "MIT",
+  "os": ["linux"],
+  "cpu": ["arm64"],
+  "files": ["bin/slugsocial", "bin/README.txt"],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sortersocial/slug.git"
+  }
+}

--- a/packages/npm/platforms/linux-x64/package.json
+++ b/packages/npm/platforms/linux-x64/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@sortersocial/slugsocial-linux-x64",
+  "version": "0.0.1",
+  "description": "Platform binary for slugsocial (linux x64)",
+  "license": "MIT",
+  "os": ["linux"],
+  "cpu": ["x64"],
+  "files": ["bin/slugsocial", "bin/README.txt"],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sortersocial/slug.git"
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds Linux platform support to the slugsocial CLI release pipeline, enabling builds for both x86_64 and ARM64 architectures using musl libc for maximum compatibility.

## Key Changes
- **Release workflow**: Added two new Linux build targets to the GitHub Actions release matrix:
  - `x86_64-unknown-linux-musl` (ubuntu-22.04)
  - `aarch64-unknown-linux-musl` (ubuntu-22.04-arm)
- **Build dependencies**: Added conditional step to install `musl-tools` on Linux runners
- **NPM packages**: Created platform-specific package.json files for Linux distributions:
  - `@sortersocial/slugsocial-linux-x64` for x86_64 builds
  - `@sortersocial/slugsocial-linux-arm64` for ARM64 builds
- **Main package**: Updated root package.json to include Linux platform packages as optional dependencies

## Implementation Details
- Uses musl libc target for Linux builds to ensure compatibility across different Linux distributions without glibc version dependencies
- Follows the existing pattern established for macOS platform packages
- Linux packages are marked as optional dependencies, allowing installation on non-Linux systems without failures

https://claude.ai/code/session_01FmYiKkqY7DGaEYimQYMXT1