### PR TITLE
fix(reducer): no ingests_by_id leak on malformed replay; document ephemeral invites

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,53 @@
+# Agent / contributor notes
+
+This file is **maintainer-facing**. Keep it aligned with the code: when you change durability (log vs RAM), `POST /ui` behavior, or command surfaces, **update the relevant section here** so it does not drift.
+
+---
+
+## Browser UI contract
+
+The web app is **not** a SPA with a JSON API for every interaction. Many mutations and UI updates use this loop:
+
+1. **Request:** `POST /ui` with `Content-Type: application/x-www-form-urlencoded`. A hidden field **`__rpc__`** holds **compact JSON** describing the action (see `HtmlUiAction` in `server/src/html/ui_action.rs`). Optional `{"$form": "field"}` holes are filled from other form fields (`server/src/form_template.rs`).
+
+2. **Response:** `Content-Type: text/javascript; charset=utf-8`. Body is executable JavaScript, usually calls to **`Idiomorph.morph`** on DOM nodes, built server-side by **`JsBuilder`** (`server/src/html/mod.rs`).
+
+3. **Client:** After `fetch`, the response body is **`eval`’d** (global submit interceptor and several `onclick` handlers in `server/src/html/mod.rs`, `server/src/html/forum.rs`, editor in `server/src/html/editor.rs`). **Idiomorph** is loaded from the layout (`server/src/html/mod.rs`).
+
+**Implications:**
+
+- **End-to-end tests** that only assert HTTP status bodies miss DOM updates. Morph paths are covered by **Playwright / Spel** tests under `test/browser_*.clj` and `clojure -M -m test.runner …` (see `scripts/clj-test.sh`).
+- Shareable URLs are normal GET routes (e.g. `/t/:tag`, thread post views). **Expand/collapse** and similar controls are **actions**, not bookmarkable GET endpoints; they use the same `POST /ui` + `__rpc__` pattern where applicable.
+
+---
+
+## `eval` on the frontend (core constraint)
+
+**Client-side `eval` of same-origin responses is intentional** for this UI model: the server emits short scripts that patch the DOM. Do not “fix” this by switching morph responses to JSON without an explicit redesign.
+
+Strict **CSP** that blocks `eval` would break the current app. Other projects may use **HMAC + nonces** around eval-like behavior; this codebase does not do **server-side eval** of user code (DSL is parsed in Rust, not `eval`’d on the server).
+
+---
+
+## Command surfaces: `HtmlUiAction` vs `RpcCommand`
+
+- **`RpcCommand` / `POST /api/v0/rpc`** (`types/src/lib.rs`, `server/src/api/rpc.rs`): **Bearer-authenticated** JSON API for CLI, automation, and programmatic clients. Durable effects go through here (append to event log, then `apply_event`).
+
+- **`HtmlUiAction` / `POST /ui`** (`server/src/html/ui_action.rs`, `server/src/api/ui_html.rs`): **Browser session** (cookie) UI commands. Payload is `__rpc__` + form fields. Responses are **JS morphs**, not JSON result objects. Used for posting from forms, checks, redact button, thread expand/collapse, new-thread slots, etc.
+
+**Rule of thumb:** New **CLI or API** verbs → `RpcCommand`. New **in-page morph or form-driven** behavior that only makes sense in the browser → `HtmlUiAction`. If both need the same operation, implement the real work once (e.g. call shared RPC helpers from `post_ui_html`) and keep the wire shapes separate.
+
+---
+
+## Durability matrix (JSONL vs RAM)
+
+**Authoritative store for replay:** `events.jsonl` (path from `SLUG_EVENT_LOG` or `{SLUG_DATA_DIR}/events.jsonl`). Boot loads and reapplies events in order (`server/src/main.rs`, `server/src/event_log.rs`, `ReducerState::apply_event` in `server/src/reducer.rs`).
+
+| Data | Durability | Where |
+|------|------------|--------|
+| Ingests, grants, rooms, identity tokens, agent binds, redactions, etc. | **JSONL** | Appended in `server/src/api/rpc.rs`, `server/src/api/auth.rs` (and related paths) before updating `ReducerState` |
+| **`RoomMintInvite` links** | **RAM only** | `AppState.invites` — not appended as `InviteMinted` today; **lost on restart** (`server/src/state.rs`, `server/src/api/rpc.rs`). Event types `InviteMinted` / `InviteRedeemed` exist for replay and a possible future persisted mint (`server/src/reducer.rs`). |
+| **OAuth / pending sessions** | **RAM only** | `AppState.pending_sessions` (`server/src/state.rs`, `server/src/api/auth.rs`) |
+| **Reducer projection** | **Derived** | Rebuilt from log on startup; not separately persisted |
+
+If you add a new ephemeral map or start persisting something that was RAM-only, **update this table and the code comments** (`server/src/state.rs` is a good anchor).

--- a/bb.edn
+++ b/bb.edn
@@ -60,6 +60,12 @@
            (invites/invites-test)
            (room-list/room-list-test))}
 
