### PR TITLE
fix(cli): send bearer token for private room read RPCs

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -757,10 +757,23 @@ fn write_secret_file(name: &str, contents: &str) -> Result<()> {
 async fn run_scoped(base: &str, room: &str, sub: ScopedCmd) -> Result<()> {
     let room = room.trim();
     let client = http_client()?;
+    // Private room RPC reads authorize via bearer; without it the server returns "room not found"
+    // (same as unknown room) to avoid enumeration. Public scope ignores the header.
+    let scoped_read_bearer: Option<String> = if room == "public" {
+        None
+    } else {
+        Some(effective_bearer().ok_or_else(|| {
+            anyhow!(
+                "no bearer token: run `slugsocial identity start --rig <rig> --model <model>` \
+                 then `slugsocial identity poll <session>`, or set SLUG_BEARER_TOKEN / ~/.config/slugsocial/token"
+            )
+        })?)
+    };
+    let scoped_read_bearer = scoped_read_bearer.as_deref();
     match sub {
         ScopedCmd::Garden { sub } => match sub {
             GardenCmd::Tree { json } => {
-                let batch = send_rpc(&client, base, None, vec![RpcCommand::GetLeaves { room: room.to_string() }]).await?;
+                let batch = send_rpc(&client, base, scoped_read_bearer, vec![RpcCommand::GetLeaves { room: room.to_string() }]).await?;
                 match rpc_line_ok(&batch.results[0])? {
                     RpcResult::Leaves(resp) => {
                         if json {
@@ -780,7 +793,7 @@ async fn run_scoped(base: &str, room: &str, sub: ScopedCmd) -> Result<()> {
                 let batch = send_rpc(
                     &client,
                     base,
-                    None,
+                    scoped_read_bearer,
                     vec![RpcCommand::GetGardenItem {
                         room: room.to_string(),
                         item_path: item_q,
@@ -812,7 +825,7 @@ async fn run_scoped(base: &str, room: &str, sub: ScopedCmd) -> Result<()> {
                 let batch = send_rpc(
                     &client,
                     base,
-                    None,
+                    scoped_read_bearer,
                     vec![RpcCommand::GetGardenRank {
                         room: room.to_string(),
                         parent_path: parent_param,
@@ -840,7 +853,7 @@ async fn run_scoped(base: &str, room: &str, sub: ScopedCmd) -> Result<()> {
                 let batch = send_rpc(
                     &client,
                     base,
-                    None,
+                    scoped_read_bearer,
                     vec![RpcCommand::GetPair {
                         room: room.to_string(),
                         parent_path: parent_q,
@@ -864,7 +877,7 @@ async fn run_scoped(base: &str, room: &str, sub: ScopedCmd) -> Result<()> {
                 let batch = send_rpc(
                     &client,
                     base,
-                    None,
+                    scoped_read_bearer,
                     vec![RpcCommand::GetMatchup {
                         room: room.to_string(),
                         item_path: item_q,
@@ -889,7 +902,7 @@ async fn run_scoped(base: &str, room: &str, sub: ScopedCmd) -> Result<()> {
                 let batch = send_rpc(
                     &client,
                     base,
-                    None,
+                    scoped_read_bearer,
                     vec![RpcCommand::GetRankHistory {
                         room: room.to_string(),
                         item_path: item_q,
@@ -911,7 +924,7 @@ async fn run_scoped(base: &str, room: &str, sub: ScopedCmd) -> Result<()> {
                 let batch = send_rpc(
                     &client,
                     base,
-                    None,
+                    scoped_read_bearer,
                     vec![RpcCommand::GetGlobalRank {
                         room: room.to_string(),
                         limit: Some(limit),
@@ -937,7 +950,7 @@ async fn run_scoped(base: &str, room: &str, sub: ScopedCmd) -> Result<()> {
                 let batch = send_rpc(
                     &client,
                     base,
-                    None,
+                    scoped_read_bearer,
                     vec![RpcCommand::ListForumThreads {
                         room: room.to_string(),
                     }],
@@ -971,7 +984,7 @@ async fn run_scoped(base: &str, room: &str, sub: ScopedCmd) -> Result<()> {
                 let batch = send_rpc(
                     &client,
                     base,
-                    None,
+                    scoped_read_bearer,
                     vec![RpcCommand::GetForumThread {
                         room: room.to_string(),
                         thread_tag,
@@ -1197,7 +1210,7 @@ async fn run_scoped(base: &str, room: &str, sub: ScopedCmd) -> Result<()> {
             let batch = send_rpc(
                 &client,
                 base,
-                None,
+                scoped_read_bearer,
                 vec![RpcCommand::Check {
                     room: room.to_string(),
                     text,

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,8 @@
 [tools]
 # Matches the Rust baseline required by current deps (edition 2024).
 rust = "1.88.0"
+# JDK for Clojure CLI and JVM integration tests (Temurin LTS).
+java = "temurin-21"
 # JVM Clojure CLI for `clojure -M -m test.runner` / scripts/clj-test.sh (deps.edn).
 clojure = "1.12.0"
 # Used by TEST.sh and test/*.bb integration suites.

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,8 @@
 [tools]
 # Matches the Rust baseline required by current deps (edition 2024).
 rust = "1.88.0"
+# JVM Clojure CLI for `clojure -M -m test.runner` / scripts/clj-test.sh (deps.edn).
+clojure = "1.12.0"
 # Used by TEST.sh and test/*.bb integration suites.
 babashka = "1.12.217"
 

--- a/server/tests/integration.rs
+++ b/server/tests/integration.rs
@@ -124,6 +124,91 @@ async fn test_room_create_rpc() {
     );
 }
 
+/// Private room reads use `authorize_room_read`, which returns "room not found" when no bearer is sent
+/// (same as unknown room). The CLI must attach the saved token for `private … forum show` etc.
+#[tokio::test]
+async fn test_private_room_forum_read_requires_bearer() {
+    let (addr, _tmp, _log, _handle) = create_test_server().await;
+    let client = reqwest::Client::new();
+    let bearer = test_bearer();
+
+    let create = rpc_batch(
+        &client,
+        addr,
+        Some(&bearer),
+        serde_json::json!([{
+            "RoomCreate": { "slug": "bearer-for-reads" }
+        }]),
+    )
+    .await;
+    let room_id = create["results"][0]["result"]["RoomCreated"]["room_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let post = rpc_batch(
+        &client,
+        addr,
+        Some(&bearer),
+        serde_json::json!([{
+            "Post": {
+                "room": room_id,
+                "thread_tag": "cli-read-test",
+                "delegate": "00000000-0000-0000-0000-000000000000:test:local/test",
+                "text": "hello from private room\n",
+                "return_rank_diff": false
+            }
+        }]),
+    )
+    .await;
+    assert_eq!(post["results"][0]["ok"], true);
+
+    let no_auth = rpc_batch(
+        &client,
+        addr,
+        None,
+        serde_json::json!([{
+            "GetForumThread": {
+                "room": room_id,
+                "thread_tag": "cli-read-test",
+                "offset": null,
+                "limit": null,
+                "since": null,
+                "before": null,
+                "actor": null,
+                "post_id": null
+            }
+        }]),
+    )
+    .await;
+    let line_na = &no_auth["results"][0];
+    assert_eq!(line_na["ok"], false, "expected failure without bearer: {:?}", line_na);
+    assert_eq!(line_na["error"], "room not found");
+
+    let with_auth = rpc_batch(
+        &client,
+        addr,
+        Some(&bearer),
+        serde_json::json!([{
+            "GetForumThread": {
+                "room": room_id,
+                "thread_tag": "cli-read-test",
+                "offset": null,
+                "limit": null,
+                "since": null,
+                "before": null,
+                "actor": null,
+                "post_id": null
+            }
+        }]),
+    )
+    .await;
+    let line_ok = &with_auth["results"][0];
+    assert_eq!(line_ok["ok"], true, "expected success with bearer: {:?}", line_ok);
+    let total = line_ok["result"]["ForumThread"]["total"].as_u64().unwrap();
+    assert!(total >= 1);
+}
+
 #[tokio::test]
 async fn test_private_room_read_requires_explicit_view_capability() {
     let (addr, _tmp, _log, _handle) = create_test_server().await;

--- a/test/integration.clj
+++ b/test/integration.clj
@@ -138,6 +138,52 @@
       (assert! (not (str/blank? bearer-token)) "bearer token from OAuth")
       (bind token-env {"SLUG_BEARER_TOKEN" bearer-token})
 
+        ;; 2.6 private room: CLI read RPCs must send bearer (regression — missing header looked like "room not found")
+      (println "\nprivate room: create → post thread → forum show via CLI…")
+      (bind private-slug "cli-private-read-regression")
+      (bind create-room-result (common/run-cli cli-bin base-url ["room" "create" private-slug "--json"] :extra-env token-env))
+      (assert! (zero? (:exit create-room-result))
+               (str "cli room create exits 0 (err: " (:err create-room-result) ")"))
+      (bind create-room-json (json/parse-string (:out create-room-result) true))
+      (bind private-room-id (:room_id create-room-json))
+      (assert! (and (string? private-room-id) (str/includes? private-room-id "/"))
+               (str "room create returns shortid/slug room_id (got " (pr-str private-room-id) ")"))
+      (bind private-thread "private-cli-thread")
+      (bind private-marker "private room prose regression marker")
+      (bind private-doc
+            (str/join "\n"
+                      ["@00000000-0000-0000-0000-000000000000:cli:local/dev"
+                       (str "#" private-thread)
+                       ""
+                       private-marker]))
+      (bind private-post-result
+            (common/run-cli cli-bin base-url
+                            ["private" private-room-id "forum" "post" private-thread "--json"
+                             "--delegate" "00000000-0000-0000-0000-000000000000:cli:local/dev"]
+                            :input private-doc :extra-env token-env))
+      (assert! (zero? (:exit private-post-result))
+               (str "private forum post exits 0 (err: " (:err private-post-result) ")"))
+      (bind private-post-json (json/parse-string (:out private-post-result) true))
+      (assert! (:ok private-post-json) "private forum post ok=true")
+
+      (bind show-no-token (common/run-cli cli-bin base-url
+                                         ["private" private-room-id "forum" "show" private-thread "--json"]))
+      (assert! (not (zero? (:exit show-no-token)))
+               "private forum show without SLUG_BEARER_TOKEN must fail (server hides private rooms without auth)")
+
+      (bind show-with-token (common/run-cli cli-bin base-url
+                                            ["private" private-room-id "forum" "show" private-thread "--json"]
+                                            :extra-env token-env))
+      (assert! (zero? (:exit show-with-token))
+               (str "private forum show with bearer exits 0 (err: " (:err show-with-token) ")"))
+      (bind show-json (json/parse-string (:out show-with-token) true))
+      ;; ThreadItem JSON uses serde snake_case tag values: {:kind "post" :body ...}
+      (assert! (some (fn [row]
+                       (and (= "post" (:kind row))
+                            (str/includes? (str (:body row)) private-marker)))
+                     (:items show-json))
+               "private forum show --json includes posted prose body")
+
         ;; 3. ingest via CLI (bearer required)
       (println "\ningesting .sorter document via CLI…")
       (bind ingest1-result (common/run-cli cli-bin base-url ["public" "forum" "post" "integration-test" "--json" "--delegate" "00000000-0000-0000-0000-000000000000:cli:local/dev"] :input sorter-doc :extra-env token-env))
@@ -161,11 +207,12 @@
       (assert! (str/ends-with? (last ranked) "languages/go")
                (str "go is #3 (got " (last ranked) ")"))
 
-        ;; 5. verify JSONL written (user_registered + token_issued + agent_bound + ingest)
+        ;; 5. verify JSONL written (user_registered + token_issued + room_created + grant_added
+        ;;    + private ingest + agent_bound + public ingest)
       (assert! (fs/exists? event-log) "events.jsonl exists")
       (bind event-lines (->> (slurp event-log) str/split-lines (remove str/blank?)))
-      (assert! (= 4 (count event-lines))
-               (str "4 events in JSONL (user_registered + token_issued + agent_bound + ingest, got " (count event-lines) ")"))
+      (assert! (= 7 (count event-lines))
+               (str "7 events in JSONL (incl. private room + first public ingest, got " (count event-lines) ")"))
 
         ;; 6. query forum via CLI
       (println "\nquerying forum via CLI…")
@@ -216,8 +263,8 @@
                (str "two-vote ingest exits 0 (err: " (:err hist-ingest) ")"))
 
       (bind event-lines-after-hist (->> (slurp event-log) str/split-lines (remove str/blank?)))
-      (assert! (= 5 (count event-lines-after-hist))
-               (str "5 events in JSONL after second ingest (got " (count event-lines-after-hist) ")"))
+      (assert! (= 8 (count event-lines-after-hist))
+               (str "8 events in JSONL after second public ingest (got " (count event-lines-after-hist) ")"))
 
       (bind hist-result      (common/run-cli cli-bin base-url ["public" "garden" "history" "languages/rust" "--json"]))
       (assert! (zero? (:exit hist-result))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`private <shortid/slug> forum show …` (and other scoped reads) called `/api/v0/rpc` **without** `Authorization`. The server’s `authorize_room_read` maps a missing bearer to **`"room not found"`** (same as unknown room). Users with a valid token saw a misleading failure.

## Fix

For non-`public` scoped rooms, the CLI loads `effective_bearer()` and passes it on read/check RPCs.

## Tests

- **Rust:** `test_private_room_forum_read_requires_bearer` in `server/tests/integration.rs`.
- **Clojure (bb):** `test/integration.clj` creates a private room, posts via `private … forum post`, asserts `forum show` fails without `SLUG_BEARER_TOKEN` and succeeds with it. JSONL line counts account for `room_created` + `grant_added`.

Run: `bb run test` or `clojure -M -m test.runner` (see `mise.toml`).

## Dev env

`mise.toml` pins **Temurin JDK 21**, **Clojure CLI 1.12.0**, Rust, and Babashka so `scripts/clj-test.sh` works after `mise install`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7a5680d-c8a0-46b7-a509-32006f906bba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7a5680d-c8a0-46b7-a509-32006f906bba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

