### PR TITLE
Post redaction: tombstones, garden rollback, Spel browser test

### DIFF
--- a/scripts/clj-test.sh
+++ b/scripts/clj-test.sh
@@ -3,3 +3,4 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 clojure -M -m test.runner
 clojure -M -m test.runner browser-sse
+clojure -M -m test.runner browser-post-redact

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -34,7 +34,7 @@ pub use stream::{get_html_stream, get_stream};
 
 pub use validate::{normalize_room_and_thread, validate_ingest_document, ValidatedIngest};
 
-pub use web_post::{check_web_ingest, post_web_ingest};
+pub use web_post::{check_web_ingest, post_web_ingest, post_web_redact};
 
 #[cfg(test)]
 mod tests {

--- a/server/src/api/rpc.rs
+++ b/server/src/api/rpc.rs
@@ -14,7 +14,8 @@ use crate::{
     canonical_path::{canonicalize_item, canonicalize_tag},
     dsl,
     events::{
-        AgentBound, Event, GrantAdded, GrantRevoked, Ingest, RoomCreated, ThreadCapability,
+        AgentBound, Event, GrantAdded, GrantRevoked, Ingest, PostRedacted, RoomCreated,
+        ThreadCapability,
     },
     html::JsBuilder,
     identity::{parse_agent, parse_username},
@@ -57,7 +58,8 @@ async fn broadcast_web_refresh(state: &AppState, room_key: &str, thread_id: &str
         crate::html::thread_feed_html_for_room(state, room_key).await
     };
 
-    let thread_feed_markup = crate::html::thread_feed_region_markup(state, Some(room_key), thread_id).await;
+    let thread_feed_markup =
+        crate::html::thread_feed_region_markup(state, Some(room_key), thread_id, None).await;
 
     let builder = JsBuilder::new().morph_selector(&format!("#{feed_id}"), feed_markup);
     let builder = if room_key == "public" {
@@ -326,6 +328,55 @@ fn build_rank_response_for_content(
         components,
         unranked_items,
     })
+}
+
+pub async fn rpc_post_redact(
+    state: &AppState,
+    headers: &HeaderMap,
+    post_id: String,
+) -> Result<RpcResult, RpcErr> {
+    let reduced_arc = state.reduced.clone();
+    let reduced = reduced_arc.read().await;
+    let principal = verify_bearer_principal(headers, &reduced).map_err(|(_, m)| (m, None))?;
+    let post_id = post_id.trim().to_string();
+    let Some(ing) = reduced.ingests_by_id.get(&post_id).cloned() else {
+        drop(reduced);
+        return Err(("post not found".into(), None));
+    };
+    if ing.principal != principal {
+        drop(reduced);
+        return Err(("not your post".into(), None));
+    }
+    if reduced.redacted_posts.contains(&post_id) {
+        drop(reduced);
+        return Err(("already redacted".into(), None));
+    }
+    let room_key = ing.room_id.trim().to_string();
+    let scope = scope_from_room_wire(&room_key);
+    if matches!(scope, ScopeId::Room(_))
+        && (!reduced.rooms.contains(&room_key)
+            || !reduced.user_has_cap(&room_key, &principal, ThreadCapability::View))
+    {
+        drop(reduced);
+        return Err(("room not found".into(), None));
+    }
+    drop(reduced);
+
+    let ev = Event::PostRedacted(PostRedacted {
+        ts: now_ms(),
+        post_id: post_id.clone(),
+        principal: principal.clone(),
+    });
+    if let Err(err) = state.event_log.append(&ev).await {
+        return Err((format!("{err}"), None));
+    }
+    {
+        let mut reduced = reduced_arc.write().await;
+        reduced.apply_event(ev);
+    }
+    let thread_tag = canonicalize_tag(&ing.thread_tag);
+    broadcast_web_refresh(state, &room_key, &thread_tag).await;
+    Ok(RpcResult::RedactPostOk {})
 }
 
 async fn rpc_post(
@@ -668,19 +719,29 @@ fn rpc_forum_thread_detail(
         });
         return match index.and_then(|idx| reduced.ingests_by_id.get(pid).map(|ing| (idx, ing))) {
             None => Err(("post not found".into(), None)),
-            Some((idx, ing)) => Ok(ThreadDetailResponse {
-                thread: format!("#{}", tag),
-                items: vec![ThreadItem::Post {
-                    id: ing.id.clone(),
-                    index: idx,
-                    ts: ing.ts,
-                    actor: ing.principal.clone(),
-                    body: ing.raw.clone(),
-                    truncated: false,
-                }],
-                total: 1,
-                offset: idx,
-            }),
+            Some((idx, ing)) => {
+                let redacted = reduced.redacted_posts.contains(&ing.id);
+                let redacted_at_ts = if redacted {
+                    reduced.post_redact_ts.get(&ing.id).copied()
+                } else {
+                    None
+                };
+                Ok(ThreadDetailResponse {
+                    thread: format!("#{}", tag),
+                    items: vec![ThreadItem::Post {
+                        id: ing.id.clone(),
+                        index: idx,
+                        ts: ing.ts,
+                        actor: ing.principal.clone(),
+                        body: if redacted { String::new() } else { ing.raw.clone() },
+                        truncated: false,
+                        redacted,
+                        redacted_at_ts,
+                    }],
+                    total: 1,
+                    offset: idx,
+                })
+            }
         };
     }
 
