### PR TITLE
Add AGENTS.md for Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+slug.social is an event-sourced social ranking platform (Rust/Axum server + Rust CLI). No external database — all state lives in an append-only JSONL file on disk.
+
+### Required system dependencies
+
+- **Rust 1.88+** — pinned by `time 0.3.47` (edition 2024). The VM image ships 1.83; the update script installs 1.88 via `rustup`.
+- **pkg-config + libssl-dev** — needed for OpenSSL (reqwest crate).
+- **Babashka (`bb`)** — Clojure task runner used for dev server, integration tests, and releases.
+
+### Key commands
+
+| Task | Command |
+|---|---|
+| Dev server (port 8080) | `bb dev` |
+| Hot-reload dev server | `bb watch` (requires `cargo-watch`) |
+| Unit + integration tests (Rust) | `cargo test --all` |
+| End-to-end tests (Babashka) | `bb test` |
+| Full test suite | `bash TEST.sh` (runs both above) |
+| Release build | `cargo build --release --all` |
+| Available bb tasks | `bb tasks` |
+
+### Gotchas
+
+- The `bb test` suite builds **release** binaries (`cargo build --release`) and spawns server + CLI processes from `target/release/`. A debug-only build is not enough for e2e tests.
+- Auth requires OAuth. The dev server (`bb dev`) has no real Google OAuth configured. Tests use a mock Google OAuth server defined in `test/oauth.bb`. To post content via the API you need a bearer token from the OAuth flow — the `SLUG_KEYS=dev:dev` env var is passed to the server but auth still requires `slug_<id>_<secret>` tokens issued through OAuth.
+- The `Check` RPC endpoint (`[{"Check":{...}}]`) does **not** require auth and can be used for dry-run ranking verification.
+- The RPC batch endpoint (`POST /api/v0/rpc`) expects a JSON **array** (transparent `Vec<RpcCommand>`), not a single object.
+- Server tests in `server/tests/tree_state_blob.rs` and `server/tests/tree_toggle_js.rs` have `return;` early-exit guards — they compile but skip their bodies intentionally.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud specific development instructions, including:

- Required system dependencies (Rust 1.88+, pkg-config, libssl-dev, Babashka)
- Key commands table for dev server, tests, builds
- Non-obvious gotchas (release builds needed for e2e tests, OAuth auth flow, RPC batch format, etc.)

### Environment verification

All checks pass on the development environment:

| Check | Result |
|---|---|
| `cargo test --all` | 103 tests pass (46 unit + 38 basic + 14 integration + 2 DSL fixtures + 2 tree + 1 toggle) |
| `bb test` | 131 e2e checks pass (53 integration + 29 auth + 25 grants + 24 invites) |
| `bb dev` (server on :8080) | Healthz OK, homepage renders, RPC Check endpoint returns rankings |

[slug_social_web_demo.mp4](https://cursor.com/agents/bc-e35f0b50-a002-4c87-b1d9-5b85c88676fb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fslug_social_web_demo.mp4)
[slug.social homepage](https://cursor.com/agents/bc-e35f0b50-a002-4c87-b1d9-5b85c88676fb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage.webp)
[Garden page](https://cursor.com/agents/bc-e35f0b50-a002-4c87-b1d9-5b85c88676fb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgarden_page.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e35f0b50-a002-4c87-b1d9-5b85c88676fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e35f0b50-a002-4c87-b1d9-5b85c88676fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

