### PR TITLE
User profiles (/u/:user), posts_by_actor index, @author in post headers

### DIFF
--- a/server/src/html/forum.rs
+++ b/server/src/html/forum.rs
@@ -11,13 +11,14 @@ use crate::{
     api::optional_principal,
     canonical_path::{canonicalize_item, canonicalize_tag},
     events::ThreadCapability,
-    reducer::{ReducerState, ScopeId},
+    identity::parse_username,
+    reducer::{scope_from_room_wire, ReducerState, ScopeId},
     state::AppState,
     timeago,
 };
 
 use super::{
-    authorship_address, bc_segment, bc_threads, cli_panel, layout, now_ms, recency_class,
+    bc_segment, bc_threads, cli_panel, layout, now_ms, profile_href, recency_class,
     render_linkified_with_embeds_in_scope, JsBuilder,
 };
 
@@ -112,6 +113,47 @@ impl ThreadNav {
 
     fn expand_url(&self, tag: &str, idx: usize) -> String {
         format!("{}/{}/{}/expand", self.thread_path_prefix, tag, idx)
+    }
+}
+
+fn thread_nav_for_ingest(ing: &crate::events::Ingest) -> Option<ThreadNav> {
+    let room = ing.room_id.trim();
+    if room.is_empty() || room == "public" {
+        Some(ThreadNav::public())
+    } else {
+        ThreadNav::from_room_id(room)
+    }
+}
+
+fn thread_post_index_in_scope(reduced: &ReducerState, ing: &crate::events::Ingest) -> Option<usize> {
+    let scope = scope_from_room_wire(&ing.room_id);
+    let tag = canonicalize_tag(&ing.thread_tag);
+    reduced
+        .ingests_by_scope_thread
+        .get(&(scope, tag))
+        .and_then(|q| q.iter().rev().position(|id| id == &ing.id))
+}
+
+fn post_header_meta(
+    nav: &ThreadNav,
+    tag: &str,
+    post_idx: usize,
+    principal: &str,
+    ts: i64,
+    now: i64,
+) -> Markup {
+    let post_href = nav.post_url(tag, post_idx);
+    let profile = profile_href(principal);
+    let hover = timeago::rfc3339_utc(ts);
+    let ago = timeago::timeago(now, ts);
+    html! {
+        div class="ingest-meta muted" title=(hover) {
+            a href=(post_href) class="post-num" { "#" (post_idx) }
+            " "
+            a href=(profile) class="post-author" { "@" (principal) }
+            " · "
+            (ago)
+        }
     }
 }
 