+  browser-ui-morph
+  {:doc "Playwright (Spel): POST /ui __rpc__ DOM morph (expand_post_full). Requires: clojure CLI, Chrome, `npx playwright install chromium`."
+   :requires ([babashka.process :as p])
+   :task (let [r @(p/process ["clojure" "-M" "-m" "test.runner" "browser-ui-morph"] {:inherit true})]
+           (when-not (zero? (:exit r)) (System/exit (:exit r))))}
+
   walkthrough-fixture
   {:doc "Run local server + mock OAuth + seeded walkthrough data for manual browser demos"
    :requires ([test.walkthrough-fixture :as walkthrough-fixture])

--- a/scripts/clj-test.sh
+++ b/scripts/clj-test.sh
@@ -4,3 +4,4 @@ cd "$(dirname "$0")/.."
 clojure -M -m test.runner
 clojure -M -m test.runner browser-sse
 clojure -M -m test.runner browser-post-redact
+clojure -M -m test.runner browser-ui-morph

--- a/server/src/api/rpc.rs
+++ b/server/src/api/rpc.rs
@@ -1331,6 +1331,7 @@ pub async fn handle_rpc_batch(
                     }
                 }
             }
+            // Invite links are stored in AppState only (not JSONL); they do not survive restart.
             RpcCommand::RoomMintInvite {
                 room,
                 capabilities,

--- a/server/src/api/ui_html.rs
+++ b/server/src/api/ui_html.rs
@@ -21,7 +21,8 @@ use crate::{
     html::{
         fragment_public_new_thread_form, fragment_room_new_thread_form, login_to_post_hint_markup,
         parse_html_ui_from_form, thread_feed_html, thread_feed_html_for_room, thread_feed_region_markup,
-        user_can_post_room, user_can_view_room, HtmlUiAction, JsBuilder, ThreadNav,
+        thread_ui_collapse_redacted_post, thread_ui_expand_post_full, thread_ui_expand_redacted_post,
+        ui_js_warn, user_can_post_room, user_can_view_room, HtmlUiAction, JsBuilder, ThreadNav,
     },
     reducer::{scope_from_room_wire, ScopeId},
     state::AppState,
@@ -181,6 +182,30 @@ async fn dispatch_ui_action(
             JsBuilder::new()
                 .morph_selector("#room-new-thread-ui-slot", markup)
                 .into_response()
+        }
+        HtmlUiAction::ExpandPostFull {
+            room,
+            thread_tag,
+            post_index,
+        } => {
+            let viewer = session.map(|s| s.username.as_str());
+            thread_ui_expand_post_full(state, &room, &thread_tag, post_index, viewer).await
+        }
+        HtmlUiAction::ExpandRedactedPost {
+            room,
+            thread_tag,
+            post_index,
+        } => {
+            let viewer = session.map(|s| s.username.as_str());
+            thread_ui_expand_redacted_post(state, &room, &thread_tag, post_index, viewer).await
+        }
+        HtmlUiAction::CollapseRedactedPost {
+            room,
+            thread_tag,
+            post_index,
+        } => {
+            let viewer = session.map(|s| s.username.as_str());
+            thread_ui_collapse_redacted_post(state, &room, &thread_tag, post_index, viewer).await
         }
     }
 }
@@ -368,12 +393,3 @@ async fn redact_success_response(state: &AppState) -> Response {
         .into_response()
 }
 
-fn ui_js_warn(msg: &str) -> Response {
-    use crate::html::js_string_literal;
-    let js = format!("console.warn({});", js_string_literal(msg));
-    Response::builder()
-        .status(StatusCode::OK)
-        .header(header::CONTENT_TYPE, "text/javascript; charset=utf-8")
-        .body(axum::body::Body::from(js))
-        .unwrap()
-}

--- a/server/src/html/forum.rs
+++ b/server/src/html/forum.rs
@@ -19,6 +19,7 @@ use crate::{
 };
 use serde_json::json;
 
