### PR TITLE
Room page: collapsible members and hidable new-thread form

### DIFF
--- a/server/src/api/ui_html.rs
+++ b/server/src/api/ui_html.rs
@@ -149,7 +149,7 @@ async fn dispatch_ui_action(
                 login_to_post_hint_markup()
             };
             JsBuilder::new()
-                .morph_selector("#public-new-thread-ui-slot", markup)
+                .morph_inner_selector("#public-new-thread-ui-slot", markup)
                 .into_response()
         }
         HtmlUiAction::ExpandRoomNewThreadForm { room_wire } => {
@@ -181,7 +181,7 @@ async fn dispatch_ui_action(
                 login_to_post_hint_markup()
             };
             JsBuilder::new()
-                .morph_selector("#room-new-thread-ui-slot", markup)
+                .morph_inner_selector("#room-new-thread-ui-slot", markup)
                 .into_response()
         }
         HtmlUiAction::SetRoomMembersExpanded { room_wire, expanded } => {
@@ -233,7 +233,7 @@ async fn dispatch_ui_action(
             } else {
                 login_to_post_hint_markup()
             };
-            let mut b = JsBuilder::new().morph_selector("#room-new-thread-ui-slot", markup);
+            let mut b = JsBuilder::new().morph_inner_selector("#room-new-thread-ui-slot", markup);
             if expanded && can_post {
                 b = b.focus_selector("#room-new-tag");
             }

--- a/server/src/api/ui_html.rs
+++ b/server/src/api/ui_html.rs
@@ -20,9 +20,10 @@ use crate::{
     canonical_path::canonicalize_tag,
     html::{
         fragment_public_new_thread_form, fragment_room_new_thread_form, login_to_post_hint_markup,
-        parse_html_ui_from_form, thread_feed_html, thread_feed_html_for_room, thread_feed_region_markup,
-        thread_ui_collapse_redacted_post, thread_ui_expand_post_full, thread_ui_expand_redacted_post,
-        ui_js_warn, user_can_post_room, user_can_view_room, HtmlUiAction, JsBuilder, ThreadNav,
+        parse_html_ui_from_form, room_members_section_markup, thread_feed_html,
+        thread_feed_html_for_room, thread_feed_region_markup, thread_ui_collapse_redacted_post,
+        thread_ui_expand_post_full, thread_ui_expand_redacted_post, ui_js_warn, user_can_post_room,
+        user_can_view_room, HtmlUiAction, JsBuilder, ThreadNav,
     },
     reducer::{scope_from_room_wire, ScopeId},
     state::AppState,
@@ -175,13 +176,68 @@ async fn dispatch_ui_action(
                 return ui_js_warn("bad room").into_response();
             };
             let markup = if can_post {
-                fragment_room_new_thread_form(&nav, true)
+                fragment_room_new_thread_form(&nav, true, false)
             } else {
                 login_to_post_hint_markup()
             };
             JsBuilder::new()
                 .morph_selector("#room-new-thread-ui-slot", markup)
                 .into_response()
+        }
+        HtmlUiAction::SetRoomMembersExpanded { room_wire, expanded } => {
+            let room_wire = room_wire.trim().to_string();
+            if room_wire.is_empty() {
+                return ui_js_warn("missing room").into_response();
+            }
+            let reduced = state.reduced.read().await;
+            let user = session.map(|s| s.username.as_str());
+            if !reduced.rooms.contains(&room_wire) {
+                drop(reduced);
+                return ui_js_warn("room not found").into_response();
+            }
+            if !user_can_view_room(&reduced, &room_wire, user) {
+                drop(reduced);
+                return ui_js_warn("forbidden").into_response();
+            }
+            let markup = room_members_section_markup(&reduced, &room_wire, expanded);
+            drop(reduced);
+            JsBuilder::new()
+                .morph_selector("#room-members-section", markup)
+                .into_response()
+        }
+        HtmlUiAction::SetRoomNewThreadComposeExpanded { room_wire, expanded } => {
+            let room_wire = room_wire.trim().to_string();
+            if room_wire.is_empty() {
+                return ui_js_warn("missing room").into_response();
+            }
+            let reduced = state.reduced.read().await;
+            let user = session.map(|s| s.username.as_str());
+            if !reduced.rooms.contains(&room_wire) {
+                drop(reduced);
+                return ui_js_warn("room not found").into_response();
+            }
+            if !user_can_view_room(&reduced, &room_wire, user) {
+                drop(reduced);
+                return ui_js_warn("forbidden").into_response();
+            }
+            let can_post = session
+                .as_ref()
+                .map(|s| user_can_post_room(&reduced, &room_wire, &s.username))
+                .unwrap_or(false);
+            drop(reduced);
+            let Some(nav) = ThreadNav::from_room_id(&room_wire) else {
+                return ui_js_warn("bad room").into_response();
+            };
+            let markup = if can_post {
+                fragment_room_new_thread_form(&nav, true, expanded)
+            } else {
+                login_to_post_hint_markup()
+            };
+            let mut b = JsBuilder::new().morph_selector("#room-new-thread-ui-slot", markup);
+            if expanded && can_post {
+                b = b.focus_selector("#room-new-tag");
+            }
+            b.into_response()
         }
         HtmlUiAction::ExpandPostFull {
             room,

--- a/server/src/html/editor.rs
+++ b/server/src/html/editor.rs
@@ -40,34 +40,6 @@ pub async fn editor_page(jar: CookieJar, uri: Uri) -> impl IntoResponse {
                 div id="editor-status" class="muted" { "type to check…" }
                 div id="editor-results" {}
             }
-            // Debounced editor: POST to /try/check, eval() the JS response.
-            script { (maud::PreEscaped(r#"
-(function() {
-    var ta = document.getElementById('editor-input');
-    var status = document.getElementById('editor-status');
-    var timer;
-    ta.addEventListener('input', function() {
-        clearTimeout(timer);
-        status.textContent = 'checking…';
-        timer = setTimeout(function() {
-            var text = ta.value.trim();
-            if (text.length < 3) {
-                status.textContent = 'type to check…';
-                document.getElementById('editor-results').innerHTML = '';
-                return;
-            }
-            fetch('/try/check', {
-                method: 'POST',
-                headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-                body: 'text=' + encodeURIComponent(text)
-            })
-            .then(function(r) { return r.text(); })
-            .then(function(js) { eval(js); })
-            .catch(function(e) { status.textContent = 'error: ' + e; });
-        }, 400);
-    });
-})();
-"#)) }
         },
         None,
         theme_from_jar(&jar),

--- a/server/src/html/forum.rs
+++ b/server/src/html/forum.rs
@@ -363,31 +363,68 @@ fn room_members_for_room(reduced: &ReducerState, room_id: &str) -> Vec<RoomMembe
     rows
 }
 
-fn room_members_collapsible(members: &[RoomMemberRow]) -> Markup {
+fn room_members_inner(members: &[RoomMemberRow]) -> Markup {
+    html! {
+        h3 { "members" }
+        ul class="room-members" {
+            @for member in members {
+                li {
+                    span class="room-member-name" { "@" (member.username) }
+                    span class="muted" {
+                        " · "
+                        (member.capabilities.join(", "))
+                    }
+                }
+            }
+        }
+    }
+}
+
+pub(crate) fn set_room_members_expanded_rpc(room_wire: &str, expanded: bool) -> String {
+    template_json_compact(&HtmlUiAction::SetRoomMembersExpanded {
+        room_wire: room_wire.to_string(),
+        expanded,
+    })
+    .expect("static json")
+}
+
+pub(crate) fn set_room_new_thread_compose_expanded_rpc(nav: &ThreadNav, expanded: bool) -> String {
+    template_json_compact(&HtmlUiAction::SetRoomNewThreadComposeExpanded {
+        room_wire: nav.room_wire.clone(),
+        expanded,
+    })
+    .expect("static json")
+}
+
+/// Fragment for `#room-members-section` — expand/collapse is server-driven via `POST /ui`.
+pub(crate) fn room_members_section_markup(
+    reduced: &ReducerState,
+    room_id: &str,
+    members_expanded: bool,
+) -> Markup {
+    let members = room_members_for_room(reduced, room_id);
     if members.is_empty() {
         return html! {};
     }
+    let rpc_open = set_room_members_expanded_rpc(room_id, true);
+    let rpc_close = set_room_members_expanded_rpc(room_id, false);
     html! {
-        button
-            type="button"
-            class="form-toggle"
-            data-toggle-target="#room-members-panel"
-            data-open-label="members & permissions"
-            data-close-label="hide members & permissions"
-            aria-expanded="false"
-        {
-            "members & permissions"
-        }
-        section id="room-members-panel" class="room-members-panel" hidden {
-            h3 { "members" }
-            ul class="room-members" {
-                @for member in members {
-                    li {
-                        span class="room-member-name" { "@" (member.username) }
-                        span class="muted" {
-                            " · "
-                            (member.capabilities.join(", "))
-                        }
+        div id="room-members-section" {
+            @if members_expanded {
+                form method="POST" action="/ui" {
+                    input type="hidden" name=(UI_RPC_FIELD) value=(rpc_close);
+                    button type="submit" class="form-toggle" aria-expanded="true" {
+                        "hide members & permissions"
+                    }
+                }
+                section class="room-members-panel" {
+                    (room_members_inner(&members))
+                }
+            } @else {
+                form method="POST" action="/ui" {
+                    input type="hidden" name=(UI_RPC_FIELD) value=(rpc_open);
+                    button type="submit" class="form-toggle" aria-expanded="false" {
+                        "members & permissions"
                     }
                 }
             }
@@ -918,15 +955,14 @@ pub async fn room_page(
     let scope = ScopeId::Room(room_id.clone());
     let mut rows = collect_thread_rows_for_scope(&reduced, &scope, now);
     let strip = auth_strip(&headers, &jar, &reduced);
-    let members = room_members_for_room(&reduced, &room_id);
     let show_new = user
         .as_ref()
         .map(|u| user_can_post_room(&reduced, &room_id, u))
         .unwrap_or(false);
-    drop(reduced);
     rows.sort_by(|a, b| b.last_ts.cmp(&a.last_ts));
 
     let Some(nav) = ThreadNav::from_room_id(&room_id) else {
+        drop(reduced);
         return (StatusCode::NOT_FOUND, "room not found").into_response();
     };
     let slug_display = room_slug.as_str();
@@ -946,7 +982,7 @@ pub async fn room_page(
                 "room garden · "
                 a href=(nav.garden_root_url()) { "~" }
             }
-            (room_members_collapsible(&members))
+            (room_members_section_markup(&reduced, &room_id, false))
             h3 { "threads" }
             (render_thread_feed(Some(&nav), "room-thread-feed", &rows, now))
             @if show_new {
@@ -957,7 +993,7 @@ pub async fn room_page(
                     }
                 }
                 div id="room-new-thread-ui-slot" {
-                    (new_thread_form_for_room(&nav, true))
+                    (new_thread_form_for_room(&nav, true, false))
                 }
             }
             (cli_panel(&forum_cli))
@@ -968,47 +1004,55 @@ pub async fn room_page(
         theme_from_jar(&jar),
         &theme_next_from_uri(&uri),
     );
+    drop(reduced);
     Html(page.into_string()).into_response()
 }
 
-fn new_thread_form_for_room(nav: &ThreadNav, show: bool) -> Markup {
+fn new_thread_form_for_room(nav: &ThreadNav, show: bool, compose_expanded: bool) -> Markup {
     if !show {
         return html! {};
     }
+    let rpc_open = set_room_new_thread_compose_expanded_rpc(nav, true);
+    let rpc_close = set_room_new_thread_compose_expanded_rpc(nav, false);
     html! {
-        button
-            type="button"
-            class="form-toggle"
-            data-toggle-target="#room-new-thread-compose"
-            data-open-label="new thread in this room"
-            data-close-label="hide new thread form"
-            aria-expanded="false"
-        {
-            "new thread in this room"
-        }
-        section class="compose" id="room-new-thread-compose" hidden {
-            h3 { "new thread in this room" }
-            div id="room-new-thread-errors" {}
-            form id="room-new-thread-form" method="POST" action="/ui" data-check-action="/ui" data-check-rpc=(template_json_compact(&json!({
-                "action": "check_ingest",
-                "room": nav.room_wire,
-                "thread_tag": {"$form": "thread_tag"},
-                "text": {"$form": "text"},
-                "error_target": "room-new-thread-errors",
-                "form_id": "room-new-thread-form",
-            })).unwrap()) {
-                input type="hidden" name=(UI_RPC_FIELD) value=(template_json_compact(&json!({
-                    "action": "post_ingest",
+        @if compose_expanded {
+            form method="POST" action="/ui" {
+                input type="hidden" name=(UI_RPC_FIELD) value=(rpc_close);
+                button type="submit" class="form-toggle" aria-expanded="true" {
+                    "hide new thread form"
+                }
+            }
+            section class="compose" id="room-new-thread-compose" {
+                h3 { "new thread in this room" }
+                div id="room-new-thread-errors" {}
+                form id="room-new-thread-form" method="POST" action="/ui" data-check-action="/ui" data-check-rpc=(template_json_compact(&json!({
+                    "action": "check_ingest",
                     "room": nav.room_wire,
                     "thread_tag": {"$form": "thread_tag"},
                     "text": {"$form": "text"},
                     "error_target": "room-new-thread-errors",
                     "form_id": "room-new-thread-form",
-                })).unwrap());
-                label for="room-new-tag" { "thread tag" }
-                input type="text" id="room-new-tag" name="thread_tag" pattern="[a-z0-9_\\-]{1,64}" required;
-                textarea name="text" rows="4" placeholder="First post body…" required {}
-                p { button type="submit" { "post" } }
+                })).unwrap()) {
+                    input type="hidden" name=(UI_RPC_FIELD) value=(template_json_compact(&json!({
+                        "action": "post_ingest",
+                        "room": nav.room_wire,
+                        "thread_tag": {"$form": "thread_tag"},
+                        "text": {"$form": "text"},
+                        "error_target": "room-new-thread-errors",
+                        "form_id": "room-new-thread-form",
+                    })).unwrap());
+                    label for="room-new-tag" { "thread tag" }
+                    input type="text" id="room-new-tag" name="thread_tag" pattern="[a-z0-9_\\-]{1,64}" required;
+                    textarea name="text" rows="4" placeholder="First post body…" required {}
+                    p { button type="submit" { "post" } }
+                }
+            }
+        } @else {
+            form method="POST" action="/ui" {
+                input type="hidden" name=(UI_RPC_FIELD) value=(rpc_open);
+                button type="submit" class="form-toggle" aria-expanded="false" {
+                    "new thread in this room"
+                }
             }
         }
     }
@@ -1035,8 +1079,8 @@ pub(crate) fn fragment_public_new_thread_form(show: bool) -> Markup {
     new_thread_form_public(show)
 }
 
-pub(crate) fn fragment_room_new_thread_form(nav: &ThreadNav, show: bool) -> Markup {
-    new_thread_form_for_room(nav, show)
+pub(crate) fn fragment_room_new_thread_form(nav: &ThreadNav, show: bool, compose_expanded: bool) -> Markup {
+    new_thread_form_for_room(nav, show, compose_expanded)
 }
 
 async fn thread_post_view_inner(

--- a/server/src/html/forum.rs
+++ b/server/src/html/forum.rs
@@ -1014,44 +1014,47 @@ fn new_thread_form_for_room(nav: &ThreadNav, show: bool, compose_expanded: bool)
     }
     let rpc_open = set_room_new_thread_compose_expanded_rpc(nav, true);
     let rpc_close = set_room_new_thread_compose_expanded_rpc(nav, false);
+    // Single root for Idiomorph when morphing `#room-new-thread-ui-slot` (expanded has form + section).
     html! {
-        @if compose_expanded {
-            form method="POST" action="/ui" {
-                input type="hidden" name=(UI_RPC_FIELD) value=(rpc_close);
-                button type="submit" class="form-toggle" aria-expanded="true" {
-                    "hide new thread form"
+        div class="room-new-thread-slot-inner" {
+            @if compose_expanded {
+                form method="POST" action="/ui" {
+                    input type="hidden" name=(UI_RPC_FIELD) value=(rpc_close);
+                    button type="submit" class="form-toggle" aria-expanded="true" {
+                        "hide new thread form"
+                    }
                 }
-            }
-            section class="compose" id="room-new-thread-compose" {
-                h3 { "new thread in this room" }
-                div id="room-new-thread-errors" {}
-                form id="room-new-thread-form" method="POST" action="/ui" data-check-action="/ui" data-check-rpc=(template_json_compact(&json!({
-                    "action": "check_ingest",
-                    "room": nav.room_wire,
-                    "thread_tag": {"$form": "thread_tag"},
-                    "text": {"$form": "text"},
-                    "error_target": "room-new-thread-errors",
-                    "form_id": "room-new-thread-form",
-                })).unwrap()) {
-                    input type="hidden" name=(UI_RPC_FIELD) value=(template_json_compact(&json!({
-                        "action": "post_ingest",
+                section class="compose" id="room-new-thread-compose" {
+                    h3 { "new thread in this room" }
+                    div id="room-new-thread-errors" {}
+                    form id="room-new-thread-form" method="POST" action="/ui" data-check-action="/ui" data-check-rpc=(template_json_compact(&json!({
+                        "action": "check_ingest",
                         "room": nav.room_wire,
                         "thread_tag": {"$form": "thread_tag"},
                         "text": {"$form": "text"},
                         "error_target": "room-new-thread-errors",
                         "form_id": "room-new-thread-form",
-                    })).unwrap());
-                    label for="room-new-tag" { "thread tag" }
-                    input type="text" id="room-new-tag" name="thread_tag" pattern="[a-z0-9_\\-]{1,64}" required;
-                    textarea name="text" rows="4" placeholder="First post body…" required {}
-                    p { button type="submit" { "post" } }
+                    })).unwrap()) {
+                        input type="hidden" name=(UI_RPC_FIELD) value=(template_json_compact(&json!({
+                            "action": "post_ingest",
+                            "room": nav.room_wire,
+                            "thread_tag": {"$form": "thread_tag"},
+                            "text": {"$form": "text"},
+                            "error_target": "room-new-thread-errors",
+                            "form_id": "room-new-thread-form",
+                        })).unwrap());
+                        label for="room-new-tag" { "thread tag" }
+                        input type="text" id="room-new-tag" name="thread_tag" pattern="[a-z0-9_\\-]{1,64}" required;
+                        textarea name="text" rows="4" placeholder="First post body…" required {}
+                        p { button type="submit" { "post" } }
+                    }
                 }
-            }
-        } @else {
-            form method="POST" action="/ui" {
-                input type="hidden" name=(UI_RPC_FIELD) value=(rpc_open);
-                button type="submit" class="form-toggle" aria-expanded="false" {
-                    "new thread in this room"
+            } @else {
+                form method="POST" action="/ui" {
+                    input type="hidden" name=(UI_RPC_FIELD) value=(rpc_open);
+                    button type="submit" class="form-toggle" aria-expanded="false" {
+                        "new thread in this room"
+                    }
                 }
             }
         }

--- a/server/src/html/forum.rs
+++ b/server/src/html/forum.rs
@@ -363,6 +363,38 @@ fn room_members_for_room(reduced: &ReducerState, room_id: &str) -> Vec<RoomMembe
     rows
 }
 
+fn room_members_collapsible(members: &[RoomMemberRow]) -> Markup {
+    if members.is_empty() {
+        return html! {};
+    }
+    html! {
+        button
+            type="button"
+            class="form-toggle"
+            data-toggle-target="#room-members-panel"
+            data-open-label="members & permissions"
+            data-close-label="hide members & permissions"
+            aria-expanded="false"
+        {
+            "members & permissions"
+        }
+        section id="room-members-panel" class="room-members-panel" hidden {
+            h3 { "members" }
+            ul class="room-members" {
+                @for member in members {
+                    li {
+                        span class="room-member-name" { "@" (member.username) }
+                        span class="muted" {
+                            " · "
+                            (member.capabilities.join(", "))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// `feed_id` is e.g. `thread-feed` (public bump list, SSE) or `room-thread-feed`.
 fn render_thread_feed(nav: Option<&ThreadNav>, feed_id: &str, rows: &[ThreadRow], now: i64) -> Markup {
     html! {
@@ -914,20 +946,7 @@ pub async fn room_page(
                 "room garden · "
                 a href=(nav.garden_root_url()) { "~" }
             }
-            @if !members.is_empty() {
-                h3 { "members" }
-                ul class="room-members" {
-                    @for member in &members {
-                        li {
-                            span class="room-member-name" { "@" (member.username) }
-                            span class="muted" {
-                                " · "
-                                (member.capabilities.join(", "))
-                            }
-                        }
-                    }
-                }
-            }
+            (room_members_collapsible(&members))
             h3 { "threads" }
             (render_thread_feed(Some(&nav), "room-thread-feed", &rows, now))
             @if show_new {
@@ -937,7 +956,9 @@ pub async fn room_page(
                         button type="submit" class="section-add-btn" { "+" }
                     }
                 }
-                div id="room-new-thread-ui-slot" {}
+                div id="room-new-thread-ui-slot" {
+                    (new_thread_form_for_room(&nav, true))
+                }
             }
             (cli_panel(&forum_cli))
             (cli_panel(&garden_cli))
@@ -960,7 +981,7 @@ fn new_thread_form_for_room(nav: &ThreadNav, show: bool) -> Markup {
             class="form-toggle"
             data-toggle-target="#room-new-thread-compose"
             data-open-label="new thread in this room"
-            data-close-label="hide room thread form"
+            data-close-label="hide new thread form"
             aria-expanded="false"
         {
             "new thread in this room"

--- a/server/src/html/mod.rs
+++ b/server/src/html/mod.rs
@@ -28,8 +28,8 @@ pub use forum::{
 
 pub(crate) use forum::{
     fragment_public_new_thread_form, fragment_room_new_thread_form, login_to_post_hint_markup,
-    thread_ui_collapse_redacted_post, thread_ui_expand_post_full, thread_ui_expand_redacted_post,
-    user_can_post_room, user_can_view_room,
+    room_members_section_markup, thread_ui_collapse_redacted_post, thread_ui_expand_post_full,
+    thread_ui_expand_redacted_post, user_can_post_room, user_can_view_room,
 };
 pub use garden::{garden_index, ontology_path, room_garden_index, room_ontology_path};
 pub use search::{search_page, search_results_fragment};
@@ -110,13 +110,23 @@ pub async fn post_theme(Form(form): Form<ThemeForm>) -> impl IntoResponse {
         .expect("theme redirect response")
 }
 
-// Embed CSS files at compile time
+// Embed CSS and shared UI script at compile time
 const THEME_DEFAULT_CSS: &str = include_str!("../../static/theme_default.css");
 const THEME_RETRO_CSS: &str = include_str!("../../static/theme_retro.css");
 const THEME_RETRO_CRAFT_CSS: &str = include_str!("../../static/theme_retro_craft.css");
+const SLUG_UI_JS: &str = include_str!("../../static/slug_ui.js");
 
-pub async fn serve_theme_css(Path(filename): Path<String>) -> impl IntoResponse {
-    // Extract theme name from filename like "theme_default.css" or "theme_retro.css"
+pub async fn serve_static(Path(filename): Path<String>) -> impl IntoResponse {
+    if filename == "slug_ui.js" {
+        return Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, "text/javascript; charset=utf-8")
+            .header(header::CACHE_CONTROL, "public, max-age=3600")
+            .body(SLUG_UI_JS.to_string())
+            .unwrap()
+            .into_response();
+    }
+
     let theme = filename
         .strip_prefix("theme_")
         .and_then(|s| s.strip_suffix(".css"));
@@ -125,7 +135,7 @@ pub async fn serve_theme_css(Path(filename): Path<String>) -> impl IntoResponse 
         Some("default") => THEME_DEFAULT_CSS,
         Some("retro") => THEME_RETRO_CSS,
         Some("retro_craft") => THEME_RETRO_CRAFT_CSS,
-        _ => return (StatusCode::NOT_FOUND, "theme not found").into_response(),
+        _ => return (StatusCode::NOT_FOUND, "static file not found").into_response(),
     };
 
     Response::builder()
@@ -219,6 +229,15 @@ impl JsBuilder {
         self
     }
 
+    /// Focus first matching element (e.g. after morphing open a compose form).
+    pub(crate) fn focus_selector(mut self, selector: &str) -> Self {
+        self.snippets.push(format!(
+            "var __slugF = document.querySelector({}); if (__slugF && __slugF.focus) {{ __slugF.focus(); }}",
+            js_string_literal(selector),
+        ));
+        self
+    }
+
     pub(crate) fn build(self) -> String {
         self.snippets.join(" ")
     }
@@ -270,21 +289,9 @@ pub(super) fn layout(title: &str, view: &str, body: Markup, views: Option<u64>, 
                 meta charset="utf-8";
                 meta name="viewport" content="width=device-width, initial-scale=1";
                 title { (title) }
-                script { (maud::PreEscaped(r#"
-(function() {
-  try {
-    var ls = localStorage.getItem('slug-theme');
-    if (!ls) return;
-    var m = document.cookie.match(/(?:^|;\s*)slug-theme=([^;]+)/);
-    var c = m ? decodeURIComponent(m[1].replace(/\+/g, ' ')) : '';
-    if (ls === c) { localStorage.removeItem('slug-theme'); return; }
-    document.cookie = 'slug-theme=' + encodeURIComponent(ls) + '; Path=/; SameSite=Lax; Max-Age=31536000';
-    location.reload();
-  } catch (e) {}
-})();
-"#)) }
                 link rel="stylesheet" href=(css_href) id="theme-stylesheet";
                 script src="https://unpkg.com/idiomorph@0.3.0/dist/idiomorph.min.js" {}
+                script src="/static/slug_ui.js" defer {}
             }
             body class=(view) {
                 @if let Some(n) = views {
@@ -311,144 +318,6 @@ pub(super) fn layout(title: &str, view: &str, body: Markup, views: Option<u64>, 
                         }
                     }
                 }
-script { (maud::PreEscaped(r#"
-                    (function() {
-                        // Spread control
-                        const slider = document.getElementById('spread-slider');
-                        const storedSpread = localStorage.getItem('slug-spread');
-
-                        function setSpread(value) {
-                            document.documentElement.style.setProperty('--spread', value);
-                            localStorage.setItem('slug-spread', value);
-                        }
-
-                        if (storedSpread !== null) {
-                            slider.value = storedSpread;
-                            setSpread(parseFloat(storedSpread));
-                        }
-
-                        slider.addEventListener('input', function() {
-                            setSpread(parseFloat(this.value));
-                        });
-
-                        // Intercept POST forms and eval the server's JS response body.
-                        document.addEventListener('submit', async (e) => {
-                            const f = e.target;
-                            if (!f || f.tagName !== 'FORM') return;
-                            if ((f.method || 'get').toLowerCase() !== 'post') return;
-                            if (f.id === 'slug-theme-form') return;
-                            e.preventDefault();
-                            const resp = await fetch(f.action, {
-                                method: 'POST',
-                                body: new URLSearchParams(new FormData(f)),
-                                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                                credentials: 'same-origin',
-                            });
-                            const js = await resp.text();
-                            if (js && js.trim()) {
-                                eval(js);
-                            }
-                        });
-
-                        // Small client-side toggles for compose panes.
-                        document.addEventListener('click', (e) => {
-                            const btn = e.target && e.target.closest && e.target.closest('[data-toggle-target]');
-                            if (!btn) return;
-                            const selector = btn.getAttribute('data-toggle-target');
-                            if (!selector) return;
-                            const target = document.querySelector(selector);
-                            if (!target) return;
-                            const willOpen = target.hasAttribute('hidden');
-                            if (willOpen) {
-                                target.removeAttribute('hidden');
-                            } else {
-                                target.setAttribute('hidden', '');
-                            }
-                            btn.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
-                            const openLabel = btn.getAttribute('data-open-label');
-                            const closeLabel = btn.getAttribute('data-close-label');
-                            if (openLabel && closeLabel) {
-                                btn.textContent = willOpen ? closeLabel : openLabel;
-                            }
-                            if (willOpen) {
-                                const firstField = target.querySelector('input[type="text"], textarea');
-                                if (firstField) firstField.focus();
-                            }
-                        });
-
-                        // Debounced forum form validation.
-                        const checkTimers = new WeakMap();
-                        async function runFormCheck(form) {
-                            const action = form.getAttribute('data-check-action');
-                            if (!action) return;
-                            const fd = new URLSearchParams(new FormData(form));
-                            const checkRpc = form.getAttribute('data-check-rpc');
-                            if (checkRpc) {
-                                fd.set('__rpc__', checkRpc);
-                            }
-                            const resp = await fetch(action, {
-                                method: 'POST',
-                                body: fd,
-                                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                                credentials: 'same-origin',
-                            });
-                            const js = await resp.text();
-                            if (js && js.trim()) {
-                                eval(js);
-                            }
-                        }
-                        document.addEventListener('input', (e) => {
-                            const target = e.target;
-                            if (!target || !target.closest) return;
-                            const form = target.closest('form[data-check-action]');
-                            if (!form) return;
-                            if (!(target.tagName === 'INPUT' || target.tagName === 'TEXTAREA')) return;
-                            const prev = checkTimers.get(form);
-                            if (prev) clearTimeout(prev);
-                            const handle = setTimeout(() => {
-                                runFormCheck(form).catch((err) => console.warn('slug form check failed', err));
-                            }, 250);
-                            checkTimers.set(form, handle);
-                        });
-
-                        // Search: debounced fetch + idiomorph.
-                        (function() {
-                            const si = document.getElementById('search-input');
-                            if (!si) return;
-                            let st;
-                            si.addEventListener('input', () => {
-                                clearTimeout(st);
-                                st = setTimeout(async () => {
-                                    const q = si.value.trim();
-                                    const el = document.getElementById('search-results');
-                                    if (!el) return;
-                                    if (q.length < 2) { el.innerHTML = ''; return; }
-                                    const r = await fetch('/search/results?q=' + encodeURIComponent(q));
-                                    Idiomorph.morph(el, await r.text());
-                                }, 150);
-                            });
-                            // Focus search input on / key
-                            document.addEventListener('keydown', (e) => {
-                                if (e.key === '/' && document.activeElement !== si) {
-                                    e.preventDefault();
-                                    si.focus();
-                                }
-                            });
-                        })();
-
-                        // SSE: evaluate server-pushed JavaScript snippets.
-                        (function connectSSE() {
-                            const ssePath = window.location.pathname + window.location.search;
-                            const es = new EventSource('/sse?path=' + encodeURIComponent(ssePath));
-                            es.onmessage = (e) => {
-                                if (e.data && e.data.trim()) {
-                                    eval(e.data);
-                                }
-                            };
-                            es.onerror = () => { es.close(); setTimeout(connectSSE, 3000); };
-                        })();
-                    })();
-                "#)) }
             }
         }
     }

--- a/server/src/html/mod.rs
+++ b/server/src/html/mod.rs
@@ -183,6 +183,11 @@ impl JsBuilder {
         )
     }
 
+    /// Morph **children** of `selector` so the outer element (e.g. `#room-new-thread-ui-slot`) keeps its `id`.
+    pub(crate) fn morph_inner_selector(self, selector: &str, markup: Markup) -> Self {
+        self.qs(selector).morph_inner(markup)
+    }
+
     pub(crate) fn morph_expr(mut self, expr: &str, markup: Markup, morph_style: Option<&str>) -> Self {
         let html = js_string_literal(&markup.into_string());
         let opts = morph_style
@@ -291,7 +296,6 @@ pub(super) fn layout(title: &str, view: &str, body: Markup, views: Option<u64>, 
                 title { (title) }
                 link rel="stylesheet" href=(css_href) id="theme-stylesheet";
                 script src="https://unpkg.com/idiomorph@0.3.0/dist/idiomorph.min.js" {}
-                script src="/static/slug_ui.js" defer {}
             }
             body class=(view) {
                 @if let Some(n) = views {
@@ -318,6 +322,7 @@ pub(super) fn layout(title: &str, view: &str, body: Markup, views: Option<u64>, 
                         }
                     }
                 }
+                script src="/static/slug_ui.js" {}
             }
         }
     }

--- a/server/src/html/ui_action.rs
+++ b/server/src/html/ui_action.rs
@@ -44,6 +44,18 @@ pub enum HtmlUiAction {
     ExpandRoomNewThreadForm {
         room_wire: String,
     },
+    /// Morph `#room-members-section` — members list open or collapsed (server-rendered).
+    SetRoomMembersExpanded {
+        room_wire: String,
+        #[serde(default)]
+        expanded: bool,
+    },
+    /// Morph `#room-new-thread-ui-slot` — compose body open or collapsed (server-rendered).
+    SetRoomNewThreadComposeExpanded {
+        room_wire: String,
+        #[serde(default)]
+        expanded: bool,
+    },
     /// Replace a truncated post card with the full body (same thread index).
     ExpandPostFull {
         room: String,
@@ -152,6 +164,49 @@ mod tests {
                 room: "public".into(),
                 thread_tag: "demo".into(),
                 post_index: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn set_room_members_expanded_defaults_false() {
+        let template = serde_json::json!({
+            "action": "set_room_members_expanded",
+            "room_wire": "ab/cd",
+        });
+        let mut form = HashMap::new();
+        form.insert(
+            UI_RPC_FIELD.to_string(),
+            serde_json::to_string(&template).unwrap(),
+        );
+        let a = parse_html_ui_from_form(&form).unwrap();
+        assert_eq!(
+            a,
+            HtmlUiAction::SetRoomMembersExpanded {
+                room_wire: "ab/cd".into(),
+                expanded: false,
+            }
+        );
+    }
+
+    #[test]
+    fn set_room_new_thread_compose_expanded_true() {
+        let template = serde_json::json!({
+            "action": "set_room_new_thread_compose_expanded",
+            "room_wire": "ab/cd",
+            "expanded": true,
+        });
+        let mut form = HashMap::new();
+        form.insert(
+            UI_RPC_FIELD.to_string(),
+            serde_json::to_string(&template).unwrap(),
+        );
+        let a = parse_html_ui_from_form(&form).unwrap();
+        assert_eq!(
+            a,
+            HtmlUiAction::SetRoomNewThreadComposeExpanded {
+                room_wire: "ab/cd".into(),
+                expanded: true,
             }
         );
     }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -27,7 +27,7 @@ pub use reducer::ReducerState;
 pub fn create_app(state: AppState) -> Router {
     Router::new()
         .route("/healthz", get(|| async { "ok" }))
-        .route("/static/:filename", get(crate::html::serve_theme_css))
+        .route("/static/:filename", get(crate::html::serve_static))
         .route("/", get(crate::html::home))
         .route("/login", get(api::get_web_login))
         .route("/logout", get(api::get_logout))

--- a/server/static/slug_ui.js
+++ b/server/static/slug_ui.js
@@ -1,0 +1,171 @@
+/**
+ * Slug web UI: only plumbing — fetch/eval/SSE. No product UI logic here.
+ */
+(function () {
+  function evalJs(js) {
+    if (js && String(js).trim()) {
+      eval(js);
+    }
+  }
+
+  // Theme cookie sync (runs before paint; full reload if localStorage disagrees with cookie)
+  try {
+    var ls = localStorage.getItem('slug-theme');
+    if (ls) {
+      var m = document.cookie.match(/(?:^|;\s*)slug-theme=([^;]+)/);
+      var c = m ? decodeURIComponent(m[1].replace(/\+/g, ' ')) : '';
+      if (ls === c) {
+        localStorage.removeItem('slug-theme');
+      } else {
+        document.cookie =
+          'slug-theme=' + encodeURIComponent(ls) + '; Path=/; SameSite=Lax; Max-Age=31536000';
+        location.reload();
+      }
+    }
+  } catch (e) {}
+
+  function initSlugUi() {
+    // Spread control (client-only preference; not routed through /ui)
+    var slider = document.getElementById('spread-slider');
+    if (slider) {
+      var storedSpread = localStorage.getItem('slug-spread');
+      function setSpread(value) {
+        document.documentElement.style.setProperty('--spread', value);
+        localStorage.setItem('slug-spread', value);
+      }
+      if (storedSpread !== null) {
+        slider.value = storedSpread;
+        setSpread(parseFloat(storedSpread));
+      }
+      slider.addEventListener('input', function () {
+        setSpread(parseFloat(this.value));
+      });
+    }
+
+    // POST forms → eval response (except theme)
+    document.addEventListener('submit', async function (e) {
+      var f = e.target;
+      if (!f || f.tagName !== 'FORM') return;
+      if ((f.method || 'get').toLowerCase() !== 'post') return;
+      if (f.id === 'slug-theme-form') return;
+      e.preventDefault();
+      var resp = await fetch(f.action, {
+        method: 'POST',
+        body: new URLSearchParams(new FormData(f)),
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        credentials: 'same-origin',
+      });
+      evalJs(await resp.text());
+    });
+
+    // Debounced DSL check: POST /ui or data-check-action, eval body
+    var checkTimers = new WeakMap();
+    async function runFormCheck(form) {
+      var action = form.getAttribute('data-check-action');
+      if (!action) return;
+      var fd = new URLSearchParams(new FormData(form));
+      var checkRpc = form.getAttribute('data-check-rpc');
+      if (checkRpc) fd.set('__rpc__', checkRpc);
+      var resp = await fetch(action, {
+        method: 'POST',
+        body: fd,
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        credentials: 'same-origin',
+      });
+      evalJs(await resp.text());
+    }
+    document.addEventListener('input', function (e) {
+      var target = e.target;
+      if (!target || !target.closest) return;
+      var form = target.closest('form[data-check-action]');
+      if (!form) return;
+      if (!(target.tagName === 'INPUT' || target.tagName === 'TEXTAREA')) return;
+      var prev = checkTimers.get(form);
+      if (prev) clearTimeout(prev);
+      var handle = setTimeout(function () {
+        runFormCheck(form).catch(function (err) {
+          console.warn('slug form check failed', err);
+        });
+      }, 250);
+      checkTimers.set(form, handle);
+    });
+
+    // Search: debounced GET fragment → Idiomorph (HTML only; not JS)
+    var si = document.getElementById('search-input');
+    if (si) {
+      var st;
+      si.addEventListener('input', function () {
+        clearTimeout(st);
+        st = setTimeout(async function () {
+          var q = si.value.trim();
+          var el = document.getElementById('search-results');
+          if (!el) return;
+          if (q.length < 2) {
+            el.innerHTML = '';
+            return;
+          }
+          var r = await fetch('/search/results?q=' + encodeURIComponent(q));
+          Idiomorph.morph(el, await r.text());
+        }, 150);
+      });
+      document.addEventListener('keydown', function (e) {
+        if (e.key === '/' && document.activeElement !== si) {
+          e.preventDefault();
+          si.focus();
+        }
+      });
+    }
+
+    // Editor page: debounced POST /try/check → eval
+    var ta = document.getElementById('editor-input');
+    if (ta) {
+      var status = document.getElementById('editor-status');
+      var timer;
+      ta.addEventListener('input', function () {
+        clearTimeout(timer);
+        if (status) status.textContent = 'checking…';
+        timer = setTimeout(function () {
+          var text = ta.value.trim();
+          if (text.length < 3) {
+            if (status) status.textContent = 'type to check…';
+            var er = document.getElementById('editor-results');
+            if (er) er.innerHTML = '';
+            return;
+          }
+          fetch('/try/check', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: 'text=' + encodeURIComponent(text),
+          })
+            .then(function (r) {
+              return r.text();
+            })
+            .then(evalJs)
+            .catch(function (e) {
+              if (status) status.textContent = 'error: ' + e;
+            });
+        }, 400);
+      });
+    }
+
+    // SSE: server-pushed JS
+    function connectSSE() {
+      var ssePath = window.location.pathname + window.location.search;
+      var es = new EventSource('/sse?path=' + encodeURIComponent(ssePath));
+      es.onmessage = function (e) {
+        evalJs(e.data);
+      };
+      es.onerror = function () {
+        es.close();
+        setTimeout(connectSSE, 3000);
+      };
+    }
+    connectSSE();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initSlugUi);
+  } else {
+    initSlugUi();
+  }
+})();

--- a/server/static/theme_default.css
+++ b/server/static/theme_default.css
@@ -256,6 +256,12 @@ section.compose textarea:focus {
 .room-members {
   margin-bottom: 10px;
 }
+.room-members-panel {
+  margin-bottom: 10px;
+}
+.room-members-panel h3 {
+  margin-top: 0;
+}
 .room-member-name {
   color: var(--signal);
   font-family: monospace;

--- a/test/browser_sse.clj
+++ b/test/browser_sse.clj
@@ -84,6 +84,13 @@
                    (let [[room-short room-slug] (str/split room-id #"/" 2)
                          room-url (str base-url "/r/" room-short "/" room-slug)]
                     (page/navigate alice-pg room-url)
+                    ;; Room new-thread compose is collapsed until POST /ui expands it (slug_ui.js must be loaded).
+                    (assert! (wait-for-text alice-pg "#room-new-thread-ui-slot"
+                                           "new thread in this room" 15000)
+                             "alice sees collapsed new-thread toggle")
+                    (locator/click (page/locator alice-pg "#room-new-thread-ui-slot button.form-toggle"))
+                    (assert! (wait-for-text alice-pg "#room-new-thread-ui-slot" "hide new thread form" 15000)
+                             "alice expands new thread compose via POST /ui")
                     (locator/fill (page/locator alice-pg "#room-new-tag") "sse-thread")
                     (locator/fill (page/locator alice-pg "#room-new-thread-compose textarea") "seed thread")
                     (locator/click (page/locator alice-pg "#room-new-thread-compose button[type='submit']"))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Private room pages show members (same grant data as CLI `audit`). Expand/collapse for **members & permissions** and **new thread compose** goes through **`POST /ui`** only: each toggle submits `__rpc__` as [`HtmlUiAction`](server/src/html/ui_action.rs) variants, and the response is **JsBuilder** that morphs the DOM (no client-side `hidden` toggling).

New-thread **slot** morphs use **`morph_inner_selector`** so `#public-new-thread-ui-slot` / `#room-new-thread-ui-slot` keep their `id` after Idiomorph updates (required for stable selectors and follow-up forms).

Client plumbing lives in [`server/static/slug_ui.js`](server/static/slug_ui.js), loaded at the **end of `<body>`** so the DOM exists when listeners attach.

## Testing

- `cargo test` in `server/`
- `bash scripts/clj-test.sh` (Clojure integration + Playwright: `browser-sse`, `browser-post-redact`, `browser-ui-morph`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c94004d-b02d-493e-84ff-6baff3127331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c94004d-b02d-493e-84ff-6baff3127331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