@@ -706,7 +767,15 @@ fn rpc_forum_thread_detail(
         .skip(offset)
         .take(limit)
         .map(|(idx, ing)| {
-            let (body, truncated) = if ing.raw.len() > MAX_BODY {
+            let redacted = reduced.redacted_posts.contains(&ing.id);
+            let redacted_at_ts = if redacted {
+                reduced.post_redact_ts.get(&ing.id).copied()
+            } else {
+                None
+            };
+            let (body, truncated) = if redacted {
+                (String::new(), false)
+            } else if ing.raw.len() > MAX_BODY {
                 (ing.raw[..MAX_BODY].to_string(), true)
             } else {
                 (ing.raw.clone(), false)
@@ -718,6 +787,8 @@ fn rpc_forum_thread_detail(
                 actor: ing.principal.clone(),
                 body,
                 truncated,
+                redacted,
+                redacted_at_ts,
             }
         })
         .collect();
@@ -1734,6 +1805,7 @@ pub async fn handle_rpc_batch(
                                 let posts: Vec<FeedPost> = matching.into_iter()
                                     .take(limit)
                                     .filter_map(|id| reduced.ingests_by_id.get(id))
+                                    .filter(|ing| !reduced.redacted_posts.contains(&ing.id))
                                     .map(|ing| {
                                         let scope = scope_from_room_wire(&ing.room_id);
                                         let thread_post_index = reduced
@@ -1762,6 +1834,12 @@ pub async fn handle_rpc_batch(
                     }
                 }
             },
+            RpcCommand::PostRedact { post_id } => {
+                match rpc_post_redact(&state, &headers, post_id).await {
+                    Ok(r) => line_ok(r),
+                    Err((e, h)) => line_err(e, h),
+                }
+            }
         };
         results.push(line);
     }

--- a/server/src/api/web_post.rs
+++ b/server/src/api/web_post.rs
@@ -13,7 +13,7 @@ use crate::{
     api::{
         auth::{optional_principal, SLUG_SESSION_COOKIE},
         handle_rpc_batch,
-        rpc::rpc_post_with_bearer,
+        rpc::{rpc_post_redact, rpc_post_with_bearer},
     },
     canonical_path::canonicalize_tag,
     html::{thread_feed_html, thread_feed_html_for_room, thread_feed_region_markup, JsBuilder},
@@ -30,6 +30,11 @@ pub struct WebPostForm {
     pub error_target: Option<String>,
     #[serde(default)]
     pub form_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct WebRedactForm {
+    pub post_id: String,
 }
 
 fn post_redirect_location(room: &str, thread_tag: &str) -> String {
@@ -153,6 +158,8 @@ async fn rpc_check_with_bearer(
 fn post_success_response<'a>(
     state: &'a AppState,
     form: &'a WebPostForm,
+    headers: &'a HeaderMap,
+    jar: &'a CookieJar,
 ) -> impl std::future::Future<Output = Response> + 'a {
     async move {
         let error_target = form_error_target(form);
@@ -161,6 +168,10 @@ fn post_success_response<'a>(
         let thread_location = post_redirect_location(&room, &thread_tag);
         let form_id = form.form_id.as_deref().unwrap_or_default();
         let scope = scope_from_room_wire(&room);
+        let viewer = {
+            let reduced = state.reduced.read().await;
+            optional_principal(headers, jar, &reduced)
+        };
         let feed_markup = match &scope {
             ScopeId::Public => thread_feed_html(state).await,
             ScopeId::Room(_) => thread_feed_html_for_room(state, &room).await,
@@ -172,6 +183,7 @@ fn post_success_response<'a>(
                 ScopeId::Room(_) => Some(room.as_str()),
             },
             &thread_tag,
+            viewer.as_deref(),
         )
         .await;
         let feed_selector = match &scope {
@@ -194,6 +206,46 @@ fn post_success_response<'a>(
             .if_current_path_not_matches(&thread_location, |builder| builder.redirect(&thread_location));
 
         builder.into_response()
+    }
+}
+
+async fn redact_success_response(state: &AppState) -> Response {
+    let feed_markup = thread_feed_html(state).await;
+    JsBuilder::new()
+        .morph_selector("#thread-feed", feed_markup)
+        .into_response()
+}
+
+pub async fn post_web_redact(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    jar: CookieJar,
+    Form(form): Form<WebRedactForm>,
+) -> impl IntoResponse {
+    let reduced = state.reduced.read().await;
+    let Some(_username) = optional_principal(&headers, &jar, &reduced) else {
+        drop(reduced);
+        return js_redirect("/login").into_response();
+    };
+    drop(reduced);
+
+    let bearer = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer ").map(|t| t.trim().to_string()))
+        .or_else(|| jar.get(SLUG_SESSION_COOKIE).map(|c| c.value().to_string()));
+
+    let Some(_bearer) = bearer else {
+        return js_redirect("/login").into_response();
+    };
+
+    match rpc_post_redact(&state, &headers, form.post_id).await {
+        Ok(RpcResult::RedactPostOk {}) => redact_success_response(&state).await.into_response(),
+        Ok(_) => (StatusCode::BAD_REQUEST, "unexpected response").into_response(),
+        Err((msg, hint)) => {
+            let detail = hint.as_deref().unwrap_or("");
+            js_error("#errors", &msg, detail).into_response()
+        }
     }
 }
 
@@ -231,7 +283,9 @@ pub async fn post_web_ingest(
     }
 
     match rpc_post_with_bearer(&state, &bearer, room.clone(), thread_tag.clone(), text).await {
-        Ok(RpcResult::PostOk { .. }) => post_success_response(&state, &form).await.into_response(),
+        Ok(RpcResult::PostOk { .. }) => post_success_response(&state, &form, &headers, &jar)
+            .await
+            .into_response(),
         Ok(_) => form_js_error(&form, "unexpected response", "Post did not return PostOk.").into_response(),
         Err((msg, hint)) => form_js_error(&form, &msg, hint.as_deref().unwrap_or("")).into_response(),
     }

--- a/server/src/events.rs
+++ b/server/src/events.rs
@@ -23,6 +23,17 @@ pub enum Event {
     InviteRedeemed(InviteRedeemed),
     /// Ingest of a DSL+prose body. Identity and routing live in event metadata.
     Ingest(Ingest),
+    /// Author removed their post from the forum and garden (votes/items from that ingest are undone).
+    PostRedacted(PostRedacted),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PostRedacted {
+    pub ts: i64,
+    /// Ingest id ([`Ingest::id`]) to redact.
+    pub post_id: String,
+    /// Principal who authored the post (must match ingest; stored for auditing).
+    pub principal: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/server/src/html/forum.rs
+++ b/server/src/html/forum.rs
@@ -114,6 +114,14 @@ impl ThreadNav {
     fn expand_url(&self, tag: &str, idx: usize) -> String {
         format!("{}/{}/{}/expand", self.thread_path_prefix, tag, idx)
     }
+
+    fn expand_deleted_url(&self, tag: &str, idx: usize) -> String {
+        format!("{}/{}/{}/expand-deleted", self.thread_path_prefix, tag, idx)
+    }
+
+    fn collapse_deleted_url(&self, tag: &str, idx: usize) -> String {
+        format!("{}/{}/{}/collapse-deleted", self.thread_path_prefix, tag, idx)
+    }
 }
 
 fn thread_nav_for_ingest(ing: &crate::events::Ingest) -> Option<ThreadNav> {
@@ -153,6 +161,97 @@ fn post_header_meta(
             a href=(profile) class="post-author" { "@" (principal) }
             " · "
             (ago)
+        }
+    }
+}
+
+fn post_header_row(
+    nav: &ThreadNav,
+    tag: &str,
+    post_idx: usize,
+    ing: &crate::events::Ingest,
+    _viewer: Option<&str>,
+    now: i64,
+    show_delete: bool,
+) -> Markup {
+    let meta = post_header_meta(nav, tag, post_idx, &ing.principal, ing.ts, now);
+    html! {
+        div class="ingest-header-row" {
+            (meta)
+            @if show_delete {
+                form class="post-delete-form" method="POST" action="/post/redact" {
+                    input type="hidden" name="post_id" value=(ing.id);
+                    button type="submit" class="post-delete-btn" { "delete" }
+                }
+            }
+        }
+    }
+}
+
+fn redacted_header_row(
+    nav: &ThreadNav,
+    tag: &str,
+    post_idx: usize,
+    ing: &crate::events::Ingest,
+    now: i64,
+    expanded: bool,
+) -> Markup {
+    let meta = post_header_meta(nav, tag, post_idx, &ing.principal, ing.ts, now);
+    let exp = nav.expand_deleted_url(tag, post_idx);
+    let coll = nav.collapse_deleted_url(tag, post_idx);
+    html! {
+        div class="ingest-header-row ingest-tombstone-row" {
+            (meta)
+            span class="post-tombstone-inline muted" {
+                "deleted · "
+                @if expanded {
+                    a href="#" class="hide-deleted-link"
+                      onclick=(format!("fetch('{coll}').then(r=>r.text()).then(eval);return false")) {
+                        "[hide deleted content]"
+                    }
+                } @else {
+                    a href="#" class="show-deleted-link"
+                      onclick=(format!("fetch('{exp}').then(r=>r.text()).then(eval);return false")) {
+                        "[show deleted content]"
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn ingest_entry_markup(
+    nav: &ThreadNav,
+    tag: &str,
+    post_idx: usize,
+    ing: &crate::events::Ingest,
+    viewer: Option<&str>,
+    now: i64,
+    reduced: &ReducerState,
+) -> Markup {
+    let redacted = reduced.redacted_posts.contains(&ing.id);
+    let show_delete = viewer == Some(ing.principal.as_str()) && !redacted;
+    if redacted {
+        html! {
+            div class="ingest-entry ingest-redacted" data-ingest-id=(ing.id) {
+                (redacted_header_row(nav, tag, post_idx, ing, now, false))
+            }
+        }
+    } else {
+        let truncated = ing.raw.len() > 2000;
+        let display_body = if truncated { &ing.raw[..2000] } else { &ing.raw[..] };
+        html! {
+            div class="ingest-entry" data-ingest-id=(ing.id) {
+                (post_header_row(nav, tag, post_idx, ing, viewer, now, show_delete))
+                (render_linkified_with_embeds_in_scope(display_body, nav.garden_root_url()))
+                @if truncated {
+                    @let exp = nav.expand_url(tag, post_idx);
+                    a href="#" class="show-full-link"
+                      onclick=(format!("fetch('{exp}').then(r=>r.text()).then(eval);return false")) {
+                        "[show full post]"
+                    }
+                }
+            }
         }
     }
 }
@@ -410,6 +509,8 @@ fn render_thread_feed_region_markup(
     offset: usize,
     total: usize,
     now: i64,
+    viewer: Option<&str>,
+    reduced: &ReducerState,
 ) -> Markup {
     let paginator_top = render_thread_paginator(nav, tag, offset, total, true);
     let paginator_bot = render_thread_paginator(nav, tag, offset, total, false);
@@ -421,19 +522,7 @@ fn render_thread_feed_region_markup(
                 (paginator_top)
                 @for (i, ing) in display_ingests.iter().enumerate() {
                     @let post_idx = offset + i;
-                    @let truncated = ing.raw.len() > 2000;
-                    @let display_body = if truncated { &ing.raw[..2000] } else { &ing.raw[..] };
-                    div class="ingest-entry" data-ingest-id=(ing.id) {
-                        (post_header_meta(nav, tag, post_idx, &ing.principal, ing.ts, now))
-                        (render_linkified_with_embeds_in_scope(display_body, nav.garden_root_url()))
-                        @if truncated {
-                            @let exp = nav.expand_url(tag, post_idx);
-                            a href="#" class="show-full-link"
-                              onclick=(format!("fetch('{exp}').then(r=>r.text()).then(eval);return false")) {
-                                "[show full post]"
-                            }
-                        }
-                    }
+                    (ingest_entry_markup(nav, tag, post_idx, ing, viewer, now, reduced))
                 }
                 (paginator_bot)
             }
@@ -441,7 +530,12 @@ fn render_thread_feed_region_markup(
     }
 }
 
-pub async fn thread_feed_region_markup(state: &AppState, room_id: Option<&str>, tag: &str) -> Markup {
+pub async fn thread_feed_region_markup(
+    state: &AppState,
+    room_id: Option<&str>,
+    tag: &str,
+    viewer: Option<&str>,
+) -> Markup {
     let tag = canonicalize_tag(tag);
     let Some(nav) = (match room_id {
         Some(room_id) => ThreadNav::from_room_id(room_id),
@@ -461,14 +555,21 @@ pub async fn thread_feed_region_markup(state: &AppState, room_id: Option<&str>, 
     let total = all_ids.len();
     let offset = total.saturating_sub(PAGE_SIZE);
     let page_ids: Vec<String> = all_ids.into_iter().skip(offset).take(PAGE_SIZE).collect();
-    let display_ingests = {
-        let reduced = state.reduced.read().await;
-        page_ids
-            .iter()
-            .filter_map(|id| reduced.ingests_by_id.get(id).cloned())
-            .collect::<Vec<_>>()
-    };
-    render_thread_feed_region_markup(&nav, &tag, &display_ingests, offset, total, now_ms())
+    let reduced = state.reduced.read().await;
+    let display_ingests = page_ids
+        .iter()
+        .filter_map(|id| reduced.ingests_by_id.get(id).cloned())
+        .collect::<Vec<_>>();
+    render_thread_feed_region_markup(
+        &nav,
+        &tag,
+        &display_ingests,
+        offset,
+        total,
+        now_ms(),
+        viewer,
+        &reduced,
+    )
 }
 
 /// Home: private rooms (signed-in), then public bump-ordered threads.
@@ -615,9 +716,17 @@ async fn thread_view_inner(
             .unwrap_or(false),
     };
     let strip = auth_strip(&headers, &jar, &reduced);
+    let now = now_ms();
+    let entry_rows: Vec<Markup> = display_ingests
+        .iter()
+        .enumerate()
+        .map(|(i, ing)| {
+            let post_idx = offset + i;
+            ingest_entry_markup(&nav, &tag, post_idx, ing, user.as_deref(), now, &reduced)
+        })
+        .collect();
     drop(reduced);
 
-    let now = now_ms();
     let paginator_top = render_thread_paginator(&nav, &tag, offset, total, true);
     let paginator_bot = render_thread_paginator(&nav, &tag, offset, total, false);
 
@@ -657,21 +766,8 @@ async fn thread_view_inner(
                     p class="muted" { "no activity yet" }
                 } @else {
                     (paginator_top)
-                    @for (i, ing) in display_ingests.iter().enumerate() {
-                        @let post_idx = offset + i;
-                        @let truncated = ing.raw.len() > 2000;
-                        @let display_body = if truncated { &ing.raw[..2000] } else { &ing.raw[..] };
-                        div class="ingest-entry" data-ingest-id=(ing.id) {
-                            (post_header_meta(&nav, &tag, post_idx, &ing.principal, ing.ts, now))
-                            (render_linkified_with_embeds_in_scope(display_body, nav.garden_root_url()))
-                            @if truncated {
-                                @let exp = nav.expand_url(&tag, post_idx);
-                                a href="#" class="show-full-link"
-                                  onclick=(format!("fetch('{exp}').then(r=>r.text()).then(eval);return false")) {
-                                    "[show full post]"
-                                }
-                            }
-                        }
+                    @for row in &entry_rows {
+                        (row)
                     }
                     (paginator_bot)
                 }
@@ -846,19 +942,23 @@ async fn thread_post_view_inner(
     tag: String,
     index_str: String,
     nav: ThreadNav,
+    viewer: Option<String>,
 ) -> impl IntoResponse {
     let tag = canonicalize_tag(&tag);
     let index: usize = index_str.parse().unwrap_or(0);
     let scope = nav.scope();
     let now = now_ms();
-    let (ing, subtitle) = {
+    let (ing, subtitle, body_markup) = {
         let reduced = state.reduced.read().await;
         let ing = reduced
             .ingests_by_scope_thread
             .get(&(scope.clone(), tag.clone()))
             .and_then(|q| q.iter().rev().nth(index))
             .and_then(|id| reduced.ingests_by_id.get(id).cloned());
-        (ing, None::<String>)
+        let body = ing.as_ref().map(|i| {
+            ingest_entry_markup(&nav, &tag, index, i, viewer.as_deref(), now, &reduced)
+        });
+        (ing, None::<String>, body)
     };
 
     let sc = nav.scope();
@@ -880,11 +980,8 @@ async fn thread_post_view_inner(
         html! {
             nav class="breadcrumb" { (bc) }
             h2 { "#" (tag) @if let Some(sub) = &subtitle { ": " (sub) } " / post #" (index) }
-            @if let Some(ing) = ing {
-                div class="ingest-entry" data-ingest-id=(ing.id) {
-                    (post_header_meta(&nav, &tag, index, &ing.principal, ing.ts, now))
-                    (render_linkified_with_embeds_in_scope(&ing.raw, nav.garden_root_url()))
-                }
+            @if let (Some(_ing), Some(bm)) = (&ing, &body_markup) {
+                (bm)
             } @else {
                 p class="muted" { "post not found" }
             }
@@ -897,8 +994,14 @@ async fn thread_post_view_inner(
 pub async fn thread_post_view(
     State(state): State<AppState>,
     Path((tag, index_str)): Path<(String, String)>,
+    headers: HeaderMap,
+    jar: CookieJar,
 ) -> impl IntoResponse {
-    thread_post_view_inner(state, tag, index_str, ThreadNav::public()).await
+    let reduced = state.reduced.read().await;
+    let viewer = optional_principal(&headers, &jar, &reduced);
+    drop(reduced);
+    thread_post_view_inner(state, tag, index_str, ThreadNav::public(), viewer)
+        .await
 }
 
 pub async fn room_thread_post_view(
@@ -918,7 +1021,7 @@ pub async fn room_thread_post_view(
     let Some(nav) = ThreadNav::from_room_id(&room_id) else {
         return (StatusCode::NOT_FOUND, "bad room path").into_response();
     };
-    thread_post_view_inner(state, tag, index_str, nav)
+    thread_post_view_inner(state, tag, index_str, nav, user)
         .await
         .into_response()
 }
@@ -928,36 +1031,150 @@ async fn thread_post_expand_inner(
     tag: String,
     index_str: String,
     nav: ThreadNav,
+    viewer: Option<String>,
 ) -> impl IntoResponse {
     let tag = canonicalize_tag(&tag);
     let index: usize = index_str.parse().unwrap_or(0);
     let now = now_ms();
     let scope = nav.scope();
 
-    let ing = {
-        let reduced = state.reduced.read().await;
-        reduced
-            .ingests_by_scope_thread
-            .get(&(scope.clone(), tag.clone()))
-            .and_then(|q| q.iter().rev().nth(index))
-            .and_then(|id| reduced.ingests_by_id.get(id).cloned())
-    };
-
+    let reduced = state.reduced.read().await;
+    let ing = reduced
+        .ingests_by_scope_thread
+        .get(&(scope.clone(), tag.clone()))
+        .and_then(|q| q.iter().rev().nth(index))
+        .and_then(|id| reduced.ingests_by_id.get(id).cloned());
     let Some(ing) = ing else {
         return (StatusCode::NOT_FOUND, "post not found").into_response();
     };
+    if reduced.redacted_posts.contains(&ing.id) {
+        return (StatusCode::NOT_FOUND, "post not found").into_response();
+    };
+    let ing_id = ing.id.clone();
+    drop(reduced);
 
     let full_html = html! {
-        div class="ingest-entry" data-ingest-id=(ing.id) {
-            (post_header_meta(&nav, &tag, index, &ing.principal, ing.ts, now))
+        div class="ingest-entry" data-ingest-id=(ing_id) {
+            (post_header_row(
+                &nav,
+                &tag,
+                index,
+                &ing,
+                viewer.as_deref(),
+                now,
+                viewer.as_deref() == Some(ing.principal.as_str()),
+            ))
             (render_linkified_with_embeds_in_scope(&ing.raw, nav.garden_root_url()))
         }
     };
 
     JsBuilder::new()
         .morph_selector(
-            &format!("[data-ingest-id=\"{}\"]", ing.id),
+            &format!("[data-ingest-id=\"{}\"]", ing_id),
             full_html,
+        )
+        .into_response()
+        .into_response()
+}
+
+async fn thread_post_expand_deleted_inner(
+    state: AppState,
+    tag: String,
+    index_str: String,
+    nav: ThreadNav,
+    _viewer: Option<String>,
+) -> impl IntoResponse {
+    let tag = canonicalize_tag(&tag);
+    let index: usize = index_str.parse().unwrap_or(0);
+    let now = now_ms();
+    let scope = nav.scope();
+
+    let full_html = {
+        let reduced = state.reduced.read().await;
+        let ing = reduced
+            .ingests_by_scope_thread
+            .get(&(scope.clone(), tag.clone()))
+            .and_then(|q| q.iter().rev().nth(index))
+            .and_then(|id| reduced.ingests_by_id.get(id).cloned());
+        let Some(ing) = ing else {
+            return (StatusCode::NOT_FOUND, "post not found").into_response();
+        };
+        if !reduced.redacted_posts.contains(&ing.id) {
+            return (StatusCode::NOT_FOUND, "post not found").into_response();
+        };
+        html! {
+            div class="ingest-entry ingest-redacted-expanded" data-ingest-id=(ing.id) {
+                (redacted_header_row(&nav, &tag, index, &ing, now, true))
+                (render_linkified_with_embeds_in_scope(&ing.raw, nav.garden_root_url()))
+            }
+        }
+    };
+
+    let ing_id = {
+        let reduced = state.reduced.read().await;
+        reduced
+            .ingests_by_scope_thread
+            .get(&(nav.scope(), tag.clone()))
+            .and_then(|q| q.iter().rev().nth(index))
+            .cloned()
+    };
+    let Some(ing_id) = ing_id else {
+        return (StatusCode::NOT_FOUND, "post not found").into_response();
+    };
+
+    JsBuilder::new()
+        .morph_selector(
+            &format!("[data-ingest-id=\"{}\"]", ing_id),
+            full_html,
+        )
+        .into_response()
+        .into_response()
+}
+
+async fn thread_post_collapse_deleted_inner(
+    state: AppState,
+    tag: String,
+    index_str: String,
+    nav: ThreadNav,
+    viewer: Option<String>,
+) -> impl IntoResponse {
+    let tag = canonicalize_tag(&tag);
+    let index: usize = index_str.parse().unwrap_or(0);
+    let now = now_ms();
+    let scope = nav.scope();
+
+    let collapsed = {
+        let reduced = state.reduced.read().await;
+        let ing = reduced
+            .ingests_by_scope_thread
+            .get(&(scope.clone(), tag.clone()))
+            .and_then(|q| q.iter().rev().nth(index))
+            .and_then(|id| reduced.ingests_by_id.get(id).cloned());
+        let Some(ing) = ing else {
+            return (StatusCode::NOT_FOUND, "post not found").into_response();
+        };
+        if !reduced.redacted_posts.contains(&ing.id) {
+            return (StatusCode::NOT_FOUND, "post not found").into_response();
+        };
+        ingest_entry_markup(&nav, &tag, index, &ing, viewer.as_deref(), now, &reduced)
+    };
+
+    let ing_id = {
+        let reduced = state.reduced.read().await;
+        reduced
+            .ingests_by_scope_thread
+            .get(&(nav.scope(), tag.clone()))
+            .and_then(|q| q.iter().rev().nth(index))
+            .cloned()
+    };
+    let Some(ing_id) = ing_id else {
+        return (StatusCode::NOT_FOUND, "post not found").into_response();
+    };
+
+    JsBuilder::new()
+        .morph_selector(
+            &format!("[data-ingest-id=\"{}\"]", ing_id),
+            collapsed,
         )
         .into_response()
         .into_response()
@@ -988,6 +1205,9 @@ pub async fn user_profile_page(
         let ids = reduced.visible_posts_for_actor(&canon, viewer.as_deref());
         let mut rows: Vec<ProfilePostRow> = Vec::new();
         for id in ids {
+            if reduced.redacted_posts.contains(&id) {
+                continue;
+            }
             let Some(ing) = reduced.ingests_by_id.get(&id).cloned() else {
                 continue;
             };
@@ -1057,8 +1277,14 @@ pub async fn user_profile_page(
 pub async fn thread_post_expand(
     State(state): State<AppState>,
     Path((tag, index_str)): Path<(String, String)>,
+    headers: HeaderMap,
+    jar: CookieJar,
 ) -> impl IntoResponse {
-    thread_post_expand_inner(state, tag, index_str, ThreadNav::public()).await
+    let reduced = state.reduced.read().await;
+    let viewer = optional_principal(&headers, &jar, &reduced);
+    drop(reduced);
+    thread_post_expand_inner(state, tag, index_str, ThreadNav::public(), viewer)
+        .await
 }
 
 pub async fn room_thread_post_expand(
@@ -1074,11 +1300,84 @@ pub async fn room_thread_post_expand(
         drop(reduced);
         return room_not_found_page().into_response();
     }
-    drop(reduced);
     let Some(nav) = ThreadNav::from_room_id(&room_id) else {
+        drop(reduced);
         return (StatusCode::NOT_FOUND, "not found").into_response();
     };
-    thread_post_expand_inner(state, tag, index_str, nav)
+    drop(reduced);
+    thread_post_expand_inner(state, tag, index_str, nav, user)
+        .await
+        .into_response()
+}
+
+pub async fn thread_post_expand_deleted(
+    State(state): State<AppState>,
+    Path((tag, index_str)): Path<(String, String)>,
+    headers: HeaderMap,
+    jar: CookieJar,
+) -> impl IntoResponse {
+    let reduced = state.reduced.read().await;
+    let viewer = optional_principal(&headers, &jar, &reduced);
+    drop(reduced);
+    thread_post_expand_deleted_inner(state, tag, index_str, ThreadNav::public(), viewer)
+        .await
+}
+
+pub async fn room_thread_post_expand_deleted(
+    State(state): State<AppState>,
+    Path((room_short, room_slug, tag, index_str)): Path<(String, String, String, String)>,
+    headers: HeaderMap,
+    jar: CookieJar,
+) -> impl IntoResponse {
+    let room_id = format!("{room_short}/{room_slug}");
+    let reduced = state.reduced.read().await;
+    let user = optional_principal(&headers, &jar, &reduced);
+    if !user_can_view_room(&reduced, &room_id, user.as_deref()) {
+        drop(reduced);
+        return room_not_found_page().into_response();
+    }
+    let Some(nav) = ThreadNav::from_room_id(&room_id) else {
+        drop(reduced);
+        return (StatusCode::NOT_FOUND, "not found").into_response();
+    };
+    drop(reduced);
+    thread_post_expand_deleted_inner(state, tag, index_str, nav, user)
+        .await
+        .into_response()
+}
+
+pub async fn thread_post_collapse_deleted(
+    State(state): State<AppState>,
+    Path((tag, index_str)): Path<(String, String)>,
+    headers: HeaderMap,
+    jar: CookieJar,
+) -> impl IntoResponse {
+    let reduced = state.reduced.read().await;
+    let viewer = optional_principal(&headers, &jar, &reduced);
+    drop(reduced);
+    thread_post_collapse_deleted_inner(state, tag, index_str, ThreadNav::public(), viewer)
+        .await
+}
+
+pub async fn room_thread_post_collapse_deleted(
+    State(state): State<AppState>,
+    Path((room_short, room_slug, tag, index_str)): Path<(String, String, String, String)>,
+    headers: HeaderMap,
+    jar: CookieJar,
+) -> impl IntoResponse {
+    let room_id = format!("{room_short}/{room_slug}");
+    let reduced = state.reduced.read().await;
+    let user = optional_principal(&headers, &jar, &reduced);
+    if !user_can_view_room(&reduced, &room_id, user.as_deref()) {
+        drop(reduced);
+        return room_not_found_page().into_response();
+    }
+    let Some(nav) = ThreadNav::from_room_id(&room_id) else {
+        drop(reduced);
+        return (StatusCode::NOT_FOUND, "not found").into_response();
+    };
+    drop(reduced);
+    thread_post_collapse_deleted_inner(state, tag, index_str, nav, user)
         .await
         .into_response()
 }

--- a/server/src/html/mod.rs
+++ b/server/src/html/mod.rs
@@ -18,9 +18,11 @@ use breadcrumb_path::OntologyPath;
 pub use auth::{auth_complete_page, auth_signed_in_fragment, choose_username_error_fragment, choose_username_page};
 pub use editor::{editor_check, editor_page};
 pub use forum::{
-    home, room_page, room_thread_post_expand, room_thread_post_view, room_thread_view,
+    home, room_page, room_thread_post_collapse_deleted, room_thread_post_expand,
+    room_thread_post_expand_deleted, room_thread_post_view, room_thread_view,
     thread_feed_html, thread_feed_html_for_room, thread_feed_region_markup,
-    thread_post_expand, thread_post_view, thread_view, ThreadNav,
+    thread_post_collapse_deleted, thread_post_expand, thread_post_expand_deleted, thread_post_view,
+    thread_view, ThreadNav,
 };
 pub use garden::{garden_index, ontology_path, room_garden_index, room_ontology_path};
 pub use search::{search_page, search_results_fragment};

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -31,6 +31,7 @@ pub fn create_app(state: AppState) -> Router {
         .route("/login", get(api::get_web_login))
         .route("/logout", get(api::get_logout))
         .route("/post", post(api::post_web_ingest))
+        .route("/post/redact", post(api::post_web_redact))
         .route("/post/check", post(api::check_web_ingest))
         .route("/sse", get(api::get_html_stream))
         .route("/stream", get(api::get_stream))
@@ -50,11 +51,27 @@ pub fn create_app(state: AppState) -> Router {
             "/t/:tag/:index/expand",
             get(crate::html::thread_post_expand),
         )
+        .route(
+            "/t/:tag/:index/expand-deleted",
+            get(crate::html::thread_post_expand_deleted),
+        )
+        .route(
+            "/t/:tag/:index/collapse-deleted",
+            get(crate::html::thread_post_collapse_deleted),
+        )
         .route("/t/:tag/:index", get(crate::html::thread_post_view))
         .route("/t/:tag", get(crate::html::thread_view))
         .route(
             "/r/:room_short/:room_slug/t/:thread_tag/:index/expand",
             get(crate::html::room_thread_post_expand),
+        )
+        .route(
+            "/r/:room_short/:room_slug/t/:thread_tag/:index/expand-deleted",
+            get(crate::html::room_thread_post_expand_deleted),
+        )
+        .route(
+            "/r/:room_short/:room_slug/t/:thread_tag/:index/collapse-deleted",
+            get(crate::html::room_thread_post_collapse_deleted),
         )
         .route(
             "/r/:room_short/:room_slug/t/:thread_tag/:index",

--- a/server/src/reducer.rs
+++ b/server/src/reducer.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use serde::{Deserialize, Serialize};
 
 use crate::canonical_path::canonicalize_tag;
+use crate::dsl;
 use crate::events::{Event, Ingest, ThreadCapability};
 use crate::path_types::CanonicalItemUrl;
 
@@ -239,6 +240,10 @@ pub struct ReducerState {
     pub ingests_ordered: Vec<String>,
     /// Username → ingest ids in post order (oldest first), for profile pages.
     pub posts_by_actor: HashMap<String, VecDeque<String>>,
+    /// Ingest ids removed by author redaction (content and thread body omitted; tombstone in UI).
+    pub redacted_posts: HashSet<String>,
+    /// Redaction event timestamp (ms) per post id.
+    pub post_redact_ts: HashMap<String, i64>,
     /// room_id → username → capabilities
     pub grants: HashMap<String, HashMap<String, HashSet<ThreadCapability>>>,
     /// room_id → chronological room admin lines (for thread UI).
@@ -265,15 +270,16 @@ impl ReducerState {
         self.posts_by_actor_ids(actor)
             .into_iter()
             .filter(|id| {
-                self.ingests_by_id.get(id).is_some_and(|ing| {
-                    let scope = scope_from_room_wire(&ing.room_id);
-                    match &scope {
-                        ScopeId::Public => true,
-                        ScopeId::Room(rid) => {
-                            viewer.is_some_and(|u| self.user_has_cap(rid, u, ThreadCapability::View))
+                !self.redacted_posts.contains(id)
+                    && self.ingests_by_id.get(id).is_some_and(|ing| {
+                        let scope = scope_from_room_wire(&ing.room_id);
+                        match &scope {
+                            ScopeId::Public => true,
+                            ScopeId::Room(rid) => {
+                                viewer.is_some_and(|u| self.user_has_cap(rid, u, ThreadCapability::View))
+                            }
                         }
-                    }
-                })
+                    })
             })
             .collect()
     }
@@ -404,6 +410,188 @@ impl ReducerState {
         0
     }
 
+    /// Apply one ingest's DSL effects to `content` (votes, items, snippets, rank history).
+    fn apply_ingest_to_content(content: &mut ContentState, ing: &Ingest) -> Result<(), ()> {
+        let doc = dsl::parse_full(&ing.raw).map_err(|_| ())?;
+        let canonical_thread = canonicalize_tag(&ing.thread_tag);
+
+        let voted_items: Vec<CanonicalItemUrl> = doc
+            .statements
+            .iter()
+            .filter_map(|s| {
+                if let dsl::Stmt::Vote { item1, item2, .. } = s {
+                    Some([item1, item2])
+                } else {
+                    None
+                }
+            })
+            .flat_map(|pair| pair.into_iter())
+            .filter_map(|raw| Self::normalize_item(raw))
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
+
+        let principal = ing.principal.clone();
+        let delegate = ing.delegate.clone();
+
+        let before: HashMap<CanonicalItemUrl, (usize, usize)> = if !voted_items.is_empty() {
+            crate::ranking::compute_group_ranking(&mut content.ranking_group, 10000, 1e-8);
+            voted_items
+                .iter()
+                .map(|it| {
+                    (
+                        it.clone(),
+                        (
+                            Self::scope_rank_of(&content.ranking_group, it, &content.item_children),
+                            Self::global_rank_of(&content.ranking_group, it),
+                        ),
+                    )
+                })
+                .collect()
+        } else {
+            HashMap::new()
+        };
+
+        let mut ingest_items: HashSet<CanonicalItemUrl> = HashSet::new();
+
+        for stmt in doc.statements {
+            match stmt {
+                dsl::Stmt::Item { title, body } => {
+                    let Some(item) = Self::normalize_item(&title) else {
+                        continue;
+                    };
+                    nav!(content.items, set_elem(item.clone()));
+                    ingest_items.insert(item.clone());
+                    Self::add_child_edge(content, &item);
+
+                    if let Some(body_text) = body {
+                        if !body_text.trim().is_empty() {
+                            nav!(content.item_bodies, keypath(item.clone()), setval(body_text));
+                        }
+                    }
+                }
+                dsl::Stmt::Vote {
+                    item1,
+                    item2,
+                    ratio_left,
+                    ratio_right,
+                    explanation,
+                } => {
+                    let Some(item_a) = Self::normalize_item(&item1) else {
+                        continue;
+                    };
+                    let Some(item_b) = Self::normalize_item(&item2) else {
+                        continue;
+                    };
+
+                    let vote = VoteData {
+                        ts: ing.ts,
+                        a: item_a.clone(),
+                        b: item_b.clone(),
+                        ratio_left,
+                        ratio_right,
+                        body: explanation,
+                        principal: principal.clone(),
+                        delegate: delegate.clone(),
+                        thread_tag: canonical_thread.clone(),
+                    };
+
+                    ingest_items.insert(item_a.clone());
+                    ingest_items.insert(item_b.clone());
+
+                    nav!(content.items, set_elem(item_a.clone()));
+                    nav!(content.items, set_elem(item_b.clone()));
+                    Self::add_child_edge(content, &item_a);
+                    Self::add_child_edge(content, &item_b);
+
+                    content.ranking_group.apply_vote(vote.clone());
+
+                    for it in [&item_a, &item_b] {
+                        nav!(content.item_votes, keypath(it.clone()), push_front(vote.clone()));
+                    }
+                }
+                dsl::Stmt::Prose { .. } => {}
+            }
+        }
+
+        for item in ingest_items.iter() {
+            nav!(content.item_snippets, keypath(item.clone()), push_front(ing.id.clone()));
+        }
+
+        for item in ingest_items.iter() {
+            nav!(
+                content.item_threads,
+                keypath(item.clone()),
+                set_elem(canonical_thread.clone())
+            );
+        }
+
+        if !voted_items.is_empty() {
+            crate::ranking::compute_group_ranking(&mut content.ranking_group, 10000, 1e-8);
+            let thread = canonical_thread.clone();
+            for item in &voted_items {
+                let after_scope = Self::scope_rank_of(&content.ranking_group, item, &content.item_children);
+                let after_global = Self::global_rank_of(&content.ranking_group, item);
+                let score = content
+                    .ranking_group
+                    .item_to_idx
+                    .get(item)
+                    .and_then(|&i| content.ranking_group.cached_scores.get(i))
+                    .copied()
+                    .unwrap_or(0.0);
+                let (before_scope, before_global) = before.get(item).copied().unwrap_or((0, 0));
+                let prev = content.rank_history.get(item).and_then(|v| v.last());
+                let scope_delta = if prev.is_none() {
+                    0
+                } else {
+                    after_scope as i32 - before_scope as i32
+                };
+                let global_delta = if prev.is_none() {
+                    0
+                } else {
+                    after_global as i32 - before_global as i32
+                };
+                let scope_total = item
+                    .parent()
+                    .and_then(|p| content.item_children.get(&p))
+                    .map(|s| s.len())
+                    .unwrap_or(0);
+                let global_total = content.ranking_group.idx_to_item.len();
+                content.rank_history.entry(item.clone()).or_default().push(RankHistoryEntry {
+                    ts: ing.ts,
+                    scope_rank: after_scope,
+                    scope_rank_delta: scope_delta,
+                    scope_total,
+                    global_rank: after_global,
+                    global_rank_delta: global_delta,
+                    global_total,
+                    score,
+                    thread: thread.clone(),
+                    post_id: ing.id.clone(),
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    fn rebuild_scope_content(&mut self, scope: ScopeId) {
+        let mut cs = ContentState::default();
+        for id in &self.ingests_ordered {
+            if self.redacted_posts.contains(id) {
+                continue;
+            }
+            let Some(ing) = self.ingests_by_id.get(id) else {
+                continue;
+            };
+            if scope_from_room_wire(&ing.room_id) != scope {
+                continue;
+            }
+            let _ = Self::apply_ingest_to_content(&mut cs, ing);
+        }
+        self.content.insert(scope, cs);
+    }
+
     pub fn apply_event(&mut self, event: Event) {
         match event {
             Event::UserRegistered(ur) => {
@@ -446,151 +634,14 @@ impl ReducerState {
 
                 self.ingests_by_id.insert(ing.id.clone(), ing.clone());
 
-                let doc = match crate::dsl::parse_full(&ing.raw) {
-                    Ok(d) => d,
-                    Err(e) => {
-                        eprintln!("WARNING: Skipping malformed ingest event {}: {}", ing.id, e);
-                        return;
-                    }
-                };
-
-                // Pre-scan: collect items directly voted on in this ingest.
-                let voted_items: Vec<CanonicalItemUrl> = doc.statements.iter().filter_map(|s| {
-                    if let crate::dsl::Stmt::Vote { item1, item2, .. } = s {
-                        Some([item1, item2])
-                    } else {
-                        None
-                    }
-                }).flat_map(|pair| pair.into_iter())
-                    .filter_map(|raw| Self::normalize_item(raw))
-                    .collect::<std::collections::HashSet<_>>()
-                    .into_iter().collect();
-
-                let principal = ing.principal.clone();
-                let delegate = ing.delegate.clone();
-
                 {
                     let content = self.content_for_scope_mut(scope.clone());
-
-                    // Snapshot ranks before votes are applied (force-compute if stale).
-                    let before: HashMap<CanonicalItemUrl, (usize, usize)> = if !voted_items.is_empty() {
-                        crate::ranking::compute_group_ranking(&mut content.ranking_group, 10000, 1e-8);
-                        voted_items.iter()
-                            .map(|it| (it.clone(), (
-                                Self::scope_rank_of(&content.ranking_group, it, &content.item_children),
-                                Self::global_rank_of(&content.ranking_group, it),
-                            )))
-                            .collect()
-                    } else {
-                        HashMap::new()
-                    };
-
-                    // Items referenced in this ingest (for snippet indexing).
-                    let mut ingest_items: HashSet<CanonicalItemUrl> = HashSet::new();
-
-                    for stmt in doc.statements {
-                        match stmt {
-                            crate::dsl::Stmt::Item { title, body } => {
-                                let Some(item) = Self::normalize_item(&title) else {
-                                    continue;
-                                };
-                                nav!(content.items, set_elem(item.clone()));
-                                ingest_items.insert(item.clone());
-                                Self::add_child_edge(content, &item);
-
-                                if let Some(body_text) = body {
-                                    if !body_text.trim().is_empty() {
-                                        nav!(content.item_bodies, keypath(item.clone()), setval(body_text));
-                                    }
-                                }
-                            }
-                            crate::dsl::Stmt::Vote {
-                                item1,
-                                item2,
-                                ratio_left,
-                                ratio_right,
-                                explanation,
-                            } => {
-                                let Some(item_a) = Self::normalize_item(&item1) else {
-                                    continue;
-                                };
-                                let Some(item_b) = Self::normalize_item(&item2) else {
-                                    continue;
-                                };
-
-                                let vote = VoteData {
-                                    ts: ing.ts,
-                                    a: item_a.clone(),
-                                    b: item_b.clone(),
-                                    ratio_left,
-                                    ratio_right,
-                                    body: explanation,
-                                    principal: principal.clone(),
-                                    delegate: delegate.clone(),
-                                    thread_tag: canonical_thread.clone(),
-                                };
-
-                                ingest_items.insert(item_a.clone());
-                                ingest_items.insert(item_b.clone());
-
-                                nav!(content.items, set_elem(item_a.clone()));
-                                nav!(content.items, set_elem(item_b.clone()));
-                                Self::add_child_edge(content, &item_a);
-                                Self::add_child_edge(content, &item_b);
-
-                                content.ranking_group.apply_vote(vote.clone());
-
-                                // Index vote by item.
-                                for it in [&item_a, &item_b] {
-                                    nav!(content.item_votes, keypath(it.clone()), push_front(vote.clone()));
-                                }
-                            }
-                            crate::dsl::Stmt::Prose { .. } => {}
-                        }
-                    }
-
-                    // Index snippets by item for this ingest.
-                    for item in ingest_items.iter() {
-                        nav!(content.item_snippets, keypath(item.clone()), push_front(ing.id.clone()));
-                    }
-
-                    // Index item -> threads (connective tissue for garden body/pair/matchup).
-                    for item in ingest_items.iter() {
-                        nav!(content.item_threads, keypath(item.clone()), set_elem(canonical_thread.clone()));
-                    }
-
-                    // Snapshot ranks after votes and push history entries.
-                    if !voted_items.is_empty() {
-                        crate::ranking::compute_group_ranking(&mut content.ranking_group, 10000, 1e-8);
-                        let thread = canonical_thread.clone();
-                        for item in &voted_items {
-                            let after_scope  = Self::scope_rank_of(&content.ranking_group, item, &content.item_children);
-                            let after_global = Self::global_rank_of(&content.ranking_group, item);
-                            let score = content.ranking_group.item_to_idx.get(item)
-                                .and_then(|&i| content.ranking_group.cached_scores.get(i))
-                                .copied().unwrap_or(0.0);
-                            let (before_scope, before_global) = before.get(item).copied().unwrap_or((0, 0));
-                            let prev = content.rank_history.get(item).and_then(|v| v.last());
-                            let scope_delta  = if prev.is_none() { 0 } else { after_scope as i32 - before_scope as i32 };
-                            let global_delta = if prev.is_none() { 0 } else { after_global as i32 - before_global as i32 };
-                            let scope_total = item.parent()
-                                .and_then(|p| content.item_children.get(&p))
-                                .map(|s| s.len())
-                                .unwrap_or(0);
-                            let global_total = content.ranking_group.idx_to_item.len();
-                            content.rank_history.entry(item.clone()).or_default().push(RankHistoryEntry {
-                                ts: ing.ts,
-                                scope_rank: after_scope,
-                                scope_rank_delta: scope_delta,
-                                scope_total,
-                                global_rank: after_global,
-                                global_rank_delta: global_delta,
-                                global_total,
-                                score,
-                                thread: thread.clone(),
-                                post_id: ing.id.clone(),
-                            });
-                        }
+                    if Self::apply_ingest_to_content(content, &ing).is_err() {
+                        eprintln!(
+                            "WARNING: Skipping malformed ingest event {}: parse failed",
+                            ing.id
+                        );
+                        return;
                     }
                 }
 
@@ -605,6 +656,15 @@ impl ReducerState {
                 nav!(self.posts_by_actor, keypath(ing.principal.clone()), push_back(ing.id.clone()));
 
                 nav!(self.actor_last_post_ts, keypath(ing.principal.clone()), setval(ing.ts));
+            }
+            Event::PostRedacted(pr) => {
+                self.redacted_posts.insert(pr.post_id.clone());
+                self.post_redact_ts.insert(pr.post_id.clone(), pr.ts);
+                let Some(ing) = self.ingests_by_id.get(&pr.post_id).cloned() else {
+                    return;
+                };
+                let scope = scope_from_room_wire(&ing.room_id.trim());
+                self.rebuild_scope_content(scope);
             }
             Event::GrantAdded(ga) => {
                 let room_id = ga.room_id.clone();
@@ -696,6 +756,8 @@ impl Default for ReducerState {
             actor_last_post_ts: HashMap::new(),
             ingests_ordered: Vec::new(),
             posts_by_actor: HashMap::new(),
+            redacted_posts: HashSet::new(),
+            post_redact_ts: HashMap::new(),
             grants: HashMap::new(),
             room_timeline: HashMap::new(),
             invites: HashMap::new(),

--- a/server/static/theme_default.css
+++ b/server/static/theme_default.css
@@ -520,6 +520,36 @@ a.post-num:hover { color: var(--signal); }
 a.post-author { color: var(--meta); font-size: 12px; text-decoration: none; }
 a.post-author:hover { color: var(--signal); text-decoration: underline; }
 
+div.ingest-header-row {
+  align-items: center;
+  background: var(--g3);
+  border-bottom: 2px solid var(--lo);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  justify-content: space-between;
+  padding: 3px 10px;
+}
+div.ingest-header-row div.ingest-meta {
+  background: transparent;
+  border-bottom: none;
+  flex: 1 1 auto;
+  padding: 0;
+}
+form.post-delete-form { display: inline; margin: 0; }
+button.post-delete-btn {
+  background: var(--g4);
+  border: var(--bv) solid;
+  border-color: var(--hi) var(--lo) var(--lo) var(--hi);
+  color: var(--ui);
+  cursor: pointer;
+  font-size: 11px;
+  padding: 1px 6px;
+}
+button.post-delete-btn:hover { color: var(--signal); }
+span.post-tombstone-inline { font-size: 12px; white-space: nowrap; }
+div.ingest-redacted pre { display: none; }
+
 ul.profile-post-list { list-style: none; padding: 0; margin: 1em 0; }
 ul.profile-post-list li { margin: 0.75em 0; }
 p.profile-post-snippet { margin: 0.25em 0 0 1em; font-size: 13px; }

--- a/server/tests/integration.rs
+++ b/server/tests/integration.rs
@@ -636,6 +636,131 @@ async fn test_ingest_actor_with_colons_is_detected_and_validated() {
 }
 
 #[tokio::test]
+async fn test_post_redact_removes_garden_and_marks_thread() {
+    let (addr, _tmp, _log, _handle) = create_test_server().await;
+    let client = reqwest::Client::new();
+    let bearer = test_bearer();
+
+    let post_body = rpc_batch(
+        &client,
+        addr,
+        Some(&bearer),
+        serde_json::json!([{
+            "Post": {
+                "room": "public",
+                "thread_tag": "redact-test",
+                "delegate": "00000000-0000-0000-0000-000000000000:test:local/test",
+                "text": "~/del-a {a}\n~/del-b {b}\n~/del-a 2:1 ~/del-b {vote line}\n",
+                "return_rank_diff": false
+            }
+        }]),
+    )
+    .await;
+    let line = &post_body["results"][0];
+    assert_eq!(line["ok"], true, "post ingest: {:?}", line);
+
+    let thread_before = rpc_batch(
+        &client,
+        addr,
+        None,
+        serde_json::json!([{
+            "GetForumThread": {
+                "room": "public",
+                "thread_tag": "redact-test",
+                "offset": null,
+                "limit": null,
+                "since": null,
+                "before": null,
+                "actor": null,
+                "post_id": null
+            }
+        }]),
+    )
+    .await;
+    let items_before = thread_before["results"][0]["result"]["ForumThread"]["items"]
+        .as_array()
+        .unwrap();
+    assert_eq!(items_before.len(), 1);
+    let post_id = items_before[0]["id"].as_str().unwrap().to_string();
+    assert_eq!(items_before[0]["redacted"], serde_json::Value::Bool(false));
+
+    let rank_before = rpc_batch(
+        &client,
+        addr,
+        None,
+        serde_json::json!([{
+            "GetGardenRank": {
+                "room": "public",
+                "parent_path": "~",
+                "depth": 1
+            }
+        }]),
+    )
+    .await;
+    let rank_line = &rank_before["results"][0];
+    assert_eq!(rank_line["ok"], true);
+    let ranking = rank_line["result"]["GardenRank"]["components"][0]["ranking"]
+        .as_array()
+        .unwrap();
+    assert_eq!(ranking.len(), 2);
+
+    let redact = rpc_batch(
+        &client,
+        addr,
+        Some(&bearer),
+        serde_json::json!([{
+            "PostRedact": { "post_id": post_id }
+        }]),
+    )
+    .await;
+    assert_eq!(redact["results"][0]["ok"], true, "redact: {:?}", redact);
+
+    let rank_after = rpc_batch(
+        &client,
+        addr,
+        None,
+        serde_json::json!([{
+            "GetGardenRank": {
+                "room": "public",
+                "parent_path": "~",
+                "depth": 1
+            }
+        }]),
+    )
+    .await;
+    let ra_line = &rank_after["results"][0];
+    assert_eq!(ra_line["ok"], true);
+    let comps = ra_line["result"]["GardenRank"]["components"].as_array().unwrap();
+    assert!(
+        comps.is_empty() || comps[0]["ranking"].as_array().unwrap().is_empty(),
+        "votes from redacted post should be removed: {:?}",
+        ra_line
+    );
+
+    let thread_after = rpc_batch(
+        &client,
+        addr,
+        None,
+        serde_json::json!([{
+            "GetForumThread": {
+                "room": "public",
+                "thread_tag": "redact-test",
+                "offset": null,
+                "limit": null,
+                "since": null,
+                "before": null,
+                "actor": null,
+                "post_id": null
+            }
+        }]),
+    )
+    .await;
+    let item = &thread_after["results"][0]["result"]["ForumThread"]["items"][0];
+    assert_eq!(item["redacted"], serde_json::Value::Bool(true));
+    assert_eq!(item["body"].as_str().unwrap(), "");
+}
+
+#[tokio::test]
 async fn test_vote_endpoint() {
     let (addr, _tmp, _log, _handle) = create_test_server().await;
     let client = reqwest::Client::new();

--- a/test/browser_post_redact.clj
+++ b/test/browser_post_redact.clj
@@ -1,0 +1,148 @@
+(ns test.browser-post-redact
+  (:require [babashka.fs :as fs]
+            [cheshire.core :as json]
+            [clojure.string :as str]
+            [com.blockether.spel.core :as core]
+            [com.blockether.spel.locator :as locator]
+            [com.blockether.spel.page :as page]
+            [test.common :as common]
+            [test.oauth :as oauth]))
+
+(def ^:private counts (atom {:pass 0 :fail 0}))
+
+(defn- assert! [pred msg]
+  (common/test-assert! counts pred msg))
+
+(defn- wait-for-text [pg selector expected timeout-ms]
+  (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+    (loop []
+      (let [text (locator/text-content (page/locator pg selector))]
+        (if (and (string? text) (str/includes? text expected))
+          true
+          (if (< (System/currentTimeMillis) deadline)
+            (do (Thread/sleep 200) (recur))
+            false))))))
+
+(defn- wait-for-absent [pg selector substr timeout-ms]
+  (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+    (loop []
+      (let [text (or (locator/text-content (page/locator pg selector)) "")]
+        (if (str/includes? text substr)
+          (if (< (System/currentTimeMillis) deadline)
+            (do (Thread/sleep 200) (recur))
+            false)
+          true)))))
+
+(defn post-redact-browser-test [& _args]
+  (println "\n━━━ browser post redact / tombstone ━━━\n")
+  (reset! counts {:pass 0 :fail 0})
+
+  (common/letlocals
+   (bind build (common/run-cargo-build-release! ["slugsocial-server"]))
+   (assert! (zero? (:exit build)) "cargo build succeeds")
+   (bind server-bin "target/release/slugsocial-server")
+
+   (bind tmp-dir (str (fs/create-temp-dir {:prefix "slug-browser-redact-"})))
+   (bind slug-port (common/pick-port))
+   (bind google-port (common/pick-port))
+   (bind base-url (str "http://127.0.0.1:" slug-port))
+   (bind google-url (str "http://127.0.0.1:" google-port))
+
+   (bind !server (atom nil))
+   (bind !google (atom nil))
+   (bind server-env (common/slug-server-env tmp-dir base-url google-url slug-port))
+   (try
+     (reset! !google (oauth/start-mock-google google-port
+                                              :google-users ["google-user-alice"]))
+     (reset! !server (common/start-server server-bin server-env))
+     (assert! (common/wait-for-server base-url 10000) "server responds to /healthz")
+
+     (let [alice-token (oauth/fetch-bearer-token! base-url :username "alice")
+           thread-tag "redact-browser"
+           ;; Items + vote so we can assert garden clears after redact
+           raw (str "# " thread-tag "\n\n"
+                    "~/tomb-a {tomb item a}\n"
+                    "~/tomb-b {tomb item b}\n"
+                    "~/tomb-a 2:1 ~/tomb-b {browser redact vote}\n")
+           post-resp (oauth/http-post-json
+                      (str base-url "/api/v0/rpc")
+                      [{"Post" {"room" "public"
+                                "thread_tag" thread-tag
+                                "text" raw
+                                "return_rank_diff" false}}]
+                      :headers {"Authorization" (str "Bearer " alice-token)})
+           post-json (json/parse-string (:body post-resp) false)
+           _ (assert! (true? (get-in post-json ["results" 0 "ok"])) "seed post via rpc")
+           thr (oauth/http-post-json
+                (str base-url "/api/v0/rpc")
+                [{"GetForumThread" {"room" "public"
+                                    "thread_tag" thread-tag
+                                    "offset" nil
+                                    "limit" nil
+                                    "since" nil
+                                    "before" nil
+                                    "actor" nil
+                                    "post_id" nil}}]
+                :headers {})
+           thr-json (json/parse-string (:body thr) false)
+           post-id (get-in thr-json ["results" 0 "result" "ForumThread" "items" 0 "id"])
+           _ (assert! (some? post-id) "forum thread returns post id")
+           rank-before (oauth/http-post-json
+                        (str base-url "/api/v0/rpc")
+                        [{"GetGardenRank" {"room" "public"
+                                          "parent_path" "~"
+                                          "depth" 1}}])
+           rb (json/parse-string (:body rank-before) false)
+           rank-n (count (get-in rb ["results" 0 "result" "GardenRank" "components" 0 "ranking"]))]
+       (assert! (pos? rank-n) "garden has ranked items before redact")
+       (core/with-playwright [pw]
+         (core/with-browser [browser (core/launch-chromium pw {:headless true :channel "chrome"})]
+           (core/with-context [ctx (core/new-context browser)]
+             (core/with-page [pg (core/new-page-from-context ctx)]
+               (page/navigate pg (str base-url "/login"))
+               (assert! (wait-for-text pg "body" "@alice" 15000) "alice session on login redirect")
+               (page/navigate pg (str base-url "/t/" thread-tag))
+               (assert! (wait-for-text pg "#thread-feed-region" "tomb item" 15000)
+                        "thread shows post body before delete")
+               (assert! (wait-for-text pg ".post-delete-btn" "delete" 5000)
+                        "delete button visible for author")
+               (let [rx (oauth/http-post-json
+                         (str base-url "/api/v0/rpc")
+                         [{"PostRedact" {"post_id" post-id}}]
+                         :headers {"Authorization" (str "Bearer " alice-token)})]
+                 (assert! (true? (get-in (json/parse-string (:body rx) false) ["results" 0 "ok"]))
+                          "PostRedact rpc succeeds"))
+               (page/navigate pg (str base-url "/t/" thread-tag))
+               (assert! (wait-for-text pg "#thread-feed-region" "deleted" 15000)
+                        "tombstone shows after redact")
+               (assert! (wait-for-absent pg "#thread-feed-region" "tomb item" 10000)
+                        "original body hidden in collapsed tombstone")
+               (assert! (wait-for-absent pg "#thread-feed-region" "post-delete-btn" 5000)
+                        "delete button gone after redact")
+               (locator/click (page/locator pg ".show-deleted-link"))
+               (assert! (wait-for-text pg "#thread-feed-region" "tomb item" 15000)
+                        "expand shows stored content")
+               (locator/click (page/locator pg ".hide-deleted-link"))
+               (assert! (wait-for-absent pg "#thread-feed-region" "tomb item" 10000)
+                        "collapse hides content again"))))))
+     (let [rank-after (oauth/http-post-json
+                       (str base-url "/api/v0/rpc")
+                       [{"GetGardenRank" {"room" "public"
+                                         "parent_path" "~"
+                                         "depth" 1}}])
+           ra (json/parse-string (:body rank-after) false)
+           comps (get-in ra ["results" 0 "result" "GardenRank" "components"])
+           empty-rank (or (empty? comps)
+                          (empty? (get (first comps) "ranking")))]
+       (assert! empty-rank "garden ranking cleared after redact"))
+
+     (finally
+       (when-some [s @!server] (common/kill-server s))
+       (when-some [g @!google] ((:stop-fn g)))
+       (babashka.fs/delete-tree tmp-dir)))
+
+   (bind {pass :pass fail :fail} @counts)
+   (if (zero? fail)
+     (println (str "\n" common/ansi-green "━━━ " pass " post-redact browser checks passed ━━━" common/ansi-reset "\n"))
+     (do (println (str "\n" common/ansi-red "━━━ " fail " post-redact browser checks FAILED ━━━" common/ansi-reset "\n"))
+         (System/exit 1)))))

--- a/test/runner.clj
+++ b/test/runner.clj
@@ -5,7 +5,8 @@
             [test.grants :as grants]
             [test.invites :as invites]
             [test.room-list :as room-list]
-            [test.browser-sse :as browser-sse]))
+            [test.browser-sse :as browser-sse]
+            [test.browser-post-redact :as browser-post-redact]))
 
 (defn run-core! []
   (integration/integration)
@@ -15,6 +16,7 @@
   (room-list/room-list-test))
 
 (defn -main [& args]
-  (if (= ["browser-sse"] (vec args))
-    (browser-sse/private-thread-sse-browser-test)
+  (case (vec args)
+    ["browser-sse"] (browser-sse/private-thread-sse-browser-test)
+    ["browser-post-redact"] (browser-post-redact/post-redact-browser-test)
     (run-core!)))

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -142,6 +142,12 @@ pub enum ThreadItem {
         actor: String,
         body: String,
         truncated: bool,
+        /// Author redacted this post; body is empty and garden contributions were removed.
+        #[serde(default)]
+        redacted: bool,
+        /// When the redaction was recorded (ms), if redacted.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        redacted_at_ts: Option<i64>,
     },
     System {
         ts: i64,
@@ -395,6 +401,10 @@ pub enum RpcCommand {
         #[serde(default)]
         limit: Option<usize>,
     },
+    /// Remove the author's post from the garden and replace the body with a tombstone in the thread.
+    PostRedact {
+        post_id: String,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -437,6 +447,7 @@ pub enum RpcResult {
     RecentVotes(RecentVotesResponse),
     Search(SearchResponse),
     Feed(FeedResponse),
+    RedactPostOk {},
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Authors can redact their own posts via **`PostRedact`** RPC or **`POST /post/redact`** (session). A durable **`PostRedacted`** event is appended; the reducer **rebuilds affected scope content** from all non-redacted ingests so **votes and items from that post are removed** from the garden.

Thread view shows a **single-row tombstone** (header height): metadata plus `deleted · [show deleted content]`. Expanding uses the same **`fetch(...).then(eval)`** pattern as full-post truncation, with **`/expand-deleted`** and **`/collapse-deleted`** routes.

## Tests

- `server/tests/integration.rs`: `test_post_redact_removes_garden_and_marks_thread`
- `test/browser_post_redact.clj`: Spel + Playwright (`clojure -M -m test.runner browser-post-redact`), also wired into `scripts/clj-test.sh`

## Notes

- Redacted posts stay in the thread index (tombstone); profile feed skips them.
- Non-authors never see the delete button; SSE refresh uses anonymous viewer (no delete in morph).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-032af16b-4dc3-4e18-957e-0b8f21a0534a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-032af16b-4dc3-4e18-957e-0b8f21a0534a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