+use super::js_string_literal;
 use super::ui_action::{HtmlUiAction, UI_RPC_FIELD};
 
 use super::{
@@ -114,18 +115,14 @@ impl ThreadNav {
     fn post_url(&self, tag: &str, idx: usize) -> String {
         format!("{}/{}/{}", self.thread_path_prefix, tag, idx)
     }
+}
 
-    fn expand_url(&self, tag: &str, idx: usize) -> String {
-        format!("{}/{}/{}/expand", self.thread_path_prefix, tag, idx)
-    }
-
-    fn expand_deleted_url(&self, tag: &str, idx: usize) -> String {
-        format!("{}/{}/{}/expand-deleted", self.thread_path_prefix, tag, idx)
-    }
-
-    fn collapse_deleted_url(&self, tag: &str, idx: usize) -> String {
-        format!("{}/{}/{}/collapse-deleted", self.thread_path_prefix, tag, idx)
-    }
+/// `POST /ui` + `__rpc__` from an inline link (`onclick`); same-origin credentials as other morph actions.
+fn thread_ui_fetch_onclick(rpc_compact_json: &str) -> String {
+    format!(
+        "fetch('/ui',{{method:'POST',headers:{{'Content-Type':'application/x-www-form-urlencoded'}},body:new URLSearchParams({{__rpc__:{}}}).toString(),credentials:'same-origin'}}).then(r=>r.text()).then(eval);return false",
+        js_string_literal(rpc_compact_json)
+    )
 }
 
 fn thread_nav_for_ingest(ing: &crate::events::Ingest) -> Option<ThreadNav> {
@@ -201,8 +198,22 @@ fn redacted_header_row(
     expanded: bool,
 ) -> Markup {
     let meta = post_header_meta(nav, tag, post_idx, &ing.principal, ing.ts, now);
-    let exp = nav.expand_deleted_url(tag, post_idx);
-    let coll = nav.collapse_deleted_url(tag, post_idx);
+    let rpc_expand = template_json_compact(&json!({
+        "action": "expand_redacted_post",
+        "room": nav.room_wire,
+        "thread_tag": tag,
+        "post_index": post_idx,
+    }))
+    .unwrap();
+    let rpc_collapse = template_json_compact(&json!({
+        "action": "collapse_redacted_post",
+        "room": nav.room_wire,
+        "thread_tag": tag,
+        "post_index": post_idx,
+    }))
+    .unwrap();
+    let onclick_expand = thread_ui_fetch_onclick(&rpc_expand);
+    let onclick_collapse = thread_ui_fetch_onclick(&rpc_collapse);
     html! {
         div class="ingest-header-row ingest-tombstone-row" {
             (meta)
@@ -210,12 +221,12 @@ fn redacted_header_row(
                 "deleted · "
                 @if expanded {
                     a href="#" class="hide-deleted-link"
-                      onclick=(format!("fetch('{coll}').then(r=>r.text()).then(eval);return false")) {
+                      onclick=(onclick_collapse) {
                         "[hide deleted content]"
                     }
                 } @else {
                     a href="#" class="show-deleted-link"
-                      onclick=(format!("fetch('{exp}').then(r=>r.text()).then(eval);return false")) {
+                      onclick=(onclick_expand) {
                         "[show deleted content]"
                     }
                 }
@@ -249,9 +260,15 @@ fn ingest_entry_markup(
                 (post_header_row(nav, tag, post_idx, ing, viewer, now, show_delete))
                 (render_linkified_with_embeds_in_scope(display_body, nav.garden_root_url()))
                 @if truncated {
-                    @let exp = nav.expand_url(tag, post_idx);
+                    @let rpc_full = template_json_compact(&json!({
+                        "action": "expand_post_full",
+                        "room": nav.room_wire,
+                        "thread_tag": tag,
+                        "post_index": post_idx,
+                    })).unwrap();
+                    @let onclick_full = thread_ui_fetch_onclick(&rpc_full);
                     a href="#" class="show-full-link"
-                      onclick=(format!("fetch('{exp}').then(r=>r.text()).then(eval);return false")) {
+                      onclick=(onclick_full) {
                         "[show full post]"
                     }
                 }
@@ -1096,30 +1113,44 @@ pub async fn room_thread_post_view(
         .into_response()
 }
 
-async fn thread_post_expand_inner(
-    state: AppState,
-    tag: String,
-    index_str: String,
-    nav: ThreadNav,
-    viewer: Option<String>,
-) -> impl IntoResponse {
-    let tag = canonicalize_tag(&tag);
-    let index: usize = index_str.parse().unwrap_or(0);
-    let now = now_ms();
-    let scope = nav.scope();
+pub(crate) async fn thread_ui_expand_post_full(
+    state: &AppState,
+    room: &str,
+    thread_tag: &str,
+    post_index: usize,
+    viewer: Option<&str>,
+) -> axum::response::Response {
+    let room = room.trim();
+    let tag = canonicalize_tag(thread_tag);
+    let scope = scope_from_room_wire(room);
+    let nav = if room.is_empty() || room == "public" {
+        ThreadNav::public()
+    } else {
+        let Some(n) = ThreadNav::from_room_id(room) else {
+            return super::ui_js_warn("bad room");
+        };
+        n
+    };
+    if let ScopeId::Room(ref rid) = scope {
+        let reduced = state.reduced.read().await;
+        if !user_can_view_room(&reduced, rid, viewer) {
+            return super::ui_js_warn("forbidden");
+        }
+    }
 
+    let now = now_ms();
     let reduced = state.reduced.read().await;
     let ing = reduced
         .ingests_by_scope_thread
         .get(&(scope.clone(), tag.clone()))
-        .and_then(|q| q.iter().rev().nth(index))
+        .and_then(|q| q.iter().rev().nth(post_index))
         .and_then(|id| reduced.ingests_by_id.get(id).cloned());
     let Some(ing) = ing else {
-        return (StatusCode::NOT_FOUND, "post not found").into_response();
+        return super::ui_js_warn("post not found");
     };
     if reduced.redacted_posts.contains(&ing.id) {
-        return (StatusCode::NOT_FOUND, "post not found").into_response();
-    };
+        return super::ui_js_warn("post not found");
+    }
     let ing_id = ing.id.clone();
     drop(reduced);
 
@@ -1128,125 +1159,118 @@ async fn thread_post_expand_inner(
             (post_header_row(
                 &nav,
                 &tag,
-                index,
+                post_index,
                 &ing,
-                viewer.as_deref(),
+                viewer,
                 now,
-                viewer.as_deref() == Some(ing.principal.as_str()),
+                viewer == Some(ing.principal.as_str()),
             ))
             (render_linkified_with_embeds_in_scope(&ing.raw, nav.garden_root_url()))
         }
     };
 
     JsBuilder::new()
-        .morph_selector(
-            &format!("[data-ingest-id=\"{}\"]", ing_id),
-            full_html,
-        )
-        .into_response()
+        .morph_selector(&format!("[data-ingest-id=\"{}\"]", ing_id), full_html)
         .into_response()
 }
 
-async fn thread_post_expand_deleted_inner(
-    state: AppState,
-    tag: String,
-    index_str: String,
-    nav: ThreadNav,
-    _viewer: Option<String>,
-) -> impl IntoResponse {
-    let tag = canonicalize_tag(&tag);
-    let index: usize = index_str.parse().unwrap_or(0);
-    let now = now_ms();
-    let scope = nav.scope();
-
-    let full_html = {
+pub(crate) async fn thread_ui_expand_redacted_post(
+    state: &AppState,
+    room: &str,
+    thread_tag: &str,
+    post_index: usize,
+    viewer: Option<&str>,
+) -> axum::response::Response {
+    let room = room.trim();
+    let tag = canonicalize_tag(thread_tag);
+    let scope = scope_from_room_wire(room);
+    let nav = if room.is_empty() || room == "public" {
+        ThreadNav::public()
+    } else {
+        let Some(n) = ThreadNav::from_room_id(room) else {
+            return super::ui_js_warn("bad room");
+        };
+        n
+    };
+    if let ScopeId::Room(ref rid) = scope {
         let reduced = state.reduced.read().await;
-        let ing = reduced
-            .ingests_by_scope_thread
-            .get(&(scope.clone(), tag.clone()))
-            .and_then(|q| q.iter().rev().nth(index))
-            .and_then(|id| reduced.ingests_by_id.get(id).cloned());
-        let Some(ing) = ing else {
-            return (StatusCode::NOT_FOUND, "post not found").into_response();
-        };
-        if !reduced.redacted_posts.contains(&ing.id) {
-            return (StatusCode::NOT_FOUND, "post not found").into_response();
-        };
-        html! {
-            div class="ingest-entry ingest-redacted-expanded" data-ingest-id=(ing.id) {
-                (redacted_header_row(&nav, &tag, index, &ing, now, true))
-                (render_linkified_with_embeds_in_scope(&ing.raw, nav.garden_root_url()))
-            }
+        if !user_can_view_room(&reduced, rid, viewer) {
+            return super::ui_js_warn("forbidden");
+        }
+    }
+
+    let now = now_ms();
+    let reduced = state.reduced.read().await;
+    let ing = reduced
+        .ingests_by_scope_thread
+        .get(&(scope.clone(), tag.clone()))
+        .and_then(|q| q.iter().rev().nth(post_index))
+        .and_then(|id| reduced.ingests_by_id.get(id).cloned());
+    let Some(ing) = ing else {
+        return super::ui_js_warn("post not found");
+    };
+    if !reduced.redacted_posts.contains(&ing.id) {
+        return super::ui_js_warn("post not found");
+    }
+    let ing_id = ing.id.clone();
+    drop(reduced);
+
+    let full_html = html! {
+        div class="ingest-entry ingest-redacted-expanded" data-ingest-id=(ing_id) {
+            (redacted_header_row(&nav, &tag, post_index, &ing, now, true))
+            (render_linkified_with_embeds_in_scope(&ing.raw, nav.garden_root_url()))
         }
     };
 
-    let ing_id = {
-        let reduced = state.reduced.read().await;
-        reduced
-            .ingests_by_scope_thread
-            .get(&(nav.scope(), tag.clone()))
-            .and_then(|q| q.iter().rev().nth(index))
-            .cloned()
-    };
-    let Some(ing_id) = ing_id else {
-        return (StatusCode::NOT_FOUND, "post not found").into_response();
-    };
-
     JsBuilder::new()
-        .morph_selector(
-            &format!("[data-ingest-id=\"{}\"]", ing_id),
-            full_html,
-        )
-        .into_response()
+        .morph_selector(&format!("[data-ingest-id=\"{}\"]", ing_id), full_html)
         .into_response()
 }
 
-async fn thread_post_collapse_deleted_inner(
-    state: AppState,
-    tag: String,
-    index_str: String,
-    nav: ThreadNav,
-    viewer: Option<String>,
-) -> impl IntoResponse {
-    let tag = canonicalize_tag(&tag);
-    let index: usize = index_str.parse().unwrap_or(0);
+pub(crate) async fn thread_ui_collapse_redacted_post(
+    state: &AppState,
+    room: &str,
+    thread_tag: &str,
+    post_index: usize,
+    viewer: Option<&str>,
+) -> axum::response::Response {
+    let room = room.trim();
+    let tag = canonicalize_tag(thread_tag);
+    let scope = scope_from_room_wire(room);
+    let nav = if room.is_empty() || room == "public" {
+        ThreadNav::public()
+    } else {
+        let Some(n) = ThreadNav::from_room_id(room) else {
+            return super::ui_js_warn("bad room");
+        };
+        n
+    };
+    if let ScopeId::Room(ref rid) = scope {
+        let reduced = state.reduced.read().await;
+        if !user_can_view_room(&reduced, rid, viewer) {
+            return super::ui_js_warn("forbidden");
+        }
+    }
+
     let now = now_ms();
-    let scope = nav.scope();
-
-    let collapsed = {
-        let reduced = state.reduced.read().await;
-        let ing = reduced
-            .ingests_by_scope_thread
-            .get(&(scope.clone(), tag.clone()))
-            .and_then(|q| q.iter().rev().nth(index))
-            .and_then(|id| reduced.ingests_by_id.get(id).cloned());
-        let Some(ing) = ing else {
-            return (StatusCode::NOT_FOUND, "post not found").into_response();
-        };
-        if !reduced.redacted_posts.contains(&ing.id) {
-            return (StatusCode::NOT_FOUND, "post not found").into_response();
-        };
-        ingest_entry_markup(&nav, &tag, index, &ing, viewer.as_deref(), now, &reduced)
+    let reduced = state.reduced.read().await;
+    let ing = reduced
+        .ingests_by_scope_thread
+        .get(&(scope.clone(), tag.clone()))
+        .and_then(|q| q.iter().rev().nth(post_index))
+        .and_then(|id| reduced.ingests_by_id.get(id).cloned());
+    let Some(ing) = ing else {
+        return super::ui_js_warn("post not found");
     };
-
-    let ing_id = {
-        let reduced = state.reduced.read().await;
-        reduced
-            .ingests_by_scope_thread
-            .get(&(nav.scope(), tag.clone()))
-            .and_then(|q| q.iter().rev().nth(index))
-            .cloned()
-    };
-    let Some(ing_id) = ing_id else {
-        return (StatusCode::NOT_FOUND, "post not found").into_response();
-    };
+    if !reduced.redacted_posts.contains(&ing.id) {
+        return super::ui_js_warn("post not found");
+    }
+    let ing_id = ing.id.clone();
+    let collapsed = ingest_entry_markup(&nav, &tag, post_index, &ing, viewer, now, &reduced);
+    drop(reduced);
 
     JsBuilder::new()
-        .morph_selector(
-            &format!("[data-ingest-id=\"{}\"]", ing_id),
-            collapsed,
-        )
-        .into_response()
+        .morph_selector(&format!("[data-ingest-id=\"{}\"]", ing_id), collapsed)
         .into_response()
 }
 
@@ -1345,115 +1369,4 @@ pub async fn user_profile_page(
         &theme_next_from_uri(&uri),
     );
     Html(page.into_string()).into_response()
-}
-
-pub async fn thread_post_expand(
-    State(state): State<AppState>,
-    Path((tag, index_str)): Path<(String, String)>,
-    headers: HeaderMap,
-    jar: CookieJar,
-) -> impl IntoResponse {
-    let reduced = state.reduced.read().await;
-    let viewer = optional_principal(&headers, &jar, &reduced);
-    drop(reduced);
-    thread_post_expand_inner(state, tag, index_str, ThreadNav::public(), viewer)
-        .await
-}
-
-pub async fn room_thread_post_expand(
-    State(state): State<AppState>,
-    Path((room_short, room_slug, tag, index_str)): Path<(String, String, String, String)>,
-    headers: HeaderMap,
-    jar: CookieJar,
-    uri: Uri,
-) -> impl IntoResponse {
-    let room_id = format!("{room_short}/{room_slug}");
-    let reduced = state.reduced.read().await;
-    let user = optional_principal(&headers, &jar, &reduced);
-    if !user_can_view_room(&reduced, &room_id, user.as_deref()) {
-        drop(reduced);
-        return room_not_found_page(&jar, &uri).into_response();
-    }
-    let Some(nav) = ThreadNav::from_room_id(&room_id) else {
-        drop(reduced);
-        return (StatusCode::NOT_FOUND, "not found").into_response();
-    };
-    drop(reduced);
-    thread_post_expand_inner(state, tag, index_str, nav, user)
-        .await
-        .into_response()
-}
-
-pub async fn thread_post_expand_deleted(
-    State(state): State<AppState>,
-    Path((tag, index_str)): Path<(String, String)>,
-    headers: HeaderMap,
-    jar: CookieJar,
-) -> impl IntoResponse {
-    let reduced = state.reduced.read().await;
-    let viewer = optional_principal(&headers, &jar, &reduced);
-    drop(reduced);
-    thread_post_expand_deleted_inner(state, tag, index_str, ThreadNav::public(), viewer)
-        .await
-}
-
-pub async fn room_thread_post_expand_deleted(
-    State(state): State<AppState>,
-    Path((room_short, room_slug, tag, index_str)): Path<(String, String, String, String)>,
-    headers: HeaderMap,
-    jar: CookieJar,
-    uri: Uri,
-) -> impl IntoResponse {
-    let room_id = format!("{room_short}/{room_slug}");
-    let reduced = state.reduced.read().await;
-    let user = optional_principal(&headers, &jar, &reduced);
-    if !user_can_view_room(&reduced, &room_id, user.as_deref()) {
-        drop(reduced);
-        return room_not_found_page(&jar, &uri).into_response();
-    }
-    let Some(nav) = ThreadNav::from_room_id(&room_id) else {
-        drop(reduced);
-        return (StatusCode::NOT_FOUND, "not found").into_response();
-    };
-    drop(reduced);
-    thread_post_expand_deleted_inner(state, tag, index_str, nav, user)
-        .await
-        .into_response()
-}
-
-pub async fn thread_post_collapse_deleted(
-    State(state): State<AppState>,
-    Path((tag, index_str)): Path<(String, String)>,
-    headers: HeaderMap,
-    jar: CookieJar,
-) -> impl IntoResponse {
-    let reduced = state.reduced.read().await;
-    let viewer = optional_principal(&headers, &jar, &reduced);
-    drop(reduced);
-    thread_post_collapse_deleted_inner(state, tag, index_str, ThreadNav::public(), viewer)
-        .await
-}
-
-pub async fn room_thread_post_collapse_deleted(
-    State(state): State<AppState>,
-    Path((room_short, room_slug, tag, index_str)): Path<(String, String, String, String)>,
-    headers: HeaderMap,
-    jar: CookieJar,
-    uri: Uri,
-) -> impl IntoResponse {
-    let room_id = format!("{room_short}/{room_slug}");
-    let reduced = state.reduced.read().await;
-    let user = optional_principal(&headers, &jar, &reduced);
-    if !user_can_view_room(&reduced, &room_id, user.as_deref()) {
-        drop(reduced);
-        return room_not_found_page(&jar, &uri).into_response();
-    }
-    let Some(nav) = ThreadNav::from_room_id(&room_id) else {
-        drop(reduced);
-        return (StatusCode::NOT_FOUND, "not found").into_response();
-    };
-    drop(reduced);
-    thread_post_collapse_deleted_inner(state, tag, index_str, nav, user)
-        .await
-        .into_response()
 }

--- a/server/src/html/mod.rs
+++ b/server/src/html/mod.rs
@@ -22,15 +22,13 @@ use breadcrumb_path::OntologyPath;
 pub use auth::{auth_complete_page, auth_signed_in_fragment, choose_username_error_fragment, choose_username_page};
 pub use editor::{editor_check, editor_page};
 pub use forum::{
-    home, room_page, room_thread_post_collapse_deleted, room_thread_post_expand,
-    room_thread_post_expand_deleted, room_thread_post_view, room_thread_view,
-    thread_feed_html, thread_feed_html_for_room, thread_feed_region_markup,
-    thread_post_collapse_deleted, thread_post_expand, thread_post_expand_deleted, thread_post_view,
-    thread_view, ThreadNav,
+    home, room_page, room_thread_post_view, room_thread_view, thread_feed_html,
+    thread_feed_html_for_room, thread_feed_region_markup, thread_post_view, thread_view, ThreadNav,
 };
 
 pub(crate) use forum::{
     fragment_public_new_thread_form, fragment_room_new_thread_form, login_to_post_hint_markup,
+    thread_ui_collapse_redacted_post, thread_ui_expand_post_full, thread_ui_expand_redacted_post,
     user_can_post_room, user_can_view_room,
 };
 pub use garden::{garden_index, ontology_path, room_garden_index, room_ontology_path};
@@ -141,6 +139,16 @@ pub async fn serve_theme_css(Path(filename): Path<String>) -> impl IntoResponse 
 
 pub(crate) fn js_string_literal(s: &str) -> String {
     serde_json::to_string(s).expect("javascript string escaping")
+}
+
+/// `console.warn` as `text/javascript` — for `POST /ui` parse errors and inline morph failures.
+pub(crate) fn ui_js_warn(msg: &str) -> Response {
+    let js = format!("console.warn({});", js_string_literal(msg));
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "text/javascript; charset=utf-8")
+        .body(Body::from(js))
+        .unwrap()
 }
 
 pub(crate) struct JsBuilder {

--- a/server/src/html/ui_action.rs
+++ b/server/src/html/ui_action.rs
@@ -44,6 +44,24 @@ pub enum HtmlUiAction {
     ExpandRoomNewThreadForm {
         room_wire: String,
     },
+    /// Replace a truncated post card with the full body (same thread index).
+    ExpandPostFull {
+        room: String,
+        thread_tag: String,
+        post_index: usize,
+    },
+    /// Expand a redacted/tombstone post to show stripped body (author view).
+    ExpandRedactedPost {
+        room: String,
+        thread_tag: String,
+        post_index: usize,
+    },
+    /// Collapse an expanded redacted post back to the tombstone card.
+    CollapseRedactedPost {
+        room: String,
+        thread_tag: String,
+        post_index: usize,
+    },
 }
 
 #[derive(Debug, Error)]
@@ -112,5 +130,29 @@ mod tests {
         );
         let a = parse_html_ui_from_form(&form).unwrap();
         assert_eq!(a, HtmlUiAction::ExpandPublicNewThreadForm);
+    }
+
+    #[test]
+    fn expand_post_full_round_trip() {
+        let template = serde_json::json!({
+            "action": "expand_post_full",
+            "room": "public",
+            "thread_tag": "demo",
+            "post_index": 3,
+        });
+        let mut form = HashMap::new();
+        form.insert(
+            UI_RPC_FIELD.to_string(),
+            serde_json::to_string(&template).unwrap(),
+        );
+        let a = parse_html_ui_from_form(&form).unwrap();
+        assert_eq!(
+            a,
+            HtmlUiAction::ExpandPostFull {
+                room: "public".into(),
+                thread_tag: "demo".into(),
+                post_index: 3,
+            }
+        );
     }
 }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -47,32 +47,8 @@ pub fn create_app(state: AppState) -> Router {
             "/r/:room_short/:room_slug/~/*path",
             get(crate::html::room_ontology_path),
         )
-        .route(
-            "/t/:tag/:index/expand",
-            get(crate::html::thread_post_expand),
-        )
-        .route(
-            "/t/:tag/:index/expand-deleted",
-            get(crate::html::thread_post_expand_deleted),
-        )
-        .route(
-            "/t/:tag/:index/collapse-deleted",
-            get(crate::html::thread_post_collapse_deleted),
-        )
         .route("/t/:tag/:index", get(crate::html::thread_post_view))
         .route("/t/:tag", get(crate::html::thread_view))
-        .route(
-            "/r/:room_short/:room_slug/t/:thread_tag/:index/expand",
-            get(crate::html::room_thread_post_expand),
-        )
-        .route(
-            "/r/:room_short/:room_slug/t/:thread_tag/:index/expand-deleted",
-            get(crate::html::room_thread_post_expand_deleted),
-        )
-        .route(
-            "/r/:room_short/:room_slug/t/:thread_tag/:index/collapse-deleted",
-            get(crate::html::room_thread_post_collapse_deleted),
-        )
         .route(
             "/r/:room_short/:room_slug/t/:thread_tag/:index",
             get(crate::html::room_thread_post_view),

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -61,7 +61,6 @@ pub fn create_app(state: AppState) -> Router {
         )
         .route("/t/:tag/:index", get(crate::html::thread_post_view))
         .route("/t/:tag", get(crate::html::thread_view))
-        // TODO DELETE THESE AND USE __RPC__ PATTERN
         .route(
             "/r/:room_short/:room_slug/t/:thread_tag/:index/expand",
             get(crate::html::room_thread_post_expand),

--- a/server/src/reducer.rs
+++ b/server/src/reducer.rs
@@ -152,7 +152,12 @@ pub struct RankHistoryEntry {
     pub post_id: String,
 }
 
-/// Durable invite link state (from [`crate::events::InviteMinted`] / [`crate::events::InviteRedeemed`]).
+/// Invite link materialized from log events [`crate::events::InviteMinted`] /
+/// [`crate::events::InviteRedeemed`] when those are replayed.
+///
+/// **`RoomMintInvite` today** stores tokens only in [`crate::state::AppState::invites`] (RAM);
+/// they are not appended to the JSONL log, so they disappear on restart. This struct is for
+/// replay and any future persisted-mint path, not for the current ephemeral RPC mint.
 #[derive(Debug, Clone)]
 pub struct ActiveInviteState {
     pub room_id: String,
@@ -632,8 +637,6 @@ impl ReducerState {
                 let canonical_thread = ing.thread_tag.clone();
                 let scope_thread_key = (scope.clone(), canonical_thread.clone());
 
-                self.ingests_by_id.insert(ing.id.clone(), ing.clone());
-
                 {
                     let content = self.content_for_scope_mut(scope.clone());
                     if Self::apply_ingest_to_content(content, &ing).is_err() {
@@ -644,6 +647,8 @@ impl ReducerState {
                         return;
                     }
                 }
+
+                self.ingests_by_id.insert(ing.id.clone(), ing.clone());
 
                 let ft = self.forum_threads.entry(scope_thread_key.clone()).or_default();
                 let prev_ts = ft.last_activity_ts;

--- a/server/src/state.rs
+++ b/server/src/state.rs
@@ -57,7 +57,9 @@ pub struct AppState {
     pub event_log: Arc<EventLog>,
     pub reduced: Arc<RwLock<ReducerState>>,
     pub pending_sessions: Arc<RwLock<HashMap<String, PendingSession>>>,
-    /// Ephemeral invite tokens (`inv_…`) until expiry or exhaustion.
+    /// Ephemeral invite tokens (`inv_…`): in this process only, not written to the event log.
+    /// Minted via `RoomMintInvite`; restarting the server drops any unused links. (Log event
+    /// types `InviteMinted` / `InviteRedeemed` exist for replay and a possible future persisted path.)
     pub invites: Arc<RwLock<HashMap<String, InviteState>>>,
     /// Broadcast channel for SSE live-streaming. Capacity = 64 events.
     pub stream_tx: broadcast::Sender<StreamEvent>,

--- a/server/tests/basic.rs
+++ b/server/tests/basic.rs
@@ -454,12 +454,16 @@ fn ranking_repeated_votes_normalized() {
 #[test]
 fn reducer_malformed_ingest_is_skipped_no_panic() {
     let mut state = ReducerState::default();
-    // Completely invalid raw text that will fail dsl::parse_full
-    state.apply_event(ingest_event(1, "this is {{ not valid DSL at all }{"));
-    // State should remain empty — no panic, no items
+    // DSL-looking line that fails parse (unclosed item body), not plain prose
+    state.apply_event(ingest_event(1, "~/t/a { unclosed "));
+    // State should remain empty — no panic, no items, no ingest id leakage
     let content = state.public();
     assert!(content.items.is_empty());
     assert!(content.ranking_group.idx_to_item.is_empty());
+    assert!(
+        state.ingests_by_id.is_empty(),
+        "malformed ingest must not be recorded in ingests_by_id"
+    );
 }
 
 #[test]

--- a/test/browser_post_redact.clj
+++ b/test/browser_post_redact.clj
@@ -1,4 +1,6 @@
 (ns test.browser-post-redact
+  "Tombstone expand/collapse uses POST /ui + __rpc__ (expand_redacted_post / collapse_redacted_post)
+   and returns eval-able JS — covered here via Playwright, not HTTP-only tests."
   (:require [babashka.fs :as fs]
             [cheshire.core :as json]
             [clojure.string :as str]

--- a/test/browser_ui_morph.clj
+++ b/test/browser_ui_morph.clj
@@ -1,0 +1,93 @@
+(ns test.browser-ui-morph
+  "Playwright (Spel) checks for JS responses that morph the DOM — e.g. POST /ui __rpc__
+   expand_post_full. These paths are not covered by HTTP-only integration tests."
+  (:require [babashka.fs :as fs]
+            [cheshire.core :as json]
+            [clojure.string :as str]
+            [com.blockether.spel.core :as core]
+            [com.blockether.spel.locator :as locator]
+            [com.blockether.spel.page :as page]
+            [test.common :as common]
+            [test.oauth :as oauth]))
+
+(def ^:private counts (atom {:pass 0 :fail 0}))
+
+(defn- assert! [pred msg]
+  (common/test-assert! counts pred msg))
+
+(defn- wait-for-text [pg selector expected timeout-ms]
+  (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+    (loop []
+      (let [text (locator/text-content (page/locator pg selector))]
+        (if (and (string? text) (str/includes? text expected))
+          true
+          (if (< (System/currentTimeMillis) deadline)
+            (do (Thread/sleep 200) (recur))
+            false))))))
+
+(defn expand-post-full-via-ui-rpc-test [& _args]
+  (println "\n━━━ browser UI morph: expand_post_full (__rpc__ + POST /ui) ━━━\n")
+  (reset! counts {:pass 0 :fail 0})
+
+  (common/letlocals
+   (bind build (common/run-cargo-build-release! ["slugsocial-server"]))
+   (assert! (zero? (:exit build)) "cargo build succeeds")
+   (bind server-bin "target/release/slugsocial-server")
+
+   (bind tmp-dir (str (fs/create-temp-dir {:prefix "slug-browser-ui-morph-"})))
+   (bind slug-port (common/pick-port))
+   (bind google-port (common/pick-port))
+   (bind base-url (str "http://127.0.0.1:" slug-port))
+   (bind google-url (str "http://127.0.0.1:" google-port))
+
+   (bind !server (atom nil))
+   (bind !google (atom nil))
+   (bind server-env (common/slug-server-env tmp-dir base-url google-url slug-port))
+   (try
+     (reset! !google (oauth/start-mock-google google-port
+                                              :google-users ["google-user-alice"]))
+     (reset! !server (common/start-server server-bin server-env))
+     (assert! (common/wait-for-server base-url 10000) "server responds to /healthz")
+
+     (let [alice-token (oauth/fetch-bearer-token! base-url :username "alice")
+           thread-tag "ui-morph-long"
+           ;; Truncation kicks in when ing.raw len > 2000 (forum markup).
+           tail "END_UI_MORPH_TAIL_MARKER"
+           long-body (str "# " thread-tag "\n\n"
+                          (str/join (repeat 400 "abcdefghij"))
+                          tail)
+           post-resp (oauth/http-post-json
+                      (str base-url "/api/v0/rpc")
+                      [{"Post" {"room" "public"
+                                "thread_tag" thread-tag
+                                "text" long-body
+                                "return_rank_diff" false}}]
+                      :headers {"Authorization" (str "Bearer " alice-token)})
+           post-json (json/parse-string (:body post-resp) false)
+           _ (assert! (true? (get-in post-json ["results" 0 "ok"])) "seed long post via rpc")]
+       (core/with-playwright [pw]
+         (core/with-browser [browser (core/launch-chromium pw {:headless true :channel "chrome"})]
+           (core/with-context [ctx (core/new-context browser)]
+             (core/with-page [pg (core/new-page-from-context ctx)]
+               (page/navigate pg (str base-url "/login"))
+               (assert! (wait-for-text pg "body" "@alice" 15000) "alice session after login")
+               (page/navigate pg (str base-url "/t/" thread-tag))
+               (assert! (wait-for-text pg "#thread-feed-region" "[show full post]" 15000)
+                        "truncated card shows expand link")
+               (let [before (or (locator/text-content (page/locator pg "#thread-feed-region")) "")]
+                 (assert! (not (str/includes? before tail))
+                          "tail marker not visible before expand"))
+               (locator/click (page/locator pg ".show-full-link"))
+               (assert! (wait-for-text pg "#thread-feed-region" tail 15000)
+                        "POST /ui morph reveals full body (tail marker visible)"))))))
+
+     (finally
+       (when-some [s @!server] (common/kill-server s))
+       (when-some [g @!google] ((:stop-fn g)))
+       (fs/delete-tree tmp-dir)))
+
+   (bind {pass :pass fail :fail} @counts)
+   (if (zero? fail)
+     (println (str "\n" common/ansi-green "━━━ " pass " UI morph browser checks passed ━━━" common/ansi-reset "\n"))
+     (do (println (str "\n" common/ansi-red "━━━ " fail " UI morph browser checks FAILED ━━━" common/ansi-reset "\n"))
+         (System/exit 1)))))

--- a/test/runner.clj
+++ b/test/runner.clj
@@ -6,7 +6,8 @@
             [test.invites :as invites]
             [test.room-list :as room-list]
             [test.browser-sse :as browser-sse]
-            [test.browser-post-redact :as browser-post-redact]))
+            [test.browser-post-redact :as browser-post-redact]
+            [test.browser-ui-morph :as browser-ui-morph]))
 
 (defn run-core! []
   (integration/integration)
@@ -19,4 +20,5 @@
   (case (vec args)
     ["browser-sse"] (browser-sse/private-thread-sse-browser-test)
     ["browser-post-redact"] (browser-post-redact/post-redact-browser-test)
+    ["browser-ui-morph"] (browser-ui-morph/expand-post-full-via-ui-rpc-test)
     (run-core!)))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

### Malformed ingest replay
- **`Event::Ingest`:** apply content before `ingests_by_id` so failed parse leaves no orphan id.
- **Test:** malformed DSL + assert `ingests_by_id` empty.

### Ephemeral invites (documented)
- Comments on `AppState.invites`, `ActiveInviteState`, and `RoomMintInvite` RPC: RAM-only mints, not in JSONL.

### Thread UI actions → `__rpc__` + `POST /ui`
- **Removed** GET routes: `/t/.../expand`, `expand-deleted`, `collapse-deleted`, and room equivalents.
- **Added** `HtmlUiAction`: `expand_post_full`, `expand_redacted_post`, `collapse_redacted_post` (`room`, `thread_tag`, `post_index`).
- Thread markup uses `fetch('/ui', …)` + `eval` for morph actions.
- **`ui_js_warn`** in `html/mod.rs`.

### Browser (Spel / Playwright) tests
- **`test.browser-ui-morph`**: seeds a >2000 char public post, opens thread in Chromium, clicks `[show full post]`, asserts unique tail appears after `POST /ui` + `__rpc__` morph.
- **`scripts/clj-test.sh`** and **`bb browser-ui-morph`** run `clojure -M -m test.runner browser-ui-morph`.
- **`browser-post-redact`** ns doc notes it covers tombstone `__rpc__` expand/collapse.

## Running browser tests
Needs Clojure CLI, Chrome, and Playwright browsers (e.g. `npx playwright install chromium`), same as existing `browser-sse` / `browser-post-redact`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40e27f2c-fd97-47d8-80bd-6f449d6bf732"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40e27f2c-fd97-47d8-80bd-6f449d6bf732"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