@@ -379,17 +421,10 @@ fn render_thread_feed_region_markup(
                 (paginator_top)
                 @for (i, ing) in display_ingests.iter().enumerate() {
                     @let post_idx = offset + i;
-                    @let post_href = nav.post_url(tag, post_idx);
-                    @let hover = timeago::rfc3339_utc(ing.ts);
-                    @let ago = timeago::timeago(now, ing.ts);
                     @let truncated = ing.raw.len() > 2000;
                     @let display_body = if truncated { &ing.raw[..2000] } else { &ing.raw[..] };
                     div class="ingest-entry" data-ingest-id=(ing.id) {
-                        div class="ingest-meta muted" title=(hover) {
-                            a href=(post_href) class="post-num" { "#" (post_idx) }
-                            " · "
-                            (ago)
-                        }
+                        (post_header_meta(nav, tag, post_idx, &ing.principal, ing.ts, now))
                         (render_linkified_with_embeds_in_scope(display_body, nav.garden_root_url()))
                         @if truncated {
                             @let exp = nav.expand_url(tag, post_idx);
@@ -624,17 +659,10 @@ async fn thread_view_inner(
                     (paginator_top)
                     @for (i, ing) in display_ingests.iter().enumerate() {
                         @let post_idx = offset + i;
-                        @let post_href = nav.post_url(&tag, post_idx);
-                        @let hover = timeago::rfc3339_utc(ing.ts);
-                        @let ago = timeago::timeago(now, ing.ts);
                         @let truncated = ing.raw.len() > 2000;
                         @let display_body = if truncated { &ing.raw[..2000] } else { &ing.raw[..] };
                         div class="ingest-entry" data-ingest-id=(ing.id) {
-                            div class="ingest-meta muted" title=(hover) {
-                                a href=(post_href) class="post-num" { "#" (post_idx) }
-                                " · "
-                                (ago)
-                            }
+                            (post_header_meta(&nav, &tag, post_idx, &ing.principal, ing.ts, now))
                             (render_linkified_with_embeds_in_scope(display_body, nav.garden_root_url()))
                             @if truncated {
                                 @let exp = nav.expand_url(&tag, post_idx);
@@ -853,14 +881,8 @@ async fn thread_post_view_inner(
             nav class="breadcrumb" { (bc) }
             h2 { "#" (tag) @if let Some(sub) = &subtitle { ": " (sub) } " / post #" (index) }
             @if let Some(ing) = ing {
-                @let hover = timeago::rfc3339_utc(ing.ts);
-                @let ago = timeago::timeago(now, ing.ts);
                 div class="ingest-entry" data-ingest-id=(ing.id) {
-                    div class="ingest-meta muted" title=(hover) {
-                        span class="address" { (authorship_address(&ing.principal, &ing.delegate)) }
-                        " · "
-                        (ago)
-                    }
+                    (post_header_meta(&nav, &tag, index, &ing.principal, ing.ts, now))
                     (render_linkified_with_embeds_in_scope(&ing.raw, nav.garden_root_url()))
                 }
             } @else {
@@ -925,17 +947,9 @@ async fn thread_post_expand_inner(
         return (StatusCode::NOT_FOUND, "post not found").into_response();
     };
 
-    let post_href = nav.post_url(&tag, index);
-    let hover = timeago::rfc3339_utc(ing.ts);
-    let ago = timeago::timeago(now, ing.ts);
-
     let full_html = html! {
         div class="ingest-entry" data-ingest-id=(ing.id) {
-            div class="ingest-meta muted" title=(hover) {
-                a href=(post_href) class="post-num" { "#" (index) }
-                " · "
-                (ago)
-            }
+            (post_header_meta(&nav, &tag, index, &ing.principal, ing.ts, now))
             (render_linkified_with_embeds_in_scope(&ing.raw, nav.garden_root_url()))
         }
     };
@@ -947,6 +961,97 @@ async fn thread_post_expand_inner(
         )
         .into_response()
         .into_response()
+}
+
+struct ProfilePostRow {
+    thread_tag: String,
+    post_idx: usize,
+    post_href: String,
+    ts: i64,
+    snippet: String,
+}
+
+pub async fn user_profile_page(
+    State(state): State<AppState>,
+    Path(username): Path<String>,
+    headers: HeaderMap,
+    jar: CookieJar,
+) -> impl IntoResponse {
+    let canon = match parse_username(&username) {
+        Ok(u) => u,
+        Err(_) => return (StatusCode::NOT_FOUND, "not found").into_response(),
+    };
+
+    let (rows, strip) = {
+        let reduced = state.reduced.read().await;
+        let viewer = optional_principal(&headers, &jar, &reduced);
+        let ids = reduced.visible_posts_for_actor(&canon, viewer.as_deref());
+        let mut rows: Vec<ProfilePostRow> = Vec::new();
+        for id in ids {
+            let Some(ing) = reduced.ingests_by_id.get(&id).cloned() else {
+                continue;
+            };
+            let Some(nav) = thread_nav_for_ingest(&ing) else {
+                continue;
+            };
+            let Some(post_idx) = thread_post_index_in_scope(&reduced, &ing) else {
+                continue;
+            };
+            let tag = canonicalize_tag(&ing.thread_tag);
+            let post_href = nav.post_url(&tag, post_idx);
+            let raw_one_line = ing.raw.lines().next().unwrap_or("").trim();
+            let snippet: String = raw_one_line.chars().take(120).collect();
+            rows.push(ProfilePostRow {
+                thread_tag: tag,
+                post_idx,
+                post_href,
+                ts: ing.ts,
+                snippet,
+            });
+        }
+        rows.sort_by(|a, b| b.ts.cmp(&a.ts));
+        let strip = auth_strip(&headers, &jar, &reduced);
+        (rows, strip)
+    };
+
+    let now = now_ms();
+    let page = layout(
+        &format!("@{canon}"),
+        "view-thread",
+        html! {
+            (strip)
+            nav class="breadcrumb" {
+                a href="/" { "slug.social" }
+                (bc_segment(&format!("@{canon}"), &profile_href(&canon), true))
+            }
+            h2 { "@" (canon) }
+            p class="muted" { "posts (newest first)" }
+            @if rows.is_empty() {
+                p class="muted" { "no public posts yet" }
+            } @else {
+                ul class="profile-post-list" {
+                    @for r in &rows {
+                        @let hover = timeago::rfc3339_utc(r.ts);
+                        @let ago = timeago::timeago(now, r.ts);
+                        li {
+                            a href=(r.post_href.as_str()) {
+                                "#" (r.thread_tag)
+                                " / #"
+                                (r.post_idx)
+                            }
+                            span class="muted" title=(hover) { " · " (ago) }
+                            @if !r.snippet.is_empty() {
+                                p class="profile-post-snippet muted" { (r.snippet) }
+                            }
+                        }
+                    }
+                }
+            }
+            (cli_panel(&format!("npx slugsocial public forum list")))
+        },
+        None,
+    );
+    Html(page.into_string()).into_response()
 }
 
 pub async fn thread_post_expand(

--- a/server/src/html/mod.rs
+++ b/server/src/html/mod.rs
@@ -24,6 +24,12 @@ pub use forum::{
 };
 pub use garden::{garden_index, ontology_path, room_garden_index, room_ontology_path};
 pub use search::{search_page, search_results_fragment};
+pub use forum::user_profile_page;
+
+/// Public profile URL path for a stored username (no `@`).
+pub(crate) fn profile_href(username: &str) -> String {
+    format!("/u/{username}")
+}
 
 // Embed CSS files at compile time
 const THEME_DEFAULT_CSS: &str = include_str!("../../static/theme_default.css");

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -36,6 +36,7 @@ pub fn create_app(state: AppState) -> Router {
         .route("/stream", get(api::get_stream))
         .route("/search", get(crate::html::search_page))
         .route("/search/results", get(crate::html::search_results_fragment))
+        .route("/u/:username", get(crate::html::user_profile_page))
         .route("/try", get(crate::html::editor_page))
         .route("/try/check", post(crate::html::editor_check))
         .route("/~", get(crate::html::garden_index))

--- a/server/src/reducer.rs
+++ b/server/src/reducer.rs
@@ -237,6 +237,8 @@ pub struct ReducerState {
 
     /// All ingest IDs in chronological order (oldest first). Used by the feed endpoint.
     pub ingests_ordered: Vec<String>,
+    /// Username → ingest ids in post order (oldest first), for profile pages.
+    pub posts_by_actor: HashMap<String, VecDeque<String>>,
     /// room_id → username → capabilities
     pub grants: HashMap<String, HashMap<String, HashSet<ThreadCapability>>>,
     /// room_id → chronological room admin lines (for thread UI).
@@ -248,6 +250,32 @@ pub struct ReducerState {
 impl ReducerState {
     pub fn content_for_scope(&self, scope: &ScopeId) -> Option<&ContentState> {
         self.content.get(scope)
+    }
+
+    /// Ingest ids authored by `actor`, oldest first. Unfiltered; use with access checks per ingest.
+    pub fn posts_by_actor_ids(&self, actor: &str) -> Vec<String> {
+        self.posts_by_actor
+            .get(actor)
+            .map(|q| q.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    /// Same order as [`Self::posts_by_actor_ids`], omitting ingests in scopes the viewer cannot see.
+    pub fn visible_posts_for_actor(&self, actor: &str, viewer: Option<&str>) -> Vec<String> {
+        self.posts_by_actor_ids(actor)
+            .into_iter()
+            .filter(|id| {
+                self.ingests_by_id.get(id).is_some_and(|ing| {
+                    let scope = scope_from_room_wire(&ing.room_id);
+                    match &scope {
+                        ScopeId::Public => true,
+                        ScopeId::Room(rid) => {
+                            viewer.is_some_and(|u| self.user_has_cap(rid, u, ThreadCapability::View))
+                        }
+                    }
+                })
+            })
+            .collect()
     }
 
     pub fn user_has_cap(&self, room_id: &str, username: &str, cap: ThreadCapability) -> bool {
@@ -574,6 +602,8 @@ impl ReducerState {
 
                 nav!(self.ingests_ordered, push_back(ing.id.clone()));
 
+                nav!(self.posts_by_actor, keypath(ing.principal.clone()), push_back(ing.id.clone()));
+
                 nav!(self.actor_last_post_ts, keypath(ing.principal.clone()), setval(ing.ts));
             }
             Event::GrantAdded(ga) => {
@@ -665,6 +695,7 @@ impl Default for ReducerState {
             forum_threads: HashMap::new(),
             actor_last_post_ts: HashMap::new(),
             ingests_ordered: Vec::new(),
+            posts_by_actor: HashMap::new(),
             grants: HashMap::new(),
             room_timeline: HashMap::new(),
             invites: HashMap::new(),

--- a/server/static/theme_default.css
+++ b/server/static/theme_default.css
@@ -517,6 +517,12 @@ div.ingest-meta {
 }
 a.post-num { color: var(--meta); font-size: 12px; }
 a.post-num:hover { color: var(--signal); }
+a.post-author { color: var(--meta); font-size: 12px; text-decoration: none; }
+a.post-author:hover { color: var(--signal); text-decoration: underline; }
+
+ul.profile-post-list { list-style: none; padding: 0; margin: 1em 0; }
+ul.profile-post-list li { margin: 0.75em 0; }
+p.profile-post-snippet { margin: 0.25em 0 0 1em; font-size: 13px; }
 div.ont-item-threads { font-size: 13px; margin: 6px 0; }
 
 /* ----------------------------------------------------------------

--- a/server/tests/basic.rs
+++ b/server/tests/basic.rs
@@ -1,7 +1,7 @@
 use slugsocial_server::{
     event_log::EventLog,
     canonical_path::{canonicalize_item, canonicalize_tag},
-    events::{Event, Ingest},
+    events::{Event, GrantAdded, Ingest, RoomCreated},
     ranking::ranked_items,
     reducer::{GroupState, ReducerState, ScopeId},
 };
@@ -786,5 +786,49 @@ fn test_ingests_by_thread_ordering() {
     assert_eq!(thread_ingests[0], "test-300");
     assert_eq!(thread_ingests[1], "test-200");
     assert_eq!(thread_ingests[2], "test-100");
+}
+
+#[test]
+fn posts_by_actor_indexes_and_profile_visibility() {
+    let mut state = ReducerState::default();
+    state.apply_event(Event::RoomCreated(RoomCreated {
+        ts: 1,
+        room_id: "ab12cd/private-room".to_string(),
+        slug: "private-room".to_string(),
+        owner: "alice".to_string(),
+    }));
+    state.apply_event(Event::GrantAdded(GrantAdded {
+        ts: 2,
+        room_id: "ab12cd/private-room".to_string(),
+        username: "bob".to_string(),
+        capabilities: vec![slugsocial_server::events::ThreadCapability::View],
+        granted_by: "alice".to_string(),
+    }));
+
+    let mut ev1 = match ingest_event(10, "~/pub/a {x}\n") {
+        Event::Ingest(i) => i,
+        _ => unreachable!(),
+    };
+    ev1.principal = "tommy".to_string();
+    ev1.thread_tag = "demo".to_string();
+    state.apply_event(Event::Ingest(ev1));
+
+    let mut ev2 = match ingest_event(20, "~/priv/x {secret}\n") {
+        Event::Ingest(i) => i,
+        _ => unreachable!(),
+    };
+    ev2.principal = "tommy".to_string();
+    ev2.room_id = "ab12cd/private-room".to_string();
+    ev2.thread_tag = "secret-thread".to_string();
+    state.apply_event(Event::Ingest(ev2));
+
+    assert_eq!(state.posts_by_actor.get("tommy").map(|q| q.len()), Some(2));
+
+    let anon = state.visible_posts_for_actor("tommy", None);
+    assert_eq!(anon.len(), 1);
+    assert!(state.ingests_by_id[&anon[0]].room_id == "public");
+
+    let bob = state.visible_posts_for_actor("tommy", Some("bob"));
+    assert_eq!(bob.len(), 2);
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Post headers**: Thread views, SSE feed fragments, expand responses, and single-post pages now show `#N` followed by a clickable `@username` linking to `/u/username` (stored form, no `@` in the URL).
- **Reducer**: `posts_by_actor` maps each principal to ingest ids in chronological order (oldest first). `visible_posts_for_actor` filters out private-room posts unless the viewer has `view` on that room (public scope always visible).
- **Profile page**: `GET /u/:username` lists that user’s posts the viewer may see, newest first, with links to the canonical post URL (`/t/...` or `/r/.../t/.../...`).
- **Tests**: `posts_by_actor_indexes_and_profile_visibility` covers indexing and private-thread filtering.

## Notes

Production hostnames can use the same paths (e.g. `https://slug.social/u/tommy`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f4c752b-11d6-49e9-affd-cae489b3ced8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f4c752b-11d6-49e9-affd-cae489b3ced8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

