### PR TITLE
Fix room forum UX and private garden routing

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -58,6 +58,11 @@
            (grants/grants-test)
            (invites/invites-test))}
 
+  walkthrough-fixture
+  {:doc "Run local server + mock OAuth + seeded walkthrough data for manual browser demos"
+   :requires ([test.walkthrough-fixture :as walkthrough-fixture])
+   :task (walkthrough-fixture/run-fixture)}
+
   perf
   {:doc "Performance test: concurrent HTTP requests to detect blocking I/O"
    :requires ([scripts.perf :as perf])

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -34,7 +34,7 @@ pub use stream::{get_html_stream, get_stream};
 
 pub use validate::{normalize_room_and_thread, validate_ingest_document, ValidatedIngest};
 
-pub use web_post::post_web_ingest;
+pub use web_post::{check_web_ingest, post_web_ingest};
 
 #[cfg(test)]
 mod tests {

--- a/server/src/api/web_post.rs
+++ b/server/src/api/web_post.rs
@@ -1,20 +1,23 @@
 use axum::{
+    body,
     extract::State,
-    http::{header, HeaderMap, StatusCode},
+    http::{header, HeaderMap, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
     Form,
 };
 use axum_extra::extract::cookie::CookieJar;
 use serde::Deserialize;
-use slug_types::RpcResult;
+use slug_types::{RpcBatch, RpcBatchResponse, RpcCommand, RpcResult};
 
 use crate::{
     api::{
         auth::{optional_principal, SLUG_SESSION_COOKIE},
+        handle_rpc_batch,
         rpc::rpc_post_with_bearer,
     },
     canonical_path::canonicalize_tag,
-    html::JsBuilder,
+    html::{thread_feed_html, thread_feed_html_for_room, thread_feed_region_markup, JsBuilder},
+    reducer::{scope_from_room_wire, ScopeId},
     state::AppState,
 };
 
@@ -23,6 +26,10 @@ pub struct WebPostForm {
     pub room: String,
     pub thread_tag: String,
     pub text: String,
+    #[serde(default)]
+    pub error_target: Option<String>,
+    #[serde(default)]
+    pub form_id: Option<String>,
 }
 
 fn post_redirect_location(room: &str, thread_tag: &str) -> String {
@@ -51,9 +58,9 @@ fn js_redirect(to: &str) -> Response {
         .unwrap()
 }
 
-fn js_error(title: &str, detail: &str) -> Response {
+fn js_error(error_target: &str, title: &str, detail: &str) -> Response {
     let markup = maud::html! {
-        div id="errors" {
+        div id=(error_target.trim_start_matches('#')) {
             p class="auth-error" { (title) }
             @if !detail.is_empty() {
                 pre class="muted" { (detail) }
@@ -61,8 +68,133 @@ fn js_error(title: &str, detail: &str) -> Response {
         }
     };
     JsBuilder::new()
-        .morph_selector("#errors", markup)
+        .morph_selector(error_target, markup)
         .into_response()
+}
+
+fn form_error_target(form: &WebPostForm) -> String {
+    form.error_target
+        .as_deref()
+        .filter(|s| !s.trim().is_empty())
+        .map(|s| {
+            if s.starts_with('#') {
+                s.to_string()
+            } else {
+                format!("#{s}")
+            }
+        })
+        .unwrap_or_else(|| "#errors".to_string())
+}
+
+fn form_js_error(form: &WebPostForm, title: &str, detail: &str) -> Response {
+    js_error(&form_error_target(form), title, detail)
+}
+
+fn js_clear_errors(error_target: &str) -> Response {
+    let markup = maud::html! {
+        div id=(error_target.trim_start_matches('#')) {}
+    };
+    JsBuilder::new()
+        .morph_selector(error_target, markup)
+        .into_response()
+}
+
+fn empty_error_markup(error_target: &str) -> maud::Markup {
+    maud::html! {
+        div id=(error_target.trim_start_matches('#')) {}
+    }
+}
+
+async fn rpc_check_with_bearer(
+    state: &AppState,
+    bearer_token: &str,
+    room: String,
+    text: String,
+) -> Result<RpcResult, (String, Option<String>)> {
+    let mut headers = HeaderMap::new();
+    let hv = HeaderValue::from_str(&format!("Bearer {bearer_token}"))
+        .map_err(|_| ("invalid session token".into(), None))?;
+    headers.insert(header::AUTHORIZATION, hv);
+
+    let response = handle_rpc_batch(
+        State(state.clone()),
+        headers,
+        axum::Json(RpcBatch(vec![RpcCommand::Check { room, text }])),
+    )
+    .await
+    .into_response();
+
+    let status = response.status();
+    if !status.is_success() {
+        return Err((format!("rpc check http {}", status), None));
+    }
+
+    let body = body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .map_err(|e| (e.to_string(), None))?;
+    let parsed: RpcBatchResponse =
+        serde_json::from_slice(&body).map_err(|e| (e.to_string(), None))?;
+    let line = parsed
+        .results
+        .into_iter()
+        .next()
+        .ok_or_else(|| ("empty rpc check response".to_string(), None))?;
+    if line.ok {
+        line.result
+            .ok_or_else(|| ("missing rpc check result".to_string(), None))
+    } else {
+        Err((
+            line.error.unwrap_or_else(|| "check failed".to_string()),
+            line.hint,
+        ))
+    }
+}
+
+fn post_success_response<'a>(
+    state: &'a AppState,
+    form: &'a WebPostForm,
+) -> impl std::future::Future<Output = Response> + 'a {
+    async move {
+        let error_target = form_error_target(form);
+        let room = form.room.trim().to_string();
+        let thread_tag = canonicalize_tag(&form.thread_tag);
+        let thread_location = post_redirect_location(&room, &thread_tag);
+        let form_id = form.form_id.as_deref().unwrap_or_default();
+        let scope = scope_from_room_wire(&room);
+        let feed_markup = match &scope {
+            ScopeId::Public => thread_feed_html(state).await,
+            ScopeId::Room(_) => thread_feed_html_for_room(state, &room).await,
+        };
+        let thread_markup = thread_feed_region_markup(
+            state,
+            match &scope {
+                ScopeId::Public => None,
+                ScopeId::Room(_) => Some(room.as_str()),
+            },
+            &thread_tag,
+        )
+        .await;
+        let feed_selector = match &scope {
+            ScopeId::Public => "#thread-feed",
+            ScopeId::Room(_) => "#room-thread-feed",
+        };
+
+        let builder = JsBuilder::new()
+            .morph_selector(&error_target, empty_error_markup(&error_target))
+            .morph_selector(feed_selector, feed_markup)
+            .if_current_path_matches(&thread_location, |builder| {
+                let builder = builder.morph_selector("#thread-feed-region", thread_markup);
+                let builder = if !form_id.trim().is_empty() {
+                    builder.qs(&format!("#{form_id}")).reset()
+                } else {
+                    builder
+                };
+                builder
+            })
+            .if_current_path_not_matches(&thread_location, |builder| builder.redirect(&thread_location));
+
+        builder.into_response()
+    }
 }
 
 pub async fn post_web_ingest(
@@ -94,13 +226,53 @@ pub async fn post_web_ingest(
     let text = form.text.clone();
 
     if text.trim().is_empty() {
-        return js_error("empty post", "Write something in the text area (DSL / prose).")
+        return form_js_error(&form, "empty post", "Write something in the text area (DSL / prose).")
             .into_response();
     }
 
     match rpc_post_with_bearer(&state, &bearer, room.clone(), thread_tag.clone(), text).await {
-        Ok(RpcResult::PostOk { .. }) => js_redirect(&post_redirect_location(&room, &thread_tag)).into_response(),
-        Ok(_) => js_error("unexpected response", "Post did not return PostOk.").into_response(),
-        Err((msg, hint)) => js_error(&msg, hint.as_deref().unwrap_or("")).into_response(),
+        Ok(RpcResult::PostOk { .. }) => post_success_response(&state, &form).await.into_response(),
+        Ok(_) => form_js_error(&form, "unexpected response", "Post did not return PostOk.").into_response(),
+        Err((msg, hint)) => form_js_error(&form, &msg, hint.as_deref().unwrap_or("")).into_response(),
+    }
+}
+
+pub async fn check_web_ingest(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    jar: CookieJar,
+    Form(form): Form<WebPostForm>,
+) -> impl IntoResponse {
+    let reduced = state.reduced.read().await;
+    let Some(_username) = optional_principal(&headers, &jar, &reduced) else {
+        drop(reduced);
+        return js_redirect("/login").into_response();
+    };
+
+    let bearer = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer ").map(|t| t.trim().to_string()))
+        .or_else(|| jar.get(SLUG_SESSION_COOKIE).map(|c| c.value().to_string()));
+    drop(reduced);
+
+    let Some(bearer) = bearer else {
+        return js_redirect("/login").into_response();
+    };
+
+    let room = form.room.trim().to_string();
+    let thread_tag = canonicalize_tag(&form.thread_tag);
+    if thread_tag.is_empty() {
+        return form_js_error(&form, "missing thread tag", "Set a thread tag before posting.").into_response();
+    }
+
+    if form.text.trim().is_empty() {
+        return js_clear_errors(&form_error_target(&form)).into_response();
+    }
+
+    match rpc_check_with_bearer(&state, &bearer, room, form.text.clone()).await {
+        Ok(RpcResult::CheckOk { .. }) => js_clear_errors(&form_error_target(&form)).into_response(),
+        Ok(_) => form_js_error(&form, "unexpected response", "Check did not return CheckOk.").into_response(),
+        Err((msg, hint)) => form_js_error(&form, &msg, hint.as_deref().unwrap_or("")).into_response(),
     }
 }

--- a/server/src/html/forum.rs
+++ b/server/src/html/forum.rs
@@ -293,7 +293,7 @@ fn compose_form(nav: &ThreadNav, thread_tag: &str, show: bool) -> Markup {
                 input type="hidden" name="thread_tag" value=(thread_tag);
                 input type="hidden" name="error_target" value="thread-compose-errors";
                 input type="hidden" name="form_id" value="thread-compose-form";
-                textarea name="text" rows="8" cols="80" placeholder="prose or ~/items and votes…" {}
+                textarea name="text" rows="5" cols="80" placeholder="prose or ~/items and votes…" {}
                 p {
                     button type="submit" { "post" }
                 }
@@ -328,7 +328,7 @@ fn new_thread_form_public(show: bool) -> Markup {
                 label for="new-thread-tag" { "thread tag" }
                 input type="text" id="new-thread-tag" name="thread_tag" pattern="[a-z0-9_\\-]{1,64}" placeholder="my-topic";
                 label for="new-thread-text" { "text" }
-                textarea id="new-thread-text" name="text" rows="6" placeholder="#my-topic\n\nYour first post…" {}
+                textarea id="new-thread-text" name="text" rows="4" placeholder="#my-topic\n\nYour first post…" {}
                 p { button type="submit" { "create / post" } }
             }
         }
@@ -806,7 +806,7 @@ fn new_thread_form_for_room(nav: &ThreadNav, show: bool) -> Markup {
                 input type="hidden" name="form_id" value="room-new-thread-form";
                 label for="room-new-tag" { "thread tag" }
                 input type="text" id="room-new-tag" name="thread_tag" pattern="[a-z0-9_\\-]{1,64}" required;
-                textarea name="text" rows="6" placeholder="First post body…" required {}
+                textarea name="text" rows="4" placeholder="First post body…" required {}
                 p { button type="submit" { "post" } }
             }
         }

--- a/server/src/html/forum.rs
+++ b/server/src/html/forum.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 
 use crate::{
     api::optional_principal,
-    canonical_path::canonicalize_tag,
+    canonical_path::{canonicalize_item, canonicalize_tag},
     events::ThreadCapability,
     reducer::{ReducerState, ScopeId},
     state::AppState,
@@ -18,7 +18,7 @@ use crate::{
 
 use super::{
     authorship_address, bc_segment, bc_threads, cli_panel, layout, now_ms, recency_class,
-    render_linkified_with_embeds, JsBuilder,
+    render_linkified_with_embeds_in_scope, JsBuilder,
 };
 
 #[derive(Clone)]
@@ -29,6 +29,12 @@ struct ThreadRow {
     ingests: usize,
 }
 
+#[derive(Clone)]
+struct RoomMemberRow {
+    username: String,
+    capabilities: Vec<&'static str>,
+}
+
 /// URL helpers for public `/t/…` and private room threads `/r/{short}/{slug}/t/…`.
 #[derive(Clone)]
 pub struct ThreadNav {
@@ -36,20 +42,22 @@ pub struct ThreadNav {
     scope: ScopeId,
     room_path: String,
     thread_path_prefix: String,
+    garden_path_prefix: String,
 }
 
 impl ThreadNav {
-    pub fn public() -> Self {
+    pub(crate) fn public() -> Self {
         Self {
             room_wire: "public".into(),
             scope: ScopeId::Public,
             room_path: "/t".into(),
             thread_path_prefix: "/t".into(),
+            garden_path_prefix: "/~".into(),
         }
     }
 
     /// `room_id` wire form `shortid/slug`.
-    pub fn from_room_id(room_id: &str) -> Option<Self> {
+    pub(crate) fn from_room_id(room_id: &str) -> Option<Self> {
         let (short, slug) = room_id.split_once('/')?;
         if short.is_empty() || slug.is_empty() {
             return None;
@@ -59,19 +67,34 @@ impl ThreadNav {
             scope: ScopeId::Room(room_id.to_string()),
             room_path: format!("/r/{short}/{slug}"),
             thread_path_prefix: format!("/r/{short}/{slug}/t"),
+            garden_path_prefix: format!("/r/{short}/{slug}/~"),
         })
     }
 
-    fn scope(&self) -> ScopeId {
+    pub(crate) fn scope(&self) -> ScopeId {
         self.scope.clone()
     }
 
-    fn room_url(&self) -> &str {
+    pub(crate) fn room_url(&self) -> &str {
         &self.room_path
     }
 
-    fn thread_url(&self, tag: &str) -> String {
+    pub(crate) fn thread_url(&self, tag: &str) -> String {
         format!("{}/{}", self.thread_path_prefix, tag)
+    }
+
+    pub(crate) fn garden_root_url(&self) -> &str {
+        &self.garden_path_prefix
+    }
+
+    pub(crate) fn garden_item_url(&self, item: &str) -> String {
+        if let Some(tail) = crate::path_types::CanonicalItemUrl::parse(item)
+            .and_then(|c| c.tilde_tail().map(str::to_owned))
+        {
+            format!("{}/{}", self.garden_path_prefix, tail)
+        } else {
+            format!("{}/{}", self.garden_path_prefix, canonicalize_item(item))
+        }
     }
 
     fn thread_page_url(&self, tag: &str, offset: usize) -> String {
@@ -139,6 +162,45 @@ fn user_can_post_room(reduced: &ReducerState, room_id: &str, username: &str) -> 
     reduced.user_has_cap(room_id, username, ThreadCapability::Post)
 }
 
+fn capability_label(cap: ThreadCapability) -> &'static str {
+    match cap {
+        ThreadCapability::View => "view",
+        ThreadCapability::Post => "post",
+        ThreadCapability::Vote => "vote",
+        ThreadCapability::AddItem => "add_item",
+        ThreadCapability::Manage => "manage",
+    }
+}
+
+fn room_members_for_room(reduced: &ReducerState, room_id: &str) -> Vec<RoomMemberRow> {
+    let mut rows: Vec<RoomMemberRow> = reduced
+        .grants
+        .get(room_id)
+        .into_iter()
+        .flat_map(|members| members.iter())
+        .map(|(username, caps)| {
+            let mut ordered = Vec::new();
+            for cap in [
+                ThreadCapability::View,
+                ThreadCapability::Post,
+                ThreadCapability::Vote,
+                ThreadCapability::AddItem,
+                ThreadCapability::Manage,
+            ] {
+                if caps.contains(&cap) {
+                    ordered.push(capability_label(cap));
+                }
+            }
+            RoomMemberRow {
+                username: username.clone(),
+                capabilities: ordered,
+            }
+        })
+        .collect();
+    rows.sort_by(|a, b| a.username.cmp(&b.username));
+    rows
+}
+
 /// `feed_id` is e.g. `thread-feed` (public bump list, SSE) or `room-thread-feed`.
 fn render_thread_feed(nav: Option<&ThreadNav>, feed_id: &str, rows: &[ThreadRow], now: i64) -> Markup {
     html! {
@@ -202,14 +264,14 @@ fn bc_room(nav: &ThreadNav, room_slug: &str, thread_tag: Option<&str>) -> Markup
         a href="/" { "slug.social" }
         @if let Some(t) = thread_tag {
             (bc_segment(
-                &format!("r / {room_slug}"),
+                &format!("room:{room_slug}"),
                 nav.room_url(),
                 false,
             ))
             (bc_segment(&format!("#{t}"), &nav.thread_url(t), true))
         } @else {
             (bc_segment(
-                &format!("r / {room_slug}"),
+                &format!("room:{room_slug}"),
                 nav.room_url(),
                 true,
             ))
@@ -225,10 +287,12 @@ fn compose_form(nav: &ThreadNav, thread_tag: &str, show: bool) -> Markup {
         section class="compose" id="thread-compose" {
             h3 { "reply" }
             p class="muted" { "Uses the same ingest DSL as the CLI. You must be logged in." }
-            div id="errors" {}
-            form method="POST" action="/post" {
+            div id="thread-compose-errors" {}
+            form id="thread-compose-form" method="POST" action="/post" data-check-action="/post/check" {
                 input type="hidden" name="room" value=(nav.room_wire.clone());
                 input type="hidden" name="thread_tag" value=(thread_tag);
+                input type="hidden" name="error_target" value="thread-compose-errors";
+                input type="hidden" name="form_id" value="thread-compose-form";
                 textarea name="text" rows="8" cols="80" placeholder="prose or ~/items and votes…" {}
                 p {
                     button type="submit" { "post" }
@@ -243,12 +307,24 @@ fn new_thread_form_public(show: bool) -> Markup {
         return html! {};
     }
     html! {
-        section class="compose" id="public-new-thread-compose" {
+        button
+            type="button"
+            class="form-toggle"
+            data-toggle-target="#public-new-thread-compose"
+            data-open-label="new public thread"
+            data-close-label="hide new public thread"
+            aria-expanded="false"
+        {
+            "new public thread"
+        }
+        section class="compose" id="public-new-thread-compose" hidden {
             h3 { "new public thread" }
             p class="muted" { "Set thread tag and body. Example: start with a title line or use the CLI-shaped DSL." }
-            div id="errors" {}
-            form method="POST" action="/post" {
+            div id="public-new-thread-errors" {}
+            form id="public-new-thread-form" method="POST" action="/post" data-check-action="/post/check" {
                 input type="hidden" name="room" value="public";
+                input type="hidden" name="error_target" value="public-new-thread-errors";
+                input type="hidden" name="form_id" value="public-new-thread-form";
                 label for="new-thread-tag" { "thread tag" }
                 input type="text" id="new-thread-tag" name="thread_tag" pattern="[a-z0-9_\\-]{1,64}" placeholder="my-topic";
                 label for="new-thread-text" { "text" }
@@ -314,7 +390,7 @@ fn render_thread_feed_region_markup(
                             " · "
                             (ago)
                         }
-                        (render_linkified_with_embeds(display_body))
+                        (render_linkified_with_embeds_in_scope(display_body, nav.garden_root_url()))
                         @if truncated {
                             @let exp = nav.expand_url(tag, post_idx);
                             a href="#" class="show-full-link"
@@ -409,7 +485,7 @@ pub async fn home(
             p class="muted" { "dark = time-ordered · light = vote-ranked" }
             (render_thread_feed(Some(&nav), "thread-feed", &public_rows, now))
             (new_thread_form_public(show_forms))
-            (cli_panel("npx slugsocial forum"))
+            (cli_panel("npx slugsocial public forum list"))
         },
         None,
     );
@@ -523,8 +599,8 @@ async fn thread_view_inner(
     };
 
     let cli = match &sc {
-        ScopeId::Public => format!("npx slugsocial forum {tag}"),
-        ScopeId::Room(r) => format!("npx slugsocial private {r} forum {tag}"),
+        ScopeId::Public => format!("npx slugsocial public forum show {tag}"),
+        ScopeId::Room(r) => format!("npx slugsocial private {r} forum show {tag}"),
     };
 
     let page = layout(
@@ -535,6 +611,12 @@ async fn thread_view_inner(
             nav class="breadcrumb" { (bc) }
             h2 { "#" (tag) @if let Some(sub) = &subtitle { ": " (sub) } }
             p class="muted" { "top=oldest · bottom=newest" }
+            @if matches!(sc, ScopeId::Room(_)) {
+                p class="muted" {
+                    "room garden · "
+                    a href=(nav.garden_root_url()) { "~" }
+                }
+            }
             div id="thread-feed-region" {
                 @if display_ingests.is_empty() {
                     p class="muted" { "no activity yet" }
@@ -553,7 +635,7 @@ async fn thread_view_inner(
                                 " · "
                                 (ago)
                             }
-                            (render_linkified_with_embeds(display_body))
+                            (render_linkified_with_embeds_in_scope(display_body, nav.garden_root_url()))
                             @if truncated {
                                 @let exp = nav.expand_url(&tag, post_idx);
                                 a href="#" class="show-full-link"
@@ -644,6 +726,7 @@ pub async fn room_page(
     let scope = ScopeId::Room(room_id.clone());
     let mut rows = collect_thread_rows_for_scope(&reduced, &scope, now);
     let strip = auth_strip(&headers, &jar, &reduced);
+    let members = room_members_for_room(&reduced, &room_id);
     let show_new = user
         .as_ref()
         .map(|u| user_can_post_room(&reduced, &room_id, u))
@@ -655,7 +738,9 @@ pub async fn room_page(
         return (StatusCode::NOT_FOUND, "room not found").into_response();
     };
     let slug_display = room_slug.as_str();
-    let cli = format!("npx slugsocial private {room_id} forum");
+    let forum_cli = format!("npx slugsocial private {room_id} forum list");
+    let garden_cli = format!("npx slugsocial private {room_id} garden tree");
+    let audit_cli = format!("npx slugsocial private {room_id} audit");
 
     let page = layout(
         &format!("room {slug_display} — slug.social"),
@@ -665,12 +750,32 @@ pub async fn room_page(
             nav class="breadcrumb" { (bc_room(&nav, slug_display, None)) }
             h2 { (slug_display) }
             p class="muted" { (room_id) }
+            p class="muted room-links" {
+                "room garden · "
+                a href=(nav.garden_root_url()) { "~" }
+            }
+            @if !members.is_empty() {
+                h3 { "members" }
+                ul class="room-members" {
+                    @for member in &members {
+                        li {
+                            span class="room-member-name" { "@" (member.username) }
+                            span class="muted" {
+                                " · "
+                                (member.capabilities.join(", "))
+                            }
+                        }
+                    }
+                }
+            }
             h3 { "threads" }
             (render_thread_feed(Some(&nav), "room-thread-feed", &rows, now))
             @if show_new {
                 (new_thread_form_for_room(&nav, show_new))
             }
-            (cli_panel(&cli))
+            (cli_panel(&forum_cli))
+            (cli_panel(&garden_cli))
+            (cli_panel(&audit_cli))
         },
         None,
     );
@@ -682,11 +787,23 @@ fn new_thread_form_for_room(nav: &ThreadNav, show: bool) -> Markup {
         return html! {};
     }
     html! {
-        section class="compose" id="room-new-thread-compose" {
+        button
+            type="button"
+            class="form-toggle"
+            data-toggle-target="#room-new-thread-compose"
+            data-open-label="new thread in this room"
+            data-close-label="hide room thread form"
+            aria-expanded="false"
+        {
+            "new thread in this room"
+        }
+        section class="compose" id="room-new-thread-compose" hidden {
             h3 { "new thread in this room" }
-            div id="errors" {}
-            form method="POST" action="/post" {
+            div id="room-new-thread-errors" {}
+            form id="room-new-thread-form" method="POST" action="/post" data-check-action="/post/check" {
                 input type="hidden" name="room" value=(nav.room_wire.clone());
+                input type="hidden" name="error_target" value="room-new-thread-errors";
+                input type="hidden" name="form_id" value="room-new-thread-form";
                 label for="room-new-tag" { "thread tag" }
                 input type="text" id="room-new-tag" name="thread_tag" pattern="[a-z0-9_\\-]{1,64}" required;
                 textarea name="text" rows="6" placeholder="First post body…" required {}
@@ -744,7 +861,7 @@ async fn thread_post_view_inner(
                         " · "
                         (ago)
                     }
-                    (render_linkified_with_embeds(&ing.raw))
+                    (render_linkified_with_embeds_in_scope(&ing.raw, nav.garden_root_url()))
                 }
             } @else {
                 p class="muted" { "post not found" }
@@ -819,7 +936,7 @@ async fn thread_post_expand_inner(
                 " · "
                 (ago)
             }
-            (render_linkified_with_embeds(&ing.raw))
+            (render_linkified_with_embeds_in_scope(&ing.raw, nav.garden_root_url()))
         }
     };
 

--- a/server/src/html/garden.rs
+++ b/server/src/html/garden.rs
@@ -1,12 +1,17 @@
 use axum::{
     extract::{Path, State},
+    http::{HeaderMap, StatusCode},
     response::{Html, IntoResponse},
 };
+use axum_extra::extract::cookie::CookieJar;
 use maud::html;
 
 use crate::{
+    api::optional_principal,
     canonical_path::canonicalize_item,
+    events::ThreadCapability,
     path_types::CanonicalItemUrl,
+    reducer::{ReducerState, ScopeId},
     ranking::{connected_components_from_voted_pairs, ranked_items_subset},
     scope_rank::{build_children_rankings, ChildrenRankings},
     state::AppState,
@@ -14,8 +19,9 @@ use crate::{
 };
 
 use super::{
-    authorship_address, bc_path, cli_panel, layout, now_ms, ratio_pct, render_linkified_with_embeds,
-    breadcrumb_path::OntologyPath,
+    authorship_address, bc_path, cli_panel, layout, now_ms, ratio_pct,
+    render_linkified_with_embeds_in_scope, breadcrumb_path::OntologyPath,
+    forum::ThreadNav,
 };
 
 /// Display path for an item: `~/languages/rust` form.
@@ -26,14 +32,34 @@ fn item_display_path(item: &str) -> String {
 }
 
 /// Canonical ontology URL for an item path.
-fn item_href(item: &str) -> String {
-    CanonicalItemUrl::parse(item)
-        .and_then(|c| c.tilde_tail().map(|t| format!("/~/{}", t)))
-        .unwrap_or_else(|| format!("/~/{}", canonicalize_item(item)))
+fn item_href(item: &str, nav: &ThreadNav) -> String {
+    nav.garden_item_url(item)
+}
+
+fn room_not_found_page() -> impl IntoResponse {
+    let body = html! {
+        nav class="breadcrumb" { a href="/" { "slug.social" } }
+        h1 { "not found" }
+        p { "The requested page could not be found." }
+        p { a href="/" { "home" } }
+    };
+    let page = layout("not found — slug.social", "view-thread", body, None);
+    (StatusCode::NOT_FOUND, Html(page.into_string()))
+}
+
+fn user_can_view_room(reduced: &ReducerState, room_id: &str, username: Option<&str>) -> bool {
+    if !reduced.rooms.contains(room_id) {
+        return false;
+    }
+    let Some(u) = username else {
+        return false;
+    };
+    reduced.user_has_cap(room_id, u, ThreadCapability::View)
 }
 
 /// Ontology index — root-level paths. Private (UUID) roots are excluded.
 pub async fn garden_index(State(state): State<AppState>) -> impl IntoResponse {
+    let nav = ThreadNav::public();
     let child_rankings = {
         let reduced = state.reduced.read().await;
         build_children_rankings(reduced.public(), &CanonicalItemUrl::ontology_root())
@@ -57,9 +83,9 @@ pub async fn garden_index(State(state): State<AppState>) -> impl IntoResponse {
                         }
                         ol class="ont-ranking-list" {
                             @for r in comp.ranked.iter() {
-                                @let href = item_href(r.item.as_str());
+                                @let href = item_href(r.item.as_str(), &nav);
                                 li {
-                                    a href=(href) { "~/" (item_display_path(r.item.as_str())) }
+                                    a href=(href) { (item_display_path(r.item.as_str())) }
                                 }
                             }
                         }
@@ -71,8 +97,8 @@ pub async fn garden_index(State(state): State<AppState>) -> impl IntoResponse {
                         ul class="ont-group-list" {
                             @for name in &child_rankings.unranked_items {
                                 li {
-                                    @let href = item_href(name.as_str());
-                                    a href=(href) { "~/" (item_display_path(name.as_str())) }
+                                    @let href = item_href(name.as_str(), &nav);
+                                    a href=(href) { (item_display_path(name.as_str())) }
                                 }
                             }
                         }
@@ -92,7 +118,48 @@ pub async fn ontology_path(
     Path(path): Path<String>,
 ) -> impl IntoResponse {
     let path = OntologyPath::from_input(&path);
-    render_scope_view(state, path).await
+    render_scope_view(state, path, ThreadNav::public()).await
+}
+
+pub async fn room_garden_index(
+    State(state): State<AppState>,
+    Path((room_short, room_slug)): Path<(String, String)>,
+    headers: HeaderMap,
+    jar: CookieJar,
+) -> impl IntoResponse {
+    let room_id = format!("{room_short}/{room_slug}");
+    let reduced = state.reduced.read().await;
+    let user = optional_principal(&headers, &jar, &reduced);
+    if !user_can_view_room(&reduced, &room_id, user.as_deref()) {
+        drop(reduced);
+        return room_not_found_page().into_response();
+    }
+    drop(reduced);
+    let Some(nav) = ThreadNav::from_room_id(&room_id) else {
+        return (StatusCode::NOT_FOUND, "bad room path").into_response();
+    };
+    render_scope_view(state, OntologyPath::root(), nav).await
+}
+
+pub async fn room_ontology_path(
+    State(state): State<AppState>,
+    Path((room_short, room_slug, path)): Path<(String, String, String)>,
+    headers: HeaderMap,
+    jar: CookieJar,
+) -> impl IntoResponse {
+    let room_id = format!("{room_short}/{room_slug}");
+    let reduced = state.reduced.read().await;
+    let user = optional_principal(&headers, &jar, &reduced);
+    if !user_can_view_room(&reduced, &room_id, user.as_deref()) {
+        drop(reduced);
+        return room_not_found_page().into_response();
+    }
+    drop(reduced);
+    let Some(nav) = ThreadNav::from_room_id(&room_id) else {
+        return (StatusCode::NOT_FOUND, "bad room path").into_response();
+    };
+    let path = OntologyPath::from_input(&path);
+    render_scope_view(state, path, nav).await
 }
 
 #[derive(Debug, Clone)]
@@ -188,11 +255,14 @@ fn build_sibling_rank(
 
 fn build_rank_history(
     reduced: &crate::reducer::ReducerState,
+    scope: &ScopeId,
     item: &str,
 ) -> Vec<RankHistoryEntryView> {
-    let public = reduced.public();
+    let content = reduced
+        .content_for_scope(scope)
+        .unwrap_or_else(|| reduced.public());
     let item_key = CanonicalItemUrl(item.to_string());
-    let entries = match public.rank_history.get(&item_key) {
+    let entries = match content.rank_history.get(&item_key) {
         None => return vec![],
         Some(e) => e,
     };
@@ -226,7 +296,7 @@ fn build_rank_history(
             .unwrap_or_default();
 
         let thread_post_index = reduced.ingests_by_scope_thread
-            .get(&(crate::reducer::ScopeId::Public, e.thread.clone()))
+            .get(&(scope.clone(), e.thread.clone()))
             .and_then(|q| q.iter().rev().position(|id| id == &e.post_id))
             .map(|i| i + 1)
             .unwrap_or(0);
@@ -246,22 +316,25 @@ fn build_rank_history(
 
 fn build_item_page_view_model(
     reduced: &crate::reducer::ReducerState,
+    scope: &ScopeId,
     item: &str,
     vote_limit: usize,
 ) -> ItemPageViewModel {
-    let public = reduced.public();
+    let content = reduced
+        .content_for_scope(scope)
+        .unwrap_or_else(|| reduced.public());
     let item_key = CanonicalItemUrl::parse(item)
         .unwrap_or_else(|| CanonicalItemUrl::parse("~/").unwrap());
-    let child_rankings = build_children_rankings(public, &item_key);
-    let touching_votes: Vec<crate::reducer::VoteData> = public
+    let child_rankings = build_children_rankings(content, &item_key);
+    let touching_votes: Vec<crate::reducer::VoteData> = content
         .item_votes
         .get(&item_key)
         .map(|q| q.iter().take(vote_limit).cloned().collect())
         .unwrap_or_default();
 
-    let rank_history = build_rank_history(reduced, item_key.as_str());
+    let rank_history = build_rank_history(reduced, scope, item_key.as_str());
 
-    let mut threads: Vec<String> = public
+    let mut threads: Vec<String> = content
         .item_threads
         .get(&item_key)
         .map(|s| s.iter().cloned().collect())
@@ -270,7 +343,11 @@ fn build_item_page_view_model(
 
     ItemPageViewModel {
         item: item_key.as_str().to_string(),
-        body: public.item_bodies.get(&item_key).cloned(),
+        body: content
+            .item_bodies
+            .get(&item_key)
+            .cloned()
+            .or_else(|| reduced.public().item_bodies.get(&item_key).cloned()),
         sibling_rank: build_sibling_rank(reduced, &item_key),
         child_rankings,
         touching_votes,
@@ -279,11 +356,17 @@ fn build_item_page_view_model(
     }
 }
 
-async fn render_scope_view(state: AppState, path: OntologyPath) -> axum::response::Response {
+async fn render_scope_view(
+    state: AppState,
+    path: OntologyPath,
+    nav: ThreadNav,
+) -> axum::response::Response {
+    let scope = nav.scope();
     let model = {
         let reduced = state.reduced.read().await;
-        build_item_page_view_model(&reduced, path.as_str(), 50)
+        build_item_page_view_model(&reduced, &scope, path.as_str(), 50)
     };
+    let thread_href = |tag: &str| nav.thread_url(tag);
 
     let page = layout(
         &item_display_path(&model.item),
@@ -304,7 +387,7 @@ async fn render_scope_view(state: AppState, path: OntologyPath) -> axum::respons
                 }
                 @if let Some(body) = &model.body {
                     div class="ont-item-content" {
-                        (render_linkified_with_embeds(body))
+                        (render_linkified_with_embeds_in_scope(body, nav.garden_root_url()))
                     }
                 } @else {
                     div class="ont-item-content" { p class="muted" { "no body yet" } }
@@ -334,9 +417,9 @@ async fn render_scope_view(state: AppState, path: OntologyPath) -> axum::respons
                                     (ago)
                                 }
                                 div class="ont-vote-header" {
-                                    a class="item-link" href=(format!("/~/{}", v.a)) { code class="vote-left" { "/" (v.a) } }
+                                    a class="item-link" href=(item_href(v.a.as_str(), &nav)) { code class="vote-left" { "/" (v.a) } }
                                     span class="vote-ratio" { (format!("{}:{}", v.ratio_left, v.ratio_right)) }
-                                    a class="item-link" href=(format!("/~/{}", v.b)) { code class="vote-right" { "/" (v.b) } }
+                                    a class="item-link" href=(item_href(v.b.as_str(), &nav)) { code class="vote-right" { "/" (v.b) } }
                                 }
                                 div class="ratio-bar" aria-label={(format!("ratio {}:{}", v.ratio_left, v.ratio_right))} {
                                     div class=(left_class) style={(format!("width: {:.3}%;", pct))} {}
@@ -374,10 +457,10 @@ async fn render_scope_view(state: AppState, path: OntologyPath) -> axum::respons
                                 " · "
                                 span class="muted" { (ago) (label) }
                                 " · "
-                                a href=(format!("/t/{}", e.thread)) { "#" (e.thread) }
+                                a href=(thread_href(&e.thread)) { "#" (e.thread) }
                                 @if e.thread_post_index > 0 {
                                     " "
-                                    a href=(format!("/t/{}/{}", e.thread, e.post_id)) {
+                                    a href=(format!("{}/{}", thread_href(&e.thread), e.thread_post_index)) {
                                         span class="muted" { "post #" (e.thread_post_index) }
                                     }
                                 }
@@ -391,9 +474,9 @@ async fn render_scope_view(state: AppState, path: OntologyPath) -> axum::respons
                                     @let right_class = if v.b.as_str() == model.item { "ratio-right current" } else { "ratio-right" };
                                     div class="rank-history-vote" {
                                         div class="ont-vote-header" {
-                                            a class="item-link" href=(format!("/~/{}", v.a)) { code { "/" (v.a) } }
+                                            a class="item-link" href=(item_href(v.a.as_str(), &nav)) { code { "/" (v.a) } }
                                             span class="vote-ratio" { (format!("{}:{}", v.ratio_left, v.ratio_right)) }
-                                            a class="item-link" href=(format!("/~/{}", v.b)) { code { "/" (v.b) } }
+                                            a class="item-link" href=(item_href(v.b.as_str(), &nav)) { code { "/" (v.b) } }
                                         }
                                         div class="ratio-bar" {
                                             div class=(left_class) style={(format!("width: {:.3}%;", pct))} {}
@@ -415,7 +498,7 @@ async fn render_scope_view(state: AppState, path: OntologyPath) -> axum::respons
                     span class="muted" { "discussed in " }
                     @for (i, tag) in model.threads.iter().enumerate() {
                         @if i > 0 { span class="muted" { " · " } }
-                        a href=(format!("/t/{tag}")) { "#" (tag) }
+                        a href=(thread_href(tag)) { "#" (tag) }
                     }
                 }
             }
@@ -432,7 +515,7 @@ async fn render_scope_view(state: AppState, path: OntologyPath) -> axum::respons
                             }
                             ol class="ont-ranking-list" {
                                 @for r in comp.ranked.iter() {
-                                    @let item_url = item_href(r.item.as_str());
+                                    @let item_url = item_href(r.item.as_str(), &nav);
                                     @let score_str = format!("{:.3}", r.score);
                                     li {
                                         a class="item-link" href=(item_url) { code { "/" (item_display_path(r.item.as_str())) } }
@@ -450,7 +533,7 @@ async fn render_scope_view(state: AppState, path: OntologyPath) -> axum::respons
                         ul class="ont-group-list" {
                             @for name in &model.child_rankings.unranked_items {
                                 li {
-                                    @let href = item_href(name.as_str());
+                                    @let href = item_href(name.as_str(), &nav);
                                     a class="item-link" href=(href) { code { "/" (item_display_path(name.as_str())) } }
                                 }
                             }
@@ -458,7 +541,11 @@ async fn render_scope_view(state: AppState, path: OntologyPath) -> axum::respons
                     }
                 }
             }
-            (cli_panel(&format!("npx slugsocial garden body {}", item_display_path(&model.item))))
+            @let cli = match &scope {
+                ScopeId::Public => format!("npx slugsocial public garden body {}", path.as_str().trim_start_matches("https://slug.social/~/")),
+                ScopeId::Room(room_id) => format!("npx slugsocial private {room_id} garden body {}", path.as_str().trim_start_matches("https://slug.social/~/")),
+            };
+            (cli_panel(&cli))
         },
         None,
     );
@@ -471,7 +558,7 @@ mod tests {
     use super::build_item_page_view_model;
     use crate::{
         events::{Event, Ingest},
-        reducer::ReducerState,
+        reducer::{ReducerState, ScopeId},
     };
 
     fn apply_ingest(state: &mut ReducerState, ts: i64, raw: &str) {
@@ -498,7 +585,7 @@ mod tests {
              ~/topic/b {beta}\n",
         );
 
-        let model = build_item_page_view_model(&reduced, "~/topic/a", 50);
+        let model = build_item_page_view_model(&reduced, &ScopeId::Public, "~/topic/a", 50);
         assert_eq!(model.body.as_deref(), Some("alpha"));
         assert!(model.sibling_rank.is_none());
         assert!(model.child_rankings.component_rankings.is_empty());
@@ -519,7 +606,7 @@ mod tests {
              ~/other/x 4:1 ~/other/y {other vote}\n",
         );
 
-        let model = build_item_page_view_model(&reduced, "~/topic/a", 50);
+        let model = build_item_page_view_model(&reduced, &ScopeId::Public, "~/topic/a", 50);
         assert_eq!(model.touching_votes.len(), 1);
         assert_eq!(model.touching_votes[0].a.as_str(), "https://slug.social/~/topic/a");
         assert_eq!(model.touching_votes[0].b.as_str(), "https://slug.social/~/topic/b");
@@ -539,7 +626,7 @@ mod tests {
              ~/topic/a 2:1 ~/topic/b {a beats b}\n",
         );
 
-        let model = build_item_page_view_model(&reduced, "~/topic/a", 50);
+        let model = build_item_page_view_model(&reduced, &ScopeId::Public, "~/topic/a", 50);
         let rank = model.sibling_rank.expect("expected sibling rank");
         assert_eq!(rank.position, 1);
         assert_eq!(rank.component_size, 2);
@@ -562,7 +649,7 @@ mod tests {
              ~/topic/kid1/leaf {leaf}\n",
         );
 
-        let model = build_item_page_view_model(&reduced, "~/topic", 50);
+        let model = build_item_page_view_model(&reduced, &ScopeId::Public, "~/topic", 50);
         assert_eq!(model.child_rankings.component_rankings.len(), 1);
         assert_eq!(model.child_rankings.component_rankings[0].pairs, 1);
         let names: Vec<&str> = model.child_rankings.component_rankings[0]

--- a/server/src/html/garden.rs
+++ b/server/src/html/garden.rs
@@ -177,7 +177,6 @@ struct RankHistoryEntryView {
     scope_rank_delta: i32,
     thread: String,
     thread_post_index: usize,
-    post_id: String,
     caused_by: Vec<crate::reducer::VoteData>,
 }
 
@@ -308,7 +307,6 @@ fn build_rank_history(
             scope_rank_delta: e.scope_rank_delta,
             thread: e.thread.clone(),
             thread_post_index,
-            post_id: e.post_id.clone(),
             caused_by,
         }
     }).collect()

--- a/server/src/html/garden.rs
+++ b/server/src/html/garden.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 use super::{
-    authorship_address, bc_path, cli_panel, layout, now_ms, ratio_pct,
+    authorship_address, bc_path, bc_segment, cli_panel, layout, now_ms, ratio_pct,
     render_linkified_with_embeds_in_scope, breadcrumb_path::OntologyPath,
     forum::ThreadNav,
 };
@@ -34,6 +34,29 @@ fn item_display_path(item: &str) -> String {
 /// Canonical ontology URL for an item path.
 fn item_href(item: &str, nav: &ThreadNav) -> String {
     nav.garden_item_url(item)
+}
+
+fn item_code_label(item: &str) -> String {
+    item_display_path(item)
+}
+
+fn scoped_bc_path(path: &OntologyPath, nav: &ThreadNav) -> maud::Markup {
+    match nav.scope() {
+        ScopeId::Public => bc_path(path),
+        ScopeId::Room(rid) => {
+            let slug = rid.split_once('/').map(|(_, s)| s).unwrap_or(rid.as_str());
+            html! {
+                a href="/" { "slug.social" }
+                (bc_segment(&format!("room:{slug}"), nav.room_url(), false))
+                (bc_segment("~", nav.garden_root_url(), path.is_root()))
+                @for (i, seg) in path.segments().iter().enumerate() {
+                    @let href = format!("{}/{}", nav.garden_root_url(), path.segments()[..=i].join("/"));
+                    @let is_last = i == path.segments().len() - 1;
+                    (bc_segment(seg, &href, is_last))
+                }
+            }
+        }
+    }
 }
 
 fn room_not_found_page() -> impl IntoResponse {
@@ -194,12 +217,15 @@ struct ItemPageViewModel {
 
 fn build_sibling_rank(
     reduced: &crate::reducer::ReducerState,
+    scope: &ScopeId,
     item: &CanonicalItemUrl,
 ) -> Option<SiblingRank> {
-    let public = reduced.public();
-    let group = &public.ranking_group;
+    let content = reduced
+        .content_for_scope(scope)
+        .unwrap_or_else(|| reduced.public());
+    let group = &content.ranking_group;
     let parent = item.parent()?;
-    let siblings: Vec<CanonicalItemUrl> = public
+    let siblings: Vec<CanonicalItemUrl> = content
         .item_children
         .get(&parent)
         .map(|s| s.iter().cloned().collect())
@@ -346,7 +372,7 @@ fn build_item_page_view_model(
             .get(&item_key)
             .cloned()
             .or_else(|| reduced.public().item_bodies.get(&item_key).cloned()),
-        sibling_rank: build_sibling_rank(reduced, &item_key),
+        sibling_rank: build_sibling_rank(reduced, scope, &item_key),
         child_rankings,
         touching_votes,
         rank_history,
@@ -370,7 +396,7 @@ async fn render_scope_view(
         &item_display_path(&model.item),
         "view-ontology view-ontology-dark",
         html! {
-            nav class="breadcrumb" { (bc_path(&path)) }
+            nav class="breadcrumb" { (scoped_bc_path(&path, &nav)) }
             section class="ont-item-shell" {
                 header class="ont-item-meta" {
                     span class="ont-item-title" { (item_display_path(&model.item)) }
@@ -415,9 +441,9 @@ async fn render_scope_view(
                                     (ago)
                                 }
                                 div class="ont-vote-header" {
-                                    a class="item-link" href=(item_href(v.a.as_str(), &nav)) { code class="vote-left" { "/" (v.a) } }
+                                    a class="item-link" href=(item_href(v.a.as_str(), &nav)) { code class="vote-left" { (item_code_label(v.a.as_str())) } }
                                     span class="vote-ratio" { (format!("{}:{}", v.ratio_left, v.ratio_right)) }
-                                    a class="item-link" href=(item_href(v.b.as_str(), &nav)) { code class="vote-right" { "/" (v.b) } }
+                                    a class="item-link" href=(item_href(v.b.as_str(), &nav)) { code class="vote-right" { (item_code_label(v.b.as_str())) } }
                                 }
                                 div class="ratio-bar" aria-label={(format!("ratio {}:{}", v.ratio_left, v.ratio_right))} {
                                     div class=(left_class) style={(format!("width: {:.3}%;", pct))} {}
@@ -472,9 +498,9 @@ async fn render_scope_view(
                                     @let right_class = if v.b.as_str() == model.item { "ratio-right current" } else { "ratio-right" };
                                     div class="rank-history-vote" {
                                         div class="ont-vote-header" {
-                                            a class="item-link" href=(item_href(v.a.as_str(), &nav)) { code { "/" (v.a) } }
+                                            a class="item-link" href=(item_href(v.a.as_str(), &nav)) { code { (item_code_label(v.a.as_str())) } }
                                             span class="vote-ratio" { (format!("{}:{}", v.ratio_left, v.ratio_right)) }
-                                            a class="item-link" href=(item_href(v.b.as_str(), &nav)) { code { "/" (v.b) } }
+                                            a class="item-link" href=(item_href(v.b.as_str(), &nav)) { code { (item_code_label(v.b.as_str())) } }
                                         }
                                         div class="ratio-bar" {
                                             div class=(left_class) style={(format!("width: {:.3}%;", pct))} {}
@@ -516,7 +542,7 @@ async fn render_scope_view(
                                     @let item_url = item_href(r.item.as_str(), &nav);
                                     @let score_str = format!("{:.3}", r.score);
                                     li {
-                                        a class="item-link" href=(item_url) { code { "/" (item_display_path(r.item.as_str())) } }
+                                        a class="item-link" href=(item_url) { code { (item_display_path(r.item.as_str())) } }
                                         span class="ont-rank-score" { (score_str) }
                                     }
                                 }
@@ -532,7 +558,7 @@ async fn render_scope_view(
                             @for name in &model.child_rankings.unranked_items {
                                 li {
                                     @let href = item_href(name.as_str(), &nav);
-                                    a class="item-link" href=(href) { code { "/" (item_display_path(name.as_str())) } }
+                                    a class="item-link" href=(href) { code { (item_display_path(name.as_str())) } }
                                 }
                             }
                         }

--- a/server/src/html/mod.rs
+++ b/server/src/html/mod.rs
@@ -20,9 +20,9 @@ pub use editor::{editor_check, editor_page};
 pub use forum::{
     home, room_page, room_thread_post_expand, room_thread_post_view, room_thread_view,
     thread_feed_html, thread_feed_html_for_room, thread_feed_region_markup,
-    thread_post_expand, thread_post_view, thread_view,
+    thread_post_expand, thread_post_view, thread_view, ThreadNav,
 };
-pub use garden::{garden_index, ontology_path};
+pub use garden::{garden_index, ontology_path, room_garden_index, room_ontology_path};
 pub use search::{search_page, search_results_fragment};
 
 // Embed CSS files at compile time
@@ -107,9 +107,23 @@ impl JsBuilder {
         self
     }
 
+    pub(crate) fn if_current_path_not_matches(mut self, path: &str, f: impl FnOnce(JsBuilder) -> JsBuilder) -> Self {
+        let inner = f(JsBuilder::new()).build();
+        self.snippets.push(format!(
+            "var __slugHere = window.location.pathname + window.location.search; var __slugPath = {path}; if (!(__slugHere === __slugPath || __slugHere.indexOf(__slugPath + '?') === 0)) {{ {inner} }}",
+            path = js_string_literal(path),
+        ));
+        self
+    }
+
     pub(crate) fn redirect(mut self, to: &str) -> Self {
         self.snippets
             .push(format!("window.location = {};", js_string_literal(to)));
+        self
+    }
+
+    pub(crate) fn raw(mut self, code: impl Into<String>) -> Self {
+        self.snippets.push(code.into());
         self
     }
 
@@ -236,6 +250,62 @@ script { (maud::PreEscaped(r#"
                             if (js && js.trim()) {
                                 eval(js);
                             }
+                        });
+
+                        // Small client-side toggles for compose panes.
+                        document.addEventListener('click', (e) => {
+                            const btn = e.target && e.target.closest && e.target.closest('[data-toggle-target]');
+                            if (!btn) return;
+                            const selector = btn.getAttribute('data-toggle-target');
+                            if (!selector) return;
+                            const target = document.querySelector(selector);
+                            if (!target) return;
+                            const willOpen = target.hasAttribute('hidden');
+                            if (willOpen) {
+                                target.removeAttribute('hidden');
+                            } else {
+                                target.setAttribute('hidden', '');
+                            }
+                            btn.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
+                            const openLabel = btn.getAttribute('data-open-label');
+                            const closeLabel = btn.getAttribute('data-close-label');
+                            if (openLabel && closeLabel) {
+                                btn.textContent = willOpen ? closeLabel : openLabel;
+                            }
+                            if (willOpen) {
+                                const firstField = target.querySelector('input[type="text"], textarea');
+                                if (firstField) firstField.focus();
+                            }
+                        });
+
+                        // Debounced forum form validation.
+                        const checkTimers = new WeakMap();
+                        async function runFormCheck(form) {
+                            const action = form.getAttribute('data-check-action');
+                            if (!action) return;
+                            const resp = await fetch(action, {
+                                method: 'POST',
+                                body: new URLSearchParams(new FormData(form)),
+                                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                                credentials: 'same-origin',
+                            });
+                            const js = await resp.text();
+                            if (js && js.trim()) {
+                                eval(js);
+                            }
+                        }
+                        document.addEventListener('input', (e) => {
+                            const target = e.target;
+                            if (!target || !target.closest) return;
+                            const form = target.closest('form[data-check-action]');
+                            if (!form) return;
+                            if (!(target.tagName === 'INPUT' || target.tagName === 'TEXTAREA')) return;
+                            const prev = checkTimers.get(form);
+                            if (prev) clearTimeout(prev);
+                            const handle = setTimeout(() => {
+                                runFormCheck(form).catch((err) => console.warn('slug form check failed', err));
+                            }, 250);
+                            checkTimers.set(form, handle);
                         });
 
                         // Search: debounced fetch + idiomorph.
@@ -383,7 +453,7 @@ fn escape_html(s: &str) -> String {
 }
 
 /// Replace ~/path slugs in raw text with clickable links.
-pub(super) fn linkify_slugs(raw: &str) -> String {
+pub(super) fn linkify_slugs_with_prefix(raw: &str, garden_prefix: &str) -> String {
     let escaped = escape_html(raw);
     let mut out = String::with_capacity(escaped.len() + 64);
     let mut i = 0;
@@ -398,7 +468,9 @@ pub(super) fn linkify_slugs(raw: &str) -> String {
                 .sum::<usize>();
             if path_len > 0 {
                 let path = &after_tilde[..path_len];
-                out.push_str(r#"<a href="/~/"#);
+                out.push_str(r#"<a href=""#);
+                out.push_str(&escape_html(garden_prefix.trim_end_matches('/')));
+                out.push('/');
                 out.push_str(path);
                 out.push_str(r#"" class="pre-link">~/"#);
                 out.push_str(path);
@@ -415,6 +487,10 @@ pub(super) fn linkify_slugs(raw: &str) -> String {
         }
     }
     out
+}
+
+pub(super) fn linkify_slugs(raw: &str) -> String {
+    linkify_slugs_with_prefix(raw, "/~")
 }
 
 #[derive(Clone)]
@@ -528,10 +604,10 @@ fn extract_embed_frames(raw: &str) -> Vec<EmbedFrame> {
     out
 }
 
-pub(super) fn render_linkified_with_embeds(raw: &str) -> Markup {
+pub(super) fn render_linkified_with_embeds_in_scope(raw: &str, garden_prefix: &str) -> Markup {
     let embeds = extract_embed_frames(raw);
     html! {
-        pre { (maud::PreEscaped(linkify_slugs(raw))) }
+        pre { (maud::PreEscaped(linkify_slugs_with_prefix(raw, garden_prefix))) }
         @if !embeds.is_empty() {
             div class="rich-embeds" {
                 @for e in embeds {
@@ -548,6 +624,10 @@ pub(super) fn render_linkified_with_embeds(raw: &str) -> Markup {
             }
         }
     }
+}
+
+pub(super) fn render_linkified_with_embeds(raw: &str) -> Markup {
+    render_linkified_with_embeds_in_scope(raw, "/~")
 }
 
 /// Small CLI hint panel showing how to look up this page from the terminal.

--- a/server/src/html/mod.rs
+++ b/server/src/html/mod.rs
@@ -122,11 +122,6 @@ impl JsBuilder {
         self
     }
 
-    pub(crate) fn raw(mut self, code: impl Into<String>) -> Self {
-        self.snippets.push(code.into());
-        self
-    }
-
     pub(crate) fn build(self) -> String {
         self.snippets.join(" ")
     }
@@ -489,10 +484,6 @@ pub(super) fn linkify_slugs_with_prefix(raw: &str, garden_prefix: &str) -> Strin
     out
 }
 
-pub(super) fn linkify_slugs(raw: &str) -> String {
-    linkify_slugs_with_prefix(raw, "/~")
-}
-
 #[derive(Clone)]
 struct EmbedFrame {
     src: String,
@@ -624,10 +615,6 @@ pub(super) fn render_linkified_with_embeds_in_scope(raw: &str, garden_prefix: &s
             }
         }
     }
-}
-
-pub(super) fn render_linkified_with_embeds(raw: &str) -> Markup {
-    render_linkified_with_embeds_in_scope(raw, "/~")
 }
 
 /// Small CLI hint panel showing how to look up this page from the terminal.

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -31,6 +31,7 @@ pub fn create_app(state: AppState) -> Router {
         .route("/login", get(api::get_web_login))
         .route("/logout", get(api::get_logout))
         .route("/post", post(api::post_web_ingest))
+        .route("/post/check", post(api::check_web_ingest))
         .route("/sse", get(api::get_html_stream))
         .route("/stream", get(api::get_stream))
         .route("/search", get(crate::html::search_page))
@@ -39,6 +40,11 @@ pub fn create_app(state: AppState) -> Router {
         .route("/try/check", post(crate::html::editor_check))
         .route("/~", get(crate::html::garden_index))
         .route("/~/*path", get(crate::html::ontology_path))
+        .route("/r/:room_short/:room_slug/~", get(crate::html::room_garden_index))
+        .route(
+            "/r/:room_short/:room_slug/~/*path",
+            get(crate::html::room_ontology_path),
+        )
         .route(
             "/t/:tag/:index/expand",
             get(crate::html::thread_post_expand),

--- a/server/static/theme_default.css
+++ b/server/static/theme_default.css
@@ -211,14 +211,16 @@ section.compose {
   border: var(--bv-lg) solid;
   border-color: var(--hi) var(--lo) var(--lo) var(--hi);
   margin: 8px 0;
-  min-width: 320px;
   padding: 10px;
-  width: fit-content;
+  width: 100%;
+  min-width: 100%;
+  max-width: 100%;
 }
 section.compose form {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  width: 100%;
 }
 section.compose textarea {
   background: var(--g1);
@@ -227,11 +229,12 @@ section.compose textarea {
   color: var(--signal);
   font-family: monospace;
   font-size: 12px;
-  min-width: 320px;
   outline: none;
   padding: 6px 8px;
   resize: vertical;
   width: 100%;
+  min-width: 100%;
+  max-width: 100%;
 }
 section.compose textarea:focus {
   border-color: var(--lo) #666 #666 var(--lo);
@@ -494,7 +497,8 @@ div.ingest-entry {
   border: var(--bv) solid;
   border-color: var(--hi) var(--lo) var(--lo) var(--hi);
   margin: 0 0 5px;
-  width: fit-content;
+  width: 100%;
+  min-width: 100%;
   max-width: 100%;
 }
 /* Slug links in pre: always link-colored, no underline */
@@ -527,10 +531,12 @@ pre {
   font-size: 12px;
   margin: 0 0 6px;
   overflow-x: auto;
+  overflow-wrap: anywhere;
   padding: 8px 10px;
   white-space: pre-wrap;
-  word-break: break-all;
-  width: fit-content;
+  word-break: break-word;
+  width: 100%;
+  min-width: 100%;
   max-width: 100%;
 }
 .rich-embeds {
@@ -686,7 +692,8 @@ body.view-ontology-dark .ont-vote-entry {
   border: var(--bv-lg) solid;
   border-color: var(--hi) var(--lo) var(--lo) var(--hi);
   margin: 6px 0;
-  width: fit-content;
+  width: 100%;
+  min-width: 100%;
   max-width: 100%;
 }
 body.view-ontology-dark .ont-item-meta,
@@ -752,7 +759,8 @@ body.view-ontology-dark details.ont-related-votes {
   border: var(--bv-lg) solid;
   border-color: var(--hi) var(--lo) var(--lo) var(--hi);
   margin: 6px 0;
-  width: fit-content;
+  width: 100%;
+  min-width: 100%;
   max-width: 100%;
 }
 body.view-ontology-dark details.ont-related-votes > summary {
@@ -828,7 +836,8 @@ body.view-ontology-light .ont-item-shell {
   border: var(--bv-lg) solid;
   border-color: var(--hi) var(--lo) var(--lo) var(--hi);
   margin: 6px 0;
-  width: fit-content;
+  width: 100%;
+  min-width: 100%;
   max-width: 100%;
 }
 body.view-ontology-light .ont-group-shell,
@@ -836,7 +845,8 @@ body.view-ontology-light .ont-vote-entry {
   background: var(--g2);
   border: 1px solid var(--lo);
   margin: 6px 0;
-  width: fit-content;
+  width: 100%;
+  min-width: 100%;
   max-width: 100%;
 }
 body.view-ontology-light .ont-item-meta,
@@ -901,7 +911,8 @@ body.view-ontology-light details.ont-related-votes {
   background: var(--g2);
   border: 1px solid var(--lo);
   margin: 6px 0;
-  width: fit-content;
+  width: 100%;
+  min-width: 100%;
   max-width: 100%;
 }
 body.view-ontology-light details.ont-related-votes > summary {
@@ -1006,7 +1017,8 @@ body.view-ontology-dark details.ont-rank-history {
   border: var(--bv-lg) solid;
   border-color: var(--hi) var(--lo) var(--lo) var(--hi);
   margin: 6px 0;
-  width: fit-content;
+  width: 100%;
+  min-width: 100%;
   max-width: 100%;
 }
 body.view-ontology-dark details.ont-rank-history > summary {

--- a/server/static/theme_default.css
+++ b/server/static/theme_default.css
@@ -206,6 +206,61 @@ form.ingest-form textarea:focus {
   gap: 8px;
 }
 
+section.compose {
+  background: var(--g2);
+  border: var(--bv-lg) solid;
+  border-color: var(--hi) var(--lo) var(--lo) var(--hi);
+  margin: 8px 0;
+  min-width: 320px;
+  padding: 10px;
+  width: fit-content;
+}
+section.compose form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+section.compose textarea {
+  background: var(--g1);
+  border: var(--bv) solid;
+  border-color: var(--lo) var(--hi) var(--hi) var(--lo);
+  color: var(--signal);
+  font-family: monospace;
+  font-size: 12px;
+  min-width: 320px;
+  outline: none;
+  padding: 6px 8px;
+  resize: vertical;
+  width: 100%;
+}
+section.compose textarea:focus {
+  border-color: var(--lo) #666 #666 var(--lo);
+}
+.form-toggle {
+  background: var(--g5);
+  border: var(--bv) solid;
+  border-color: var(--hi) var(--lo) var(--lo) var(--hi);
+  color: var(--signal);
+  cursor: pointer;
+  font-size: 12px;
+  margin: 8px 0 4px;
+  padding: 4px 10px;
+}
+.form-toggle:active {
+  border-color: var(--lo) var(--hi) var(--hi) var(--lo);
+  transform: translate(1px, 1px);
+}
+.room-members {
+  margin-bottom: 10px;
+}
+.room-member-name {
+  color: var(--signal);
+  font-family: monospace;
+}
+.room-links {
+  margin-top: 0;
+}
+
 /* ----------------------------------------------------------------
    AUTH FORM — choose username, complete page
    ---------------------------------------------------------------- */

--- a/server/static/theme_retro.css
+++ b/server/static/theme_retro.css
@@ -66,11 +66,13 @@ p.auth-success { color: #00ff41; font-family: monospace; font-size: 0.8rem; marg
 
 .compose {
   margin: 1rem 0;
+  width: 100%;
 }
 .compose form {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  width: 100%;
 }
 .compose textarea,
 .compose input[type="text"] {
@@ -81,6 +83,7 @@ p.auth-success { color: #00ff41; font-family: monospace; font-size: 0.8rem; marg
   font-size: 0.85rem;
   padding: 0.5rem;
   width: 100%;
+  min-width: 100%;
   box-sizing: border-box;
 }
 .compose textarea:focus,
@@ -108,6 +111,24 @@ p.auth-success { color: #00ff41; font-family: monospace; font-size: 0.8rem; marg
 }
 .room-members li {
   margin: 0.25rem 0;
+}
+
+div.ingest-entry,
+pre,
+.ont-item-shell,
+.ont-group-shell,
+.ont-vote-entry,
+details.ont-related-votes,
+details.ont-rank-history {
+  width: 100%;
+  min-width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+pre {
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 /* Ontology view: paper mode */

--- a/server/static/theme_retro.css
+++ b/server/static/theme_retro.css
@@ -64,6 +64,52 @@ p.auth-success { color: #00ff41; font-family: monospace; font-size: 0.8rem; marg
 .ingest-form button[type="submit"]:hover { border-color: #00ff41; }
 .ingest-form button[type="submit"]:disabled { opacity: 0.5; cursor: default; }
 
+.compose {
+  margin: 1rem 0;
+}
+.compose form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.compose textarea,
+.compose input[type="text"] {
+  background: #0a0a0a;
+  border: 1px solid #333;
+  color: #00ff41;
+  font-family: monospace;
+  font-size: 0.85rem;
+  padding: 0.5rem;
+  width: 100%;
+  box-sizing: border-box;
+}
+.compose textarea:focus,
+.compose input[type="text"]:focus {
+  outline: 1px solid #00ff41;
+}
+.form-toggle {
+  background: #0a0a0a;
+  border: 1px solid #333;
+  color: #00ff41;
+  cursor: pointer;
+  font-family: monospace;
+  font-size: 0.85rem;
+  padding: 0.25rem 0.75rem;
+}
+.form-toggle:hover { border-color: #00ff41; }
+.room-links,
+.room-members {
+  font-family: monospace;
+  font-size: 0.85rem;
+}
+.room-members {
+  list-style: none;
+  padding-left: 0;
+}
+.room-members li {
+  margin: 0.25rem 0;
+}
+
 /* Ontology view: paper mode */
 body.view-ontology {
   background: #f5f0e8;

--- a/server/tests/integration.rs
+++ b/server/tests/integration.rs
@@ -279,7 +279,9 @@ async fn test_private_room_thread_urls_use_t_segment() {
     );
     let post_js = post.text().await.unwrap();
     let location = format!("/r/{room_short}/{room_slug}/t/main-thread");
-    assert_eq!(post_js, format!("window.location = {:?};", location));
+    assert!(post_js.contains(&format!("window.location = {:?};", location)));
+    assert!(post_js.contains("#room-thread-feed"));
+    assert!(post_js.contains("#thread-feed-region"));
 
     let thread_page = client
         .get(format!("http://{addr}{location}"))
@@ -291,6 +293,100 @@ async fn test_private_room_thread_urls_use_t_segment() {
     let body = thread_page.text().await.unwrap();
     assert!(body.contains("#main-thread"));
     assert!(body.contains("private post via web"));
+}
+
+#[tokio::test]
+async fn test_private_room_post_links_use_private_garden_routes() {
+    let (addr, _tmp, _log, _handle) = create_test_server().await;
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let bearer = test_bearer();
+
+    let create = rpc_batch(
+        &client,
+        addr,
+        Some(&bearer),
+        serde_json::json!([{
+            "RoomCreate": { "slug": "private-garden-links" }
+        }]),
+    )
+    .await;
+    let room_id = create["results"][0]["result"]["RoomCreated"]["room_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let (room_short, room_slug) = room_id.split_once('/').unwrap();
+
+    let post = client
+        .post(format!("http://{addr}/post"))
+        .header("Authorization", format!("Bearer {bearer}"))
+        .form(&[
+            ("room", room_id.as_str()),
+            ("thread_tag", "garden-thread"),
+            ("text", "~/secret/item {classified}\n~/secret/other {other body}\n~/secret/item 3:1 ~/secret/other {because}\n"),
+        ])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(post.status(), reqwest::StatusCode::OK);
+
+    let thread_page = client
+        .get(format!("http://{addr}/r/{room_short}/{room_slug}/t/garden-thread"))
+        .header("Authorization", format!("Bearer {bearer}"))
+        .send()
+        .await
+        .unwrap();
+    assert!(thread_page.status().is_success());
+    let body = thread_page.text().await.unwrap();
+    assert!(body.contains(&format!("/r/{room_short}/{room_slug}/~/secret/item")));
+    assert!(!body.contains("href=\"/~/secret/item\""));
+
+    let garden_page = client
+        .get(format!("http://{addr}/r/{room_short}/{room_slug}/~/secret/item"))
+        .header("Authorization", format!("Bearer {bearer}"))
+        .send()
+        .await
+        .unwrap();
+    assert!(garden_page.status().is_success());
+    let garden_body = garden_page.text().await.unwrap();
+    assert!(garden_body.contains("classified"));
+    assert!(garden_body.contains(&format!("/r/{room_short}/{room_slug}/t/garden-thread")));
+}
+
+#[tokio::test]
+async fn test_post_check_returns_targeted_js_error_for_missing_thread_tag() {
+    let (addr, _tmp, _log, _handle) = create_test_server().await;
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let bearer = test_bearer();
+
+    let resp = client
+        .post(format!("http://{addr}/post/check"))
+        .header("Authorization", format!("Bearer {bearer}"))
+        .form(&[
+            ("room", "public"),
+            ("thread_tag", ""),
+            ("text", "hello"),
+            ("error_target", "thread-compose-errors"),
+        ])
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        resp.headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok()),
+        Some("text/javascript; charset=utf-8")
+    );
+    let js = resp.text().await.unwrap();
+    assert!(js.contains("#thread-compose-errors"));
+    assert!(js.contains("missing thread tag"));
 }
 
 #[tokio::test]

--- a/test/oauth.clj
+++ b/test/oauth.clj
@@ -49,7 +49,7 @@
           resp (.send (http-client) req (java.net.http.HttpResponse$BodyHandlers/ofString))]
       {:status (.statusCode resp) :body (.body resp) :headers (.map (.headers resp))})))
 
-(defn http-post-form [url form]
+(defn http-post-form [url form & {:keys [headers]}]
   (let [pairs (->> form
                    (map (fn [[k v]]
                           (str (java.net.URLEncoder/encode (name k) "UTF-8")
@@ -58,6 +58,8 @@
                    (str/join "&"))
         b (java.net.http.HttpRequest/newBuilder (java.net.URI/create url))]
     (.header b "Content-Type" "application/x-www-form-urlencoded")
+    (doseq [[k v] (or headers {})]
+      (.header b k v))
     (let [req (-> b
                   (.timeout request-timeout)
                   (.POST (java.net.http.HttpRequest$BodyPublishers/ofString pairs))

--- a/test/walkthrough_fixture.clj
+++ b/test/walkthrough_fixture.clj
@@ -1,0 +1,104 @@
+(ns test.walkthrough-fixture
+  "Launch a local slug server with mock OAuth and seed browser-friendly demo data."
+  (:require [babashka.fs :as fs]
+            [cheshire.core :as json]
+            [clojure.string :as str]
+            [test.common :as common]
+            [test.oauth :as oauth]))
+
+(defn- assert! [pred msg]
+  (when-not pred
+    (throw (ex-info msg {}))))
+
+(defn- default-agent [n]
+  (format "00000000-0000-4000-8000-%012d:test:walkthrough/browser" n))
+
+(defn- rpc! [base-url bearer payload]
+  (oauth/http-post-json
+    (str base-url "/api/v0/rpc")
+    payload
+    :headers {"Authorization" (str "Bearer " bearer)}))
+
+(defn- parse-json [resp]
+  (json/parse-string (:body resp) true))
+
+(defn- ok-result [resp]
+  (let [body (parse-json resp)
+        line (get-in body [:results 0])]
+    (assert! (= 200 (:status resp)) (str "expected HTTP 200, got " (:status resp)))
+    (assert! (true? (:ok line)) (str "rpc line failed: " line))
+    (:result line)))
+
+(defn- seed-demo! [base-url]
+  (let [alice-token (oauth/fetch-bearer-token! base-url :username "alice" :agent (default-agent 1))
+        bob-token (oauth/fetch-bearer-token! base-url :username "bob" :agent (default-agent 2))
+        room-result (ok-result (rpc! base-url alice-token [{"RoomCreate" {"slug" "walkthrough-room"}}]))
+        room-id (get-in room-result [:RoomCreated :room_id])
+        [room-short room-slug] (str/split room-id #"/" 2)]
+    (ok-result
+      (rpc! base-url alice-token
+            [{"RoomGrant" {"room" room-id
+                           "username" "bob"
+                           "capabilities" ["view" "post" "vote" "add_item"]}}]))
+    (let [post-resp (oauth/http-post-form
+                      (str base-url "/post")
+                      {:room room-id
+                       :thread_tag "walkthrough-thread"
+                       :text "~/secret/item {classified}\n~/secret/other {secondary}\n~/secret/item 3:1 ~/secret/other {because}\n"}
+                      :headers {"Authorization" (str "Bearer " alice-token)})]
+      (assert! (= 200 (:status post-resp)) "seed post must succeed"))
+    {:users {:alice {:token alice-token}
+             :bob {:token bob-token}}
+     :room {:id room-id
+            :short room-short
+            :slug room-slug
+            :url (str base-url "/r/" room-short "/" room-slug)
+            :thread_url (str base-url "/r/" room-short "/" room-slug "/t/walkthrough-thread")
+            :garden_url (str base-url "/r/" room-short "/" room-slug "/~/secret/item")}}))
+
+(defn run-fixture [& _args]
+  (let [build (common/run-cargo-build-release! ["slugsocial-server"])
+        _ (assert! (zero? (:exit build)) "cargo build --release failed")
+        server-bin "target/release/slugsocial-server"
+        tmp-dir (str (fs/create-temp-dir {:prefix "slug-walkthrough-"}))
+        slug-port (common/pick-port)
+        google-port (common/pick-port)
+        base-url (str "http://127.0.0.1:" slug-port)
+        google-url (str "http://127.0.0.1:" google-port)
+        stable-dir "/tmp/slug-walkthrough-fixture"
+        summary-path (str stable-dir "/summary.json")
+        !server (atom nil)
+        !google (atom nil)
+        server-env (common/slug-server-env tmp-dir base-url google-url slug-port)]
+    (try
+      (fs/create-dirs stable-dir)
+      (reset! !google
+              (oauth/start-mock-google google-port
+                                       :google-users ["google-user-alice" "google-user-bob"]))
+      (reset! !server (common/start-server server-bin server-env))
+      (assert! (common/wait-for-server base-url 10000) "server did not become healthy")
+      (let [seeded (seed-demo! base-url)
+            summary {:base_url base-url
+                     :mock_google_url google-url
+                     :data_dir tmp-dir
+                     :summary seeded}]
+        (spit summary-path (json/generate-string summary {:pretty true}))
+        (println "")
+        (println "walkthrough fixture ready")
+        (println (str "  base url:      " base-url))
+        (println (str "  room page:     " (get-in summary [:summary :room :url])))
+        (println (str "  thread page:   " (get-in summary [:summary :room :thread_url])))
+        (println (str "  garden page:   " (get-in summary [:summary :room :garden_url])))
+        (println (str "  summary json:  " summary-path))
+        (println "")
+        (println "seeded users")
+        (println "  alice / bob via mock OAuth")
+        (println "")
+        (println "press Ctrl-C to stop")
+        (flush)
+        (while true
+          (Thread/sleep 1000)))
+      (finally
+        (when-some [s @!server] (common/kill-server s))
+        (when-some [g @!google] ((:stop-fn g)))
+        (fs/delete-tree tmp-dir)))))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add room-scoped garden routes under `/r/:room_short/:room_slug/~...` and route `~/...` links in private room posts/garden pages to those room paths
- improve room forum UX: hidden new-thread forms, per-keystroke `/post/check` validation, room member/capability list, updated breadcrumbs, and correct CLI command strings with `forum show`
- polish room forum/garden rendering: room-scoped ontology breadcrumbs, cleaner `~/...` labels in vote/history links, full-width post cards, and smaller compose textareas
- make web post responses refresh the current thread/feed in place while still redirecting when posting from elsewhere
- add a reusable `bb walkthrough-fixture` task that starts local slug + mock OAuth and seeds a private-room/thread/garden demo scenario for manual walkthroughs
- extend integration coverage for private room garden links and targeted form-check errors

## Testing
- `cargo test -p slugsocial-server --lib -- --nocapture`
- `cargo test -p slugsocial-server --test integration -- --nocapture`
- `cargo test -p slugsocial-server --test integration test_private_room_post_links_use_private_garden_routes -- --nocapture`
- `cargo test -p slugsocial-server --test integration test_private_room_thread_urls_use_t_segment -- --nocapture`
- `bb walkthrough-fixture` and authenticated URL checks from `/tmp/slug-walkthrough-fixture/summary.json`
- polished browser walkthrough artifact: [polished_private_room_walkthrough.mp4](https://cursor.com/agents/bc-5d390c85-7c42-470f-9fdb-5d411b772a08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpolished_private_room_walkthrough.mp4)
- screenshots: [room hidden form](https://cursor.com/agents/bc-5d390c85-7c42-470f-9fdb-5d411b772a08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpolish_room_page_hidden_form.webp) [compact form](https://cursor.com/agents/bc-5d390c85-7c42-470f-9fdb-5d411b772a08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpolish_room_page_compact_form.webp) [full width thread](https://cursor.com/agents/bc-5d390c85-7c42-470f-9fdb-5d411b772a08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpolish_thread_page_full_width.webp) [room garden breadcrumbs](https://cursor.com/agents/bc-5d390c85-7c42-470f-9fdb-5d411b772a08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpolish_room_garden_breadcrumbs.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d390c85-7c42-470f-9fdb-5d411b772a08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d390c85-7c42-470f-9fdb-5d411b772a08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

