### PR TITLE
Craft theme: full-width thread reply on mobile

### DIFF
--- a/server/static/theme_retro_craft.css
+++ b/server/static/theme_retro_craft.css
@@ -454,3 +454,31 @@ body.view-ontology #controls {
   border-bottom: none;
   border-top: none;
 }
+
+/* Thread reply: drop the compose panel on small screens; textarea spans the viewport */
+@media (max-width: 600px) {
+  section#thread-compose {
+    border: none;
+    margin-left: -1.25rem;
+    margin-right: -1.25rem;
+    margin-top: 1.25rem;
+    max-width: none;
+    padding: 0 0 0.75rem;
+    width: auto;
+  }
+  section#thread-compose textarea {
+    border-radius: 0;
+    border-left: none;
+    border-right: none;
+    box-sizing: border-box;
+    display: block;
+    margin: 0;
+    max-width: none;
+    width: 100%;
+  }
+  section#thread-compose #thread-compose-errors,
+  section#thread-compose form > p {
+    padding-left: 1.25rem;
+    padding-right: 1.25rem;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On viewports ≤600px, the Craft theme thread reply block (`#thread-compose`) no longer uses the bordered compose panel. The textarea stretches edge-to-edge across the screen (canceling the body’s horizontal padding via negative margins). The post button and error area keep the normal content inset so they stay aligned with the rest of the page.

## Files

- `server/static/theme_retro_craft.css` — mobile media query for `#thread-compose` only; other themes unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9be26562-d793-4afb-8f22-92e159ae45f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9be26562-d793-4afb-8f22-92e159ae45f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

