### PR TITLE
Serialize durable writes through a writer actor

### DIFF
--- a/server/src/api/auth.rs
+++ b/server/src/api/auth.rs
@@ -10,11 +10,11 @@ use base64::Engine;
 use serde::Deserialize;
 use slug_types::{PendingSessionPollResponse, PendingSessionStartRequest, PendingSessionStartResponse, WhoamiResponse};
 use std::{collections::HashMap, sync::Arc};
-use tokio::sync::RwLock;
+use tokio::sync::{oneshot, RwLock};
 
 use crate::{
     api::helpers::{api_error, now_ms, sha256_hex},
-    events::{Event, GrantAdded, TokenIssued, UserRegistered},
+    events::{Event, TokenIssued},
     html::{
         auth_complete_page, auth_signed_in_fragment, choose_username_error_fragment,
         choose_username_page, theme_cookie_header_from_jar, theme_from_jar, theme_next_from_uri, JsBuilder,
@@ -22,6 +22,7 @@ use crate::{
     identity::{parse_agent, parse_username},
     reducer::ReducerState,
     state::{AppState, PendingSession},
+    write_cmd::WriteCmd,
 };
 
 /// Delegate id for browser users who land via `/join/inv_…` (no CLI agent).
@@ -103,52 +104,6 @@ fn redirect_with_session_cookie(public_url: &str, path_and_query: &str, bearer: 
     res
 }
 
-async fn apply_invite_redemption(state: &AppState, invite_token: &str, grantee_username: &str) -> Result<(), String> {
-    let now = now_ms();
-    let ga = {
-        let mut invites = state.invites.write().await;
-        let Some(inv) = invites.get_mut(invite_token) else {
-            return Err("invite not found".into());
-        };
-        if now > inv.expires_at_ms {
-            invites.remove(invite_token);
-            return Err("invite expired".into());
-        }
-        if inv.current_uses >= inv.max_uses {
-            return Err("invite exhausted".into());
-        }
-        inv.current_uses += 1;
-        Event::GrantAdded(GrantAdded {
-            ts: now,
-            room_id: inv.room_id.clone(),
-            username: grantee_username.to_string(),
-            capabilities: inv.capabilities.clone(),
-            granted_by: inv.inviter.clone(),
-        })
-    };
-
-    match state.event_log.append(&ga).await {
-        Ok(()) => {
-            let mut reduced = state.reduced.write().await;
-            reduced.apply_event(ga);
-            let mut invites = state.invites.write().await;
-            if let Some(inv) = invites.get(invite_token) {
-                if inv.current_uses >= inv.max_uses {
-                    invites.remove(invite_token);
-                }
-            }
-            Ok(())
-        }
-        Err(e) => {
-            let mut invites = state.invites.write().await;
-            if let Some(inv) = invites.get_mut(invite_token) {
-                inv.current_uses = inv.current_uses.saturating_sub(1);
-            }
-            Err(format!("{e}"))
-        }
-    }
-}
-
 fn pending_sessions(state: &AppState) -> Arc<RwLock<HashMap<String, PendingSession>>> {
     state.pending_sessions.clone()
 }
@@ -162,7 +117,7 @@ fn extract_jwt_sub(jwt: &str) -> Option<String> {
     v.get("sub")?.as_str().map(|s| s.to_string())
 }
 
-fn parse_bearer(headers: &HeaderMap) -> Result<String, (StatusCode, String)> {
+pub(crate) fn parse_bearer(headers: &HeaderMap) -> Result<String, (StatusCode, String)> {
     let Some(value) = headers.get(axum::http::header::AUTHORIZATION) else {
         return Err((StatusCode::UNAUTHORIZED, "missing Authorization header".to_string()));
     };
@@ -185,7 +140,7 @@ pub fn verify_bearer_principal(
     verify_token(reduced, &bearer)
 }
 
-fn verify_token(reduced: &crate::reducer::ReducerState, bearer: &str) -> Result<String, (StatusCode, String)> {
+pub(crate) fn verify_token(reduced: &crate::reducer::ReducerState, bearer: &str) -> Result<String, (StatusCode, String)> {
     // slug_<token_id>_<secret>
     let Some(rest) = bearer.strip_prefix("slug_") else {
         return Err((StatusCode::UNAUTHORIZED, "invalid token format".to_string()));
@@ -207,7 +162,7 @@ fn verify_token(reduced: &crate::reducer::ReducerState, bearer: &str) -> Result<
 }
 
 /// `stored_username` must already be in persisted shape (lowercase slug, no `@`).
-fn issue_token_for_user(stored_username: &str) -> (String, TokenIssued) {
+pub(crate) fn issue_token_for_user(stored_username: &str) -> (String, TokenIssued) {
     let username = stored_username.to_string();
     let token_id = {
         let mut id = String::new();
@@ -378,19 +333,29 @@ pub async fn get_auth_callback(
         if let Some(username) = existing {
             let invite_tok = s.redeem_invite.clone();
             let (bearer, token_event) = issue_token_for_user(&username);
-            // append token event
             let ev = Event::TokenIssued(token_event);
-            if let Err(err) = state.event_log.append(&ev).await {
-                return api_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to persist token", Some(format!("{err}"))).into_response();
-            }
+            let (tx, rx) = oneshot::channel();
+            if state
+                .write_tx
+                .send(WriteCmd::OAuthTokenIssue {
+                    token_event: ev,
+                    redeem_invite: invite_tok,
+                    reply: tx,
+                })
+                .await
+                .is_err()
             {
-                let mut reduced = reduced_arc.write().await;
-                reduced.apply_event(ev);
+                return api_error(StatusCode::INTERNAL_SERVER_ERROR, "writer unavailable", None).into_response();
             }
-            if let Some(tok) = invite_tok {
-                if let Err(e) = apply_invite_redemption(&state, &tok, &username).await {
-                    tracing::warn!(error = %e, "invite redemption skipped after oauth");
+            match rx.await {
+                Err(_) => {
+                    return api_error(StatusCode::INTERNAL_SERVER_ERROR, "writer dropped", None).into_response();
                 }
+                Ok(Err(err)) => {
+                    return api_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to persist token", Some(err))
+                        .into_response();
+                }
+                Ok(Ok(())) => {}
             }
             let cookie_bearer = bearer.clone();
             s.complete = Some((username, bearer));
@@ -471,42 +436,37 @@ pub async fn post_choose_username(
     }
     drop(reduced);
 
-    let ur = Event::UserRegistered(UserRegistered {
-        ts: now_ms(),
-        username: canon_user.clone(),
-        provider: provider.to_lowercase(),
-        provider_id: provider_id.clone(),
-    });
-
-    let (bearer, ti) = issue_token_for_user(&canon_user);
-    let ti_ev = Event::TokenIssued(ti);
-
-    // Persist events.
-    if let Err(err) = state.event_log.append(&ur).await {
-        return api_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to persist user", Some(format!("{err}"))).into_response();
-    }
-    if let Err(err) = state.event_log.append(&ti_ev).await {
-        return api_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to persist token", Some(format!("{err}"))).into_response();
-    }
-
-    // Apply to reducer.
-    {
-        let mut reduced = reduced_arc.write().await;
-        reduced.apply_event(ur.clone());
-        reduced.apply_event(ti_ev.clone());
-    }
-
-    // Redeem invite (if any) before marking the session complete.
-    if let Some(tok) = {
+    let redeem_invite = {
         let sessions_read = sessions.read().await;
         sessions_read.get(&form.session).and_then(|s| s.redeem_invite.clone())
-    } {
-        if let Err(e) = apply_invite_redemption(&state, &tok, &canon_user).await {
-            tracing::warn!(error = %e, "invite redemption skipped after registration");
-        }
+    };
+
+    let (tx, rx) = oneshot::channel();
+    if state
+        .write_tx
+        .send(WriteCmd::Register {
+            username: canon_user.clone(),
+            provider,
+            provider_id,
+            redeem_invite,
+            reply: tx,
+        })
+        .await
+        .is_err()
+    {
+        return api_error(StatusCode::INTERNAL_SERVER_ERROR, "writer unavailable", None).into_response();
     }
 
-    // Mark complete for polling.
+    let bearer = match rx.await {
+        Err(_) => {
+            return api_error(StatusCode::INTERNAL_SERVER_ERROR, "writer dropped", None).into_response();
+        }
+        Ok(Err(msg)) => {
+            return js_form_error_fragment(&form.session, &msg).into_response();
+        }
+        Ok(Ok(b)) => b,
+    };
+
     {
         let mut sessions_write = sessions.write().await;
         let s = sessions_write.get_mut(&form.session).expect("session checked above");

--- a/server/src/api/auth.rs
+++ b/server/src/api/auth.rs
@@ -423,19 +423,6 @@ pub async fn post_choose_username(
         return js_form_error_fragment(&form.session, &format!("invalid agent format — {msg}")).into_response();
     }
 
-    let reduced_arc = state.reduced.clone();
-    let reduced = reduced_arc.read().await;
-    let provider_key = (provider.to_lowercase(), provider_id.clone());
-    if reduced.users_by_provider.contains_key(&provider_key) {
-        return js_form_error_fragment(&form.session, "provider already registered").into_response();
-    }
-    if reduced.users_by_provider.values().any(|u| u == &canon_user) {
-        drop(reduced);
-        return js_form_error_fragment(&form.session, "that username is taken — try another")
-            .into_response();
-    }
-    drop(reduced);
-
     let redeem_invite = {
         let sessions_read = sessions.read().await;
         sessions_read.get(&form.session).and_then(|s| s.redeem_invite.clone())

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -4,6 +4,7 @@ mod rpc;
 mod stream;
 mod validate;
 mod ui_html;
+pub(crate) mod write_actor;
 
 pub use auth::{
     get_join_invite,

--- a/server/src/api/rpc.rs
+++ b/server/src/api/rpc.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::sync::OnceLock;
 
 use axum::{
@@ -7,6 +7,7 @@ use axum::{
     response::IntoResponse,
     Json,
 };
+use tokio::sync::oneshot;
 use rand::seq::SliceRandom;
 use slug_types::paths::{ForumThreadUrl, GardenItemUrl, TildeOntologyPath};
 use slug_types::*;
@@ -14,19 +15,16 @@ use slug_types::*;
 use crate::{
     canonical_path::{canonicalize_item, canonicalize_tag},
     dsl,
-    events::{
-        AgentBound, Event, GrantAdded, GrantRevoked, Ingest, PostRedacted, RoomCreated,
-        ThreadCapability,
-    },
-    html::JsBuilder,
+    events::{Event, Ingest, ThreadCapability},
     identity::{parse_agent, parse_username},
     path_types::CanonicalItemUrl,
     ranking::{connected_components_from_voted_pairs, ranked_items_subset},
     reducer::{scope_from_room_wire, ReducerState, ScopeId},
     state::{AppState, InviteState},
+    write_cmd::WriteCmd,
 };
 
-use super::auth::verify_bearer_principal;
+use super::auth::{parse_bearer, verify_bearer_principal};
 use super::helpers::{
     compute_connectivity_stats, is_pair_voted, now_ms, paginate_rankings, parse_parent_specs,
     pick_random_distinct_canonical, resolve_item, vote_touches_path,
@@ -41,42 +39,6 @@ fn empty_content() -> &'static crate::reducer::ContentState {
 fn content_for_room<'a>(reduced: &'a ReducerState, room: &str) -> &'a crate::reducer::ContentState {
     let scope = scope_from_room_wire(room);
     reduced.content.get(&scope).unwrap_or(empty_content())
-}
-
-async fn broadcast_web_refresh(state: &AppState, room_key: &str, thread_id: &str) {
-    let feed_id = if room_key == "public" { "thread-feed" } else { "room-thread-feed" };
-    let thread_url = if room_key == "public" {
-        format!("/t/{thread_id}")
-    } else if let Some((short, slug)) = room_key.split_once('/') {
-        format!("/r/{short}/{slug}/t/{thread_id}")
-    } else {
-        format!("/t/{thread_id}")
-    };
-
-    let feed_markup = if room_key == "public" {
-        crate::html::thread_feed_html(state).await
-    } else {
-        crate::html::thread_feed_html_for_room(state, room_key).await
-    };
-
-    let thread_feed_markup =
-        crate::html::thread_feed_region_markup(state, Some(room_key), thread_id, None).await;
-
-    let builder = JsBuilder::new().morph_selector(&format!("#{feed_id}"), feed_markup);
-    let builder = builder.qs("#new-thread-compose form").reset();
-    let builder = builder.if_current_path_matches(&thread_url, |builder| {
-        builder.morph_selector("#thread-feed-region", thread_feed_markup)
-    });
-    let js = builder.build();
-    let mut path_prefixes = vec![if room_key == "public" {
-        "/".to_string()
-    } else if let Some((short, slug)) = room_key.split_once('/') {
-        format!("/r/{short}/{slug}")
-    } else {
-        "/".to_string()
-    }];
-    path_prefixes.push(thread_url.clone());
-    let _ = state.js_tx.send(crate::state::JsSnippet { code: js, path_prefixes });
 }
 
 type RpcErr = (String, Option<String>);
@@ -141,69 +103,6 @@ fn authorize_room_read(reduced: &ReducerState, headers: &HeaderMap, room: &str) 
     Ok(Some(principal))
 }
 
-fn compute_scope_rank_changes(
-    parent: &CanonicalItemUrl,
-    before: &crate::scope_rank::ChildrenRankings,
-    after: &crate::scope_rank::ChildrenRankings,
-    room_wire: &str,
-) -> Option<ScopeRankChanges> {
-    fn build_positions(rankings: &crate::scope_rank::ChildrenRankings) -> HashMap<CanonicalItemUrl, Option<RankPosition>> {
-        let mut map = HashMap::new();
-        for comp in &rankings.component_rankings {
-            let total = comp.ranked.len();
-            for (i, item) in comp.ranked.iter().enumerate() {
-                map.insert(item.item.clone(), Some(RankPosition { rank: i + 1, of: total }));
-            }
-        }
-        for item in &rankings.unranked_items {
-            map.insert(item.clone(), None);
-        }
-        map
-    }
-
-    let before_pos = build_positions(before);
-    let after_pos = build_positions(after);
-
-    let all_items: std::collections::BTreeSet<CanonicalItemUrl> = before_pos.keys().cloned()
-        .chain(after_pos.keys().cloned())
-        .collect();
-
-    let mut changes: Vec<RankChange> = Vec::new();
-    for item in all_items {
-        let b = before_pos.get(&item).cloned().flatten();
-        let a = after_pos.get(&item).cloned().flatten();
-        let changed = match (&b, &a) {
-            (Some(bp), Some(ap)) => bp.rank != ap.rank || bp.of != ap.of,
-            (None, Some(_)) => true,
-            (Some(_), None) => true,
-            (None, None) => false,
-        };
-        if changed {
-            changes.push(RankChange {
-                item: GardenItemUrl::from_stored(&item, room_wire),
-                before: b,
-                after: a,
-            });
-        }
-    }
-
-    if changes.is_empty() {
-        return None;
-    }
-
-    changes.sort_by(|a, b| match (&a.after, &b.after) {
-        (Some(ap), Some(bp)) => ap.rank.cmp(&bp.rank),
-        (Some(_), None) => std::cmp::Ordering::Less,
-        (None, Some(_)) => std::cmp::Ordering::Greater,
-        (None, None) => a.item.cmp(&b.item),
-    });
-
-    Some(ScopeRankChanges {
-        parent: GardenItemUrl::from_stored(parent, room_wire).into_inner(),
-        changes,
-    })
-}
-
 fn parse_capability(s: &str) -> Result<ThreadCapability, String> {
     match s {
         "view" => Ok(ThreadCapability::View),
@@ -213,13 +112,6 @@ fn parse_capability(s: &str) -> Result<ThreadCapability, String> {
         "manage" => Ok(ThreadCapability::Manage),
         other => Err(format!("unknown capability: {other}")),
     }
-}
-
-fn gen_short_id() -> String {
-    use rand::Rng;
-    const ALPHABET: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyz";
-    let mut rng = rand::thread_rng();
-    (0..7).map(|_| ALPHABET[rng.gen_range(0..ALPHABET.len())] as char).collect()
 }
 
 fn gen_invite_token() -> String {
@@ -330,48 +222,19 @@ pub async fn rpc_post_redact(
     headers: &HeaderMap,
     post_id: String,
 ) -> Result<RpcResult, RpcErr> {
-    let reduced_arc = state.reduced.clone();
-    let reduced = reduced_arc.read().await;
-    let principal = verify_bearer_principal(headers, &reduced).map_err(|(_, m)| (m, None))?;
-    let post_id = post_id.trim().to_string();
-    let Some(ing) = reduced.ingests_by_id.get(&post_id).cloned() else {
-        drop(reduced);
-        return Err(("post not found".into(), None));
-    };
-    if ing.principal != principal {
-        drop(reduced);
-        return Err(("not your post".into(), None));
-    }
-    if reduced.redacted_posts.contains(&post_id) {
-        drop(reduced);
-        return Err(("already redacted".into(), None));
-    }
-    let room_key = ing.room_id.trim().to_string();
-    let scope = scope_from_room_wire(&room_key);
-    if matches!(scope, ScopeId::Room(_))
-        && (!reduced.rooms.contains(&room_key)
-            || !reduced.user_has_cap(&room_key, &principal, ThreadCapability::View))
-    {
-        drop(reduced);
-        return Err(("room not found".into(), None));
-    }
-    drop(reduced);
-
-    let ev = Event::PostRedacted(PostRedacted {
-        ts: now_ms(),
-        post_id: post_id.clone(),
-        principal: principal.clone(),
-    });
-    if let Err(err) = state.event_log.append(&ev).await {
-        return Err((format!("{err}"), None));
-    }
-    {
-        let mut reduced = reduced_arc.write().await;
-        reduced.apply_event(ev);
-    }
-    let thread_tag = canonicalize_tag(&ing.thread_tag);
-    broadcast_web_refresh(state, &room_key, &thread_tag).await;
-    Ok(RpcResult::RedactPostOk {})
+    let bearer = parse_bearer(headers).map_err(|(_, m)| (m, None))?;
+    let (tx, rx) = oneshot::channel();
+    state
+        .write_tx
+        .send(WriteCmd::Redact {
+            post_id: post_id.trim().to_string(),
+            bearer,
+            reply: tx,
+        })
+        .await
+        .map_err(|_| ("writer unavailable".into(), None))?;
+    rx.await
+        .map_err(|_| ("writer dropped".into(), None))?
 }
 
 async fn rpc_post(
@@ -391,10 +254,10 @@ async fn rpc_post(
     let delegate: Option<String> = match delegate_opt {
         None => None,
         Some(ref s) if s.trim().is_empty() => None,
-        Some(s) => Some(parse_agent(&s).map_err(|msg| (format!("invalid delegate format"), Some(msg)))?),
+        Some(ref s) => Some(parse_agent(s).map_err(|msg| (format!("invalid delegate format"), Some(msg)))?),
     };
 
-    let (room_key, thread_id) = normalize_room_and_thread(&room, &thread_tag);
+    let (room_key, _thread_id) = normalize_room_and_thread(&room, &thread_tag);
     let scope = scope_from_room_wire(&room_key);
 
     let is_private = !matches!(scope, ScopeId::Public);
@@ -436,119 +299,25 @@ async fn rpc_post(
             _ => {}
         }
     }
-    let need_agent_bind = delegate
-        .as_ref()
-        .map(|d| reduced.agent_bindings.get(d).is_none())
-        .unwrap_or(false);
     drop(reduced);
 
-    let mut events_appended: usize = 0;
-
-    if need_agent_bind {
-        if let Some(agent_id) = delegate.clone() {
-            let ab = Event::AgentBound(AgentBound {
-                ts: now_ms(),
-                agent: agent_id,
-                username: principal.clone(),
-            });
-            if let Err(err) = state.event_log.append(&ab).await {
-                return Err((format!("{err}"), None));
-            }
-            events_appended += 1;
-            let mut reduced = reduced_arc.write().await;
-            reduced.apply_event(ab);
-        }
-    }
-
-    let voted_parent_scopes: Vec<CanonicalItemUrl> = {
-        let mut parents: HashSet<CanonicalItemUrl> = HashSet::new();
-        for s in &v.doc.statements {
-            if let dsl::Stmt::Vote { item1, item2, .. } = s {
-                if let (Ok(a), Ok(b)) = (resolve_item(item1), resolve_item(item2)) {
-                    if let Some(p) = a.parent() { parents.insert(p); }
-                    if let Some(p) = b.parent() { parents.insert(p); }
-                }
-            }
-        }
-        let mut out: Vec<CanonicalItemUrl> = parents.into_iter().collect();
-        out.sort();
-        out
-    };
-
-    let pre_rankings: HashMap<CanonicalItemUrl, crate::scope_rank::ChildrenRankings> =
-        if !voted_parent_scopes.is_empty() {
-            let reduced = reduced_arc.read().await;
-            let content = content_for_room(&reduced, &room_key);
-            voted_parent_scopes
-                .iter()
-                .map(|p| (p.clone(), crate::scope_rank::build_children_rankings(content, p)))
-                .collect()
-        } else {
-            HashMap::new()
-        };
-
-    let ingest_event = Event::Ingest(Ingest {
-        ts: v.ts,
-        id: uuid::Uuid::new_v4().to_string(),
-        raw: v.raw_text.clone(),
-        principal: principal.clone(),
-        delegate: delegate.clone(),
-        room_id: room_key.clone(),
-        thread_tag: thread_id.clone(),
-    });
-
-    if let Err(err) = state.event_log.append(&ingest_event).await {
-        return Err((format!("{err}"), None));
-    }
-    events_appended += 1;
-
-    {
-        let mut reduced = reduced_arc.write().await;
-        reduced.apply_event(ingest_event);
-    }
-
-    broadcast_web_refresh(state, &room_key, &thread_id).await;
-
-    let ranking_changes: Option<Vec<ScopeRankChanges>> = if return_rank_diff && !voted_parent_scopes.is_empty() {
-        let reduced = reduced_arc.read().await;
-        let content = content_for_room(&reduced, &room_key);
-        let v: Vec<ScopeRankChanges> = voted_parent_scopes
-            .iter()
-            .filter_map(|p| {
-                let before = pre_rankings.get(p)?;
-                let after = crate::scope_rank::build_children_rankings(content, p);
-                compute_scope_rank_changes(p, before, &after, &room_key)
-            })
-            .collect();
-        if v.is_empty() { None } else { Some(v) }
-    } else {
-        None
-    };
-
-    let (pair_hint, rank_hint, web_url) = if room_key == "public" {
-        (
-            "npx slugsocial public garden pair".to_string(),
-            "npx slugsocial public garden rank".to_string(),
-            ForumThreadUrl::from_room_tag("public", &thread_id),
-        )
-    } else {
-        (
-            format!("npx slugsocial private {room_key} garden pair"),
-            format!("npx slugsocial private {room_key} garden rank"),
-            ForumThreadUrl::from_room_tag(&room_key, &thread_id),
-        )
-    };
-
-    Ok(RpcResult::PostOk {
-        events_appended,
-        ranking_changes,
-        threads: vec![format!("#{}", thread_id)],
-        next: NextMoves {
-            pair: pair_hint,
-            rank: rank_hint,
-            web: web_url,
-        },
-    })
+    let bearer = parse_bearer(headers).map_err(|(_, m)| (m, None))?;
+    let (tx, rx) = oneshot::channel();
+    state
+        .write_tx
+        .send(WriteCmd::Post {
+            room,
+            thread_tag,
+            delegate_opt,
+            text,
+            return_rank_diff,
+            bearer,
+            reply: tx,
+        })
+        .await
+        .map_err(|_| ("writer unavailable".into(), None))?;
+    rx.await
+        .map_err(|_| ("writer dropped".into(), None))?
 }
 
 /// Post forum content using a raw bearer token (CLI `Authorization` header or browser session cookie).
@@ -1209,58 +978,31 @@ pub async fn handle_rpc_batch(
                 }
             }
             RpcCommand::RoomCreate { slug } => {
-                // Scope the first read so its guard drops before any nested `read().await` / `write().await`.
-                // A guard from `match verify(..., &*state.reduced.read().await)` would otherwise live for the
-                // whole `match` and deadlock here (tokio::sync::RwLock is not reentrant).
-                let principal = {
-                    let reduced = state.reduced.read().await;
-                    verify_bearer_principal(&headers, &*reduced)
-                };
-                match principal {
+                match parse_bearer(&headers) {
                     Err((_, m)) => line_err(m, None),
-                    Ok(principal) => {
+                    Ok(bearer) => {
                         let slug = slug.trim().to_lowercase();
                         if slug.is_empty() || slug.len() > 64 {
                             line_err("slug must be 1-64 characters", None)
                         } else if !slug.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
                             line_err("slug must be lowercase alphanumeric with hyphens", None)
                         } else {
-                            let short_id = loop {
-                                let id = gen_short_id();
-                                if !state.reduced.read().await.rooms.contains(&format!("{id}/{slug}")) {
-                                    break id;
-                                }
-                            };
-                            let room_id = format!("{short_id}/{slug}");
-                            let ts = now_ms();
-                            let tc_ev = Event::RoomCreated(RoomCreated {
-                                ts,
-                                room_id: room_id.clone(),
-                                slug: slug.clone(),
-                                owner: principal.clone(),
-                            });
-                            let ga_ev = Event::GrantAdded(GrantAdded {
-                                ts,
-                                room_id: room_id.clone(),
-                                username: principal.clone(),
-                                capabilities: vec![
-                                    ThreadCapability::View,
-                                    ThreadCapability::Post,
-                                    ThreadCapability::Vote,
-                                    ThreadCapability::AddItem,
-                                    ThreadCapability::Manage,
-                                ],
-                                granted_by: principal.clone(),
-                            });
-                            if let Err(e) = state.event_log.append(&tc_ev).await {
-                                line_err(format!("{e}"), None)
-                            } else if let Err(e) = state.event_log.append(&ga_ev).await {
-                                line_err(format!("{e}"), None)
-                            } else {
-                                let mut r = state.reduced.write().await;
-                                r.apply_event(tc_ev);
-                                r.apply_event(ga_ev);
-                                line_ok(RpcResult::RoomCreated { room_id })
+                            let (tx, rx) = oneshot::channel();
+                            match state
+                                .write_tx
+                                .send(WriteCmd::RoomCreate {
+                                    slug,
+                                    bearer,
+                                    reply: tx,
+                                })
+                                .await
+                            {
+                                Err(_) => line_err("writer unavailable", None),
+                                Ok(()) => match rx.await {
+                                    Err(_) => line_err("writer dropped", None),
+                                    Ok(Ok(r)) => line_ok(r),
+                                    Ok(Err((msg, hint))) => line_err(msg, hint),
+                                },
                             }
                         }
                     }
@@ -1303,22 +1045,30 @@ pub async fn handle_rpc_batch(
                                             .collect();
                                         match caps {
                                             Err(msg) => line_err(msg, None),
-                                            Ok(caps) => {
-                                                let ga_ev = Event::GrantAdded(GrantAdded {
-                                                    ts: now_ms(),
-                                                    room_id: room,
-                                                    username: target,
-                                                    capabilities: caps,
-                                                    granted_by: principal,
-                                                });
-                                                if let Err(e) = state.event_log.append(&ga_ev).await {
-                                                    line_err(format!("{e}"), None)
-                                                } else {
-                                                    let mut r = state.reduced.write().await;
-                                                    r.apply_event(ga_ev);
-                                                    line_ok(RpcResult::GrantOk {})
+                                            Ok(_) => match parse_bearer(&headers) {
+                                                Err((_, m)) => line_err(m, None),
+                                                Ok(bearer) => {
+                                                    let (tx, rx) = oneshot::channel();
+                                                    match state
+                                                        .write_tx
+                                                        .send(WriteCmd::Grant {
+                                                            room,
+                                                            username,
+                                                            capabilities,
+                                                            bearer,
+                                                            reply: tx,
+                                                        })
+                                                        .await
+                                                    {
+                                                        Err(_) => line_err("writer unavailable", None),
+                                                        Ok(()) => match rx.await {
+                                                            Err(_) => line_err("writer dropped", None),
+                                                            Ok(Ok(r)) => line_ok(r),
+                                                            Ok(Err((msg, hint))) => line_err(msg, hint),
+                                                        },
+                                                    }
                                                 }
-                                            }
+                                            },
                                         }
                                     }
                                 }
@@ -1485,22 +1235,30 @@ pub async fn handle_rpc_batch(
                                     } else {
                                         match parse_capability(capability.trim()) {
                                             Err(msg) => line_err(msg, None),
-                                            Ok(cap) => {
-                                                let gr_ev = Event::GrantRevoked(GrantRevoked {
-                                                    ts: now_ms(),
-                                                    room_id: room,
-                                                    username: target,
-                                                    capabilities: vec![cap],
-                                                    revoked_by: principal,
-                                                });
-                                                if let Err(e) = state.event_log.append(&gr_ev).await {
-                                                    line_err(format!("{e}"), None)
-                                                } else {
-                                                    let mut r = state.reduced.write().await;
-                                                    r.apply_event(gr_ev);
-                                                    line_ok(RpcResult::GrantOk {})
+                                            Ok(_cap) => match parse_bearer(&headers) {
+                                                Err((_, m)) => line_err(m, None),
+                                                Ok(bearer) => {
+                                                    let (tx, rx) = oneshot::channel();
+                                                    match state
+                                                        .write_tx
+                                                        .send(WriteCmd::Revoke {
+                                                            room,
+                                                            username,
+                                                            capability,
+                                                            bearer,
+                                                            reply: tx,
+                                                        })
+                                                        .await
+                                                    {
+                                                        Err(_) => line_err("writer unavailable", None),
+                                                        Ok(()) => match rx.await {
+                                                            Err(_) => line_err("writer dropped", None),
+                                                            Ok(Ok(r)) => line_ok(r),
+                                                            Ok(Err((msg, hint))) => line_err(msg, hint),
+                                                        },
+                                                    }
                                                 }
-                                            }
+                                            },
                                         }
                                     }
                                 }
@@ -1527,8 +1285,8 @@ pub async fn handle_rpc_batch(
                 let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT);
                 let offset = offset.unwrap_or(0);
                 let want_percent = percent.unwrap_or(false);
-                let mut reduced = state.reduced.write().await;
-                let content = reduced.content.entry(scope_from_room_wire(&room)).or_default();
+                let reduced = state.reduced.read().await;
+                let mut content = content_for_room(&reduced, &room).clone();
                 let group = &mut content.ranking_group;
                 let n = group.idx_to_item.len();
                 let (mut comps, _) = connected_components_from_voted_pairs(

--- a/server/src/api/rpc.rs
+++ b/server/src/api/rpc.rs
@@ -29,7 +29,7 @@ use super::helpers::{
     compute_connectivity_stats, is_pair_voted, now_ms, paginate_rankings, parse_parent_specs,
     pick_random_distinct_canonical, resolve_item, vote_touches_path,
 };
-use super::validate::{normalize_room_and_thread, validate_ingest_document};
+use super::validate::validate_ingest_document;
 
 fn empty_content() -> &'static crate::reducer::ContentState {
     static E: OnceLock<crate::reducer::ContentState> = OnceLock::new();
@@ -246,61 +246,6 @@ async fn rpc_post(
     text: String,
     return_rank_diff: bool,
 ) -> Result<RpcResult, RpcErr> {
-    let reduced_arc = state.reduced.clone();
-    let reduced = reduced_arc.read().await;
-
-    let principal = verify_bearer_principal(headers, &reduced).map_err(|(_, m)| (m, None))?;
-
-    let delegate: Option<String> = match delegate_opt {
-        None => None,
-        Some(ref s) if s.trim().is_empty() => None,
-        Some(ref s) => Some(parse_agent(s).map_err(|msg| (format!("invalid delegate format"), Some(msg)))?),
-    };
-
-    let (room_key, _thread_id) = normalize_room_and_thread(&room, &thread_tag);
-    let scope = scope_from_room_wire(&room_key);
-
-    let is_private = !matches!(scope, ScopeId::Public);
-    if is_private && !reduced.rooms.contains(&room_key) {
-        drop(reduced);
-        return Err(("unknown room".into(), Some(format!("room `{}` does not exist", room_key))));
-    }
-
-    let v = validate_ingest_document(&reduced, &text, &scope).map_err(|(st, m, h)| {
-        let _ = st;
-        (m, h)
-    })?;
-
-    if is_private {
-        let mut required: HashSet<ThreadCapability> = HashSet::new();
-        required.insert(ThreadCapability::View);
-        for stmt in &v.doc.statements {
-            match stmt {
-                dsl::Stmt::Vote { .. } => { required.insert(ThreadCapability::Vote); }
-                dsl::Stmt::Item { .. } => { required.insert(ThreadCapability::AddItem); }
-                dsl::Stmt::Prose { .. } => { required.insert(ThreadCapability::Post); }
-            }
-        }
-        let missing: Vec<_> = required.iter()
-            .filter(|cap| !reduced.user_has_cap(&room_key, &principal, **cap))
-            .collect();
-        if !missing.is_empty() {
-            drop(reduced);
-            return Err(("insufficient capabilities for this room".into(), None));
-        }
-    }
-
-    if let Some(ref d) = delegate {
-        match reduced.agent_bindings.get(d) {
-            Some(u) if u != &principal => {
-                drop(reduced);
-                return Err(("delegate already bound to another user".into(), None));
-            }
-            _ => {}
-        }
-    }
-    drop(reduced);
-
     let bearer = parse_bearer(headers).map_err(|(_, m)| (m, None))?;
     let (tx, rx) = oneshot::channel();
     state
@@ -981,29 +926,22 @@ pub async fn handle_rpc_batch(
                 match parse_bearer(&headers) {
                     Err((_, m)) => line_err(m, None),
                     Ok(bearer) => {
-                        let slug = slug.trim().to_lowercase();
-                        if slug.is_empty() || slug.len() > 64 {
-                            line_err("slug must be 1-64 characters", None)
-                        } else if !slug.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
-                            line_err("slug must be lowercase alphanumeric with hyphens", None)
-                        } else {
-                            let (tx, rx) = oneshot::channel();
-                            match state
-                                .write_tx
-                                .send(WriteCmd::RoomCreate {
-                                    slug,
-                                    bearer,
-                                    reply: tx,
-                                })
-                                .await
-                            {
-                                Err(_) => line_err("writer unavailable", None),
-                                Ok(()) => match rx.await {
-                                    Err(_) => line_err("writer dropped", None),
-                                    Ok(Ok(r)) => line_ok(r),
-                                    Ok(Err((msg, hint))) => line_err(msg, hint),
-                                },
-                            }
+                        let (tx, rx) = oneshot::channel();
+                        match state
+                            .write_tx
+                            .send(WriteCmd::RoomCreate {
+                                slug,
+                                bearer,
+                                reply: tx,
+                            })
+                            .await
+                        {
+                            Err(_) => line_err("writer unavailable", None),
+                            Ok(()) => match rx.await {
+                                Err(_) => line_err("writer dropped", None),
+                                Ok(Ok(r)) => line_ok(r),
+                                Ok(Err((msg, hint))) => line_err(msg, hint),
+                            },
                         }
                     }
                 }
@@ -1013,66 +951,27 @@ pub async fn handle_rpc_batch(
                 username,
                 capabilities,
             } => {
-                let principal = {
-                    let reduced = state.reduced.read().await;
-                    verify_bearer_principal(&headers, &*reduced)
-                };
-                match principal {
+                match parse_bearer(&headers) {
                     Err((_, m)) => line_err(m, None),
-                    Ok(principal) => {
-                        let can_manage = {
-                            let reduced = state.reduced.read().await;
-                            reduced.user_has_cap(&room, &principal, ThreadCapability::Manage)
-                        };
-                        if !can_manage {
-                            line_err("requires Manage capability", None)
-                        } else if capabilities.is_empty() {
-                            line_err("capabilities must not be empty", None)
-                        } else {
-                            match parse_username(&username) {
-                                Err(msg) => line_err("invalid username", Some(msg)),
-                                Ok(target) => {
-                                    let user_exists = {
-                                        let reduced = state.reduced.read().await;
-                                        reduced.users_by_provider.values().any(|u| u == &target)
-                                    };
-                                    if !user_exists {
-                                        line_err(format!("user @{target} not found"), None)
-                                    } else {
-                                        let caps: Result<Vec<ThreadCapability>, String> = capabilities
-                                            .iter()
-                                            .map(|c| parse_capability(c.trim()))
-                                            .collect();
-                                        match caps {
-                                            Err(msg) => line_err(msg, None),
-                                            Ok(_) => match parse_bearer(&headers) {
-                                                Err((_, m)) => line_err(m, None),
-                                                Ok(bearer) => {
-                                                    let (tx, rx) = oneshot::channel();
-                                                    match state
-                                                        .write_tx
-                                                        .send(WriteCmd::Grant {
-                                                            room,
-                                                            username,
-                                                            capabilities,
-                                                            bearer,
-                                                            reply: tx,
-                                                        })
-                                                        .await
-                                                    {
-                                                        Err(_) => line_err("writer unavailable", None),
-                                                        Ok(()) => match rx.await {
-                                                            Err(_) => line_err("writer dropped", None),
-                                                            Ok(Ok(r)) => line_ok(r),
-                                                            Ok(Err((msg, hint))) => line_err(msg, hint),
-                                                        },
-                                                    }
-                                                }
-                                            },
-                                        }
-                                    }
-                                }
-                            }
+                    Ok(bearer) => {
+                        let (tx, rx) = oneshot::channel();
+                        match state
+                            .write_tx
+                            .send(WriteCmd::Grant {
+                                room,
+                                username,
+                                capabilities,
+                                bearer,
+                                reply: tx,
+                            })
+                            .await
+                        {
+                            Err(_) => line_err("writer unavailable", None),
+                            Ok(()) => match rx.await {
+                                Err(_) => line_err("writer dropped", None),
+                                Ok(Ok(r)) => line_ok(r),
+                                Ok(Err((msg, hint))) => line_err(msg, hint),
+                            },
                         }
                     }
                 }
@@ -1209,60 +1108,27 @@ pub async fn handle_rpc_batch(
                 username,
                 capability,
             } => {
-                let principal = {
-                    let reduced = state.reduced.read().await;
-                    verify_bearer_principal(&headers, &*reduced)
-                };
-                match principal {
+                match parse_bearer(&headers) {
                     Err((_, m)) => line_err(m, None),
-                    Ok(principal) => {
-                        let can_manage = {
-                            let reduced = state.reduced.read().await;
-                            reduced.user_has_cap(&room, &principal, ThreadCapability::Manage)
-                        };
-                        if !can_manage {
-                            line_err("requires Manage capability", None)
-                        } else {
-                            match parse_username(&username) {
-                                Err(msg) => line_err("invalid username", Some(msg)),
-                                Ok(target) => {
-                                    let user_exists = {
-                                        let reduced = state.reduced.read().await;
-                                        reduced.users_by_provider.values().any(|u| u == &target)
-                                    };
-                                    if !user_exists {
-                                        line_err(format!("user @{target} not found"), None)
-                                    } else {
-                                        match parse_capability(capability.trim()) {
-                                            Err(msg) => line_err(msg, None),
-                                            Ok(_cap) => match parse_bearer(&headers) {
-                                                Err((_, m)) => line_err(m, None),
-                                                Ok(bearer) => {
-                                                    let (tx, rx) = oneshot::channel();
-                                                    match state
-                                                        .write_tx
-                                                        .send(WriteCmd::Revoke {
-                                                            room,
-                                                            username,
-                                                            capability,
-                                                            bearer,
-                                                            reply: tx,
-                                                        })
-                                                        .await
-                                                    {
-                                                        Err(_) => line_err("writer unavailable", None),
-                                                        Ok(()) => match rx.await {
-                                                            Err(_) => line_err("writer dropped", None),
-                                                            Ok(Ok(r)) => line_ok(r),
-                                                            Ok(Err((msg, hint))) => line_err(msg, hint),
-                                                        },
-                                                    }
-                                                }
-                                            },
-                                        }
-                                    }
-                                }
-                            }
+                    Ok(bearer) => {
+                        let (tx, rx) = oneshot::channel();
+                        match state
+                            .write_tx
+                            .send(WriteCmd::Revoke {
+                                room,
+                                username,
+                                capability,
+                                bearer,
+                                reply: tx,
+                            })
+                            .await
+                        {
+                            Err(_) => line_err("writer unavailable", None),
+                            Ok(()) => match rx.await {
+                                Err(_) => line_err("writer dropped", None),
+                                Ok(Ok(r)) => line_ok(r),
+                                Ok(Err((msg, hint))) => line_err(msg, hint),
+                            },
                         }
                     }
                 }

--- a/server/src/api/write_actor.rs
+++ b/server/src/api/write_actor.rs
@@ -1,0 +1,712 @@
+//! Serialized writer: all event-log appends and reducer mutations go through one task.
+
+use std::collections::{HashMap, HashSet};
+
+use slug_types::paths::ForumThreadUrl;
+use tokio::sync::mpsc;
+
+use crate::{
+    dsl,
+    events::{AgentBound, Event, GrantAdded, Ingest, PostRedacted, UserRegistered},
+    html::JsBuilder,
+    identity::parse_agent,
+    path_types::CanonicalItemUrl,
+    reducer::{scope_from_room_wire, ReducerState, ScopeId},
+    state::AppState,
+    write_cmd::WriteCmd,
+};
+
+use super::auth::{issue_token_for_user, verify_token};
+use super::helpers::{now_ms, resolve_item};
+use super::validate::{normalize_room_and_thread, validate_ingest_document};
+use slug_types::RpcResult;
+
+fn gen_short_id() -> String {
+    use rand::Rng;
+    const ALPHABET: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyz";
+    let mut rng = rand::thread_rng();
+    (0..7).map(|_| ALPHABET[rng.gen_range(0..ALPHABET.len())] as char).collect()
+}
+
+fn parse_capability(s: &str) -> Result<crate::events::ThreadCapability, String> {
+    use crate::events::ThreadCapability;
+    match s {
+        "view" => Ok(ThreadCapability::View),
+        "post" => Ok(ThreadCapability::Post),
+        "vote" => Ok(ThreadCapability::Vote),
+        "add_item" => Ok(ThreadCapability::AddItem),
+        "manage" => Ok(ThreadCapability::Manage),
+        other => Err(format!("unknown capability: {other}")),
+    }
+}
+
+fn empty_content() -> &'static crate::reducer::ContentState {
+    use std::sync::OnceLock;
+    static E: OnceLock<crate::reducer::ContentState> = OnceLock::new();
+    E.get_or_init(Default::default)
+}
+
+fn content_for_room<'a>(reduced: &'a ReducerState, room: &str) -> &'a crate::reducer::ContentState {
+    let scope = scope_from_room_wire(room);
+    reduced.content.get(&scope).unwrap_or(empty_content())
+}
+
+async fn broadcast_web_refresh(state: &AppState, room_key: &str, thread_id: &str) {
+    let feed_id = if room_key == "public" { "thread-feed" } else { "room-thread-feed" };
+    let thread_url = if room_key == "public" {
+        format!("/t/{thread_id}")
+    } else if let Some((short, slug)) = room_key.split_once('/') {
+        format!("/r/{short}/{slug}/t/{thread_id}")
+    } else {
+        format!("/t/{thread_id}")
+    };
+
+    let feed_markup = if room_key == "public" {
+        crate::html::thread_feed_html(state).await
+    } else {
+        crate::html::thread_feed_html_for_room(state, room_key).await
+    };
+
+    let thread_feed_markup =
+        crate::html::thread_feed_region_markup(state, Some(room_key), thread_id, None).await;
+
+    let builder = JsBuilder::new().morph_selector(&format!("#{feed_id}"), feed_markup);
+    let builder = builder.qs("#new-thread-compose form").reset();
+    let builder = builder.if_current_path_matches(&thread_url, |builder| {
+        builder.morph_selector("#thread-feed-region", thread_feed_markup)
+    });
+    let js = builder.build();
+    let mut path_prefixes = vec![if room_key == "public" {
+        "/".to_string()
+    } else if let Some((short, slug)) = room_key.split_once('/') {
+        format!("/r/{short}/{slug}")
+    } else {
+        "/".to_string()
+    }];
+    path_prefixes.push(thread_url.clone());
+    let _ = state.js_tx.send(crate::state::JsSnippet { code: js, path_prefixes });
+}
+
+fn compute_scope_rank_changes(
+    parent: &CanonicalItemUrl,
+    before: &crate::scope_rank::ChildrenRankings,
+    after: &crate::scope_rank::ChildrenRankings,
+    room_wire: &str,
+) -> Option<slug_types::ScopeRankChanges> {
+    use slug_types::{RankChange, RankPosition, ScopeRankChanges};
+    use std::collections::BTreeSet;
+    fn build_positions(
+        rankings: &crate::scope_rank::ChildrenRankings,
+    ) -> HashMap<CanonicalItemUrl, Option<RankPosition>> {
+        let mut map = HashMap::new();
+        for comp in &rankings.component_rankings {
+            let total = comp.ranked.len();
+            for (i, item) in comp.ranked.iter().enumerate() {
+                map.insert(item.item.clone(), Some(RankPosition { rank: i + 1, of: total }));
+            }
+        }
+        for item in &rankings.unranked_items {
+            map.insert(item.clone(), None);
+        }
+        map
+    }
+
+    let before_pos = build_positions(before);
+    let after_pos = build_positions(after);
+
+    let all_items: BTreeSet<CanonicalItemUrl> = before_pos
+        .keys()
+        .cloned()
+        .chain(after_pos.keys().cloned())
+        .collect();
+
+    let mut changes: Vec<RankChange> = Vec::new();
+    for item in all_items {
+        let b = before_pos.get(&item).cloned().flatten();
+        let a = after_pos.get(&item).cloned().flatten();
+        let changed = match (&b, &a) {
+            (Some(bp), Some(ap)) => bp.rank != ap.rank || bp.of != ap.of,
+            (None, Some(_)) => true,
+            (Some(_), None) => true,
+            (None, None) => false,
+        };
+        if changed {
+            changes.push(RankChange {
+                item: slug_types::paths::GardenItemUrl::from_stored(&item, room_wire),
+                before: b,
+                after: a,
+            });
+        }
+    }
+
+    if changes.is_empty() {
+        return None;
+    }
+
+    changes.sort_by(|a, b| match (&a.after, &b.after) {
+        (Some(ap), Some(bp)) => ap.rank.cmp(&bp.rank),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => a.item.cmp(&b.item),
+    });
+
+    Some(ScopeRankChanges {
+        parent: slug_types::paths::GardenItemUrl::from_stored(parent, room_wire).into_inner(),
+        changes,
+    })
+}
+
+async fn redeem_invite_grant(state: &AppState, invite_token: &str, grantee_username: &str) -> Result<(), String> {
+    let now = now_ms();
+    let ga = {
+        let mut invites = state.invites.write().await;
+        let Some(inv) = invites.get_mut(invite_token) else {
+            return Err("invite not found".into());
+        };
+        if now > inv.expires_at_ms {
+            invites.remove(invite_token);
+            return Err("invite expired".into());
+        }
+        if inv.current_uses >= inv.max_uses {
+            return Err("invite exhausted".into());
+        }
+        inv.current_uses += 1;
+        Event::GrantAdded(GrantAdded {
+            ts: now,
+            room_id: inv.room_id.clone(),
+            username: grantee_username.to_string(),
+            capabilities: inv.capabilities.clone(),
+            granted_by: inv.inviter.clone(),
+        })
+    };
+
+    match state.event_log.append(&ga).await {
+        Ok(()) => {
+            let mut reduced = state.reduced.write().await;
+            reduced.apply_event(ga);
+            drop(reduced);
+            let mut invites = state.invites.write().await;
+            if let Some(inv) = invites.get(invite_token) {
+                if inv.current_uses >= inv.max_uses {
+                    invites.remove(invite_token);
+                }
+            }
+            Ok(())
+        }
+        Err(e) => {
+            let mut invites = state.invites.write().await;
+            if let Some(inv) = invites.get_mut(invite_token) {
+                inv.current_uses = inv.current_uses.saturating_sub(1);
+            }
+            Err(format!("{e}"))
+        }
+    }
+}
+
+pub async fn writer_actor(mut rx: mpsc::Receiver<WriteCmd>, state: AppState) {
+    while let Some(cmd) = rx.recv().await {
+        match cmd {
+            WriteCmd::Post {
+                room,
+                thread_tag,
+                delegate_opt,
+                text,
+                return_rank_diff,
+                bearer,
+                reply,
+            } => {
+                let out = async {
+                    let mut reduced = state.reduced.write().await;
+
+                    let principal =
+                        verify_token(&reduced, &bearer).map_err(|(_, m)| (m, None))?;
+
+                    let delegate: Option<String> = match delegate_opt {
+                        None => None,
+                        Some(ref s) if s.trim().is_empty() => None,
+                        Some(s) => Some(
+                            parse_agent(&s).map_err(|msg| (format!("invalid delegate format"), Some(msg)))?,
+                        ),
+                    };
+
+                    let (room_key, thread_id) = normalize_room_and_thread(&room, &thread_tag);
+                    let scope = scope_from_room_wire(&room_key);
+                    let is_private = !matches!(scope, ScopeId::Public);
+                    if is_private && !reduced.rooms.contains(&room_key) {
+                        return Err((
+                            "unknown room".into(),
+                            Some(format!("room `{}` does not exist", room_key)),
+                        ));
+                    }
+
+                    let v = validate_ingest_document(&reduced, &text, &scope)
+                        .map_err(|(st, m, h)| {
+                            let _ = st;
+                            (m, h)
+                        })?;
+
+                    if is_private {
+                        use crate::events::ThreadCapability;
+                        let mut required: HashSet<ThreadCapability> = HashSet::new();
+                        required.insert(ThreadCapability::View);
+                        for stmt in &v.doc.statements {
+                            match stmt {
+                                dsl::Stmt::Vote { .. } => {
+                                    required.insert(ThreadCapability::Vote);
+                                }
+                                dsl::Stmt::Item { .. } => {
+                                    required.insert(ThreadCapability::AddItem);
+                                }
+                                dsl::Stmt::Prose { .. } => {
+                                    required.insert(ThreadCapability::Post);
+                                }
+                            }
+                        }
+                        let missing: Vec<_> = required
+                            .iter()
+                            .filter(|cap| !reduced.user_has_cap(&room_key, &principal, **cap))
+                            .collect();
+                        if !missing.is_empty() {
+                            return Err(("insufficient capabilities for this room".into(), None));
+                        }
+                    }
+
+                    if let Some(ref d) = delegate {
+                        match reduced.agent_bindings.get(d) {
+                            Some(u) if u != &principal => {
+                                return Err(("delegate already bound to another user".into(), None));
+                            }
+                            _ => {}
+                        }
+                    }
+
+                    let need_agent_bind = delegate
+                        .as_ref()
+                        .map(|d| reduced.agent_bindings.get(d).is_none())
+                        .unwrap_or(false);
+
+                    let voted_parent_scopes: Vec<CanonicalItemUrl> = {
+                        let mut parents: HashSet<CanonicalItemUrl> = HashSet::new();
+                        for s in &v.doc.statements {
+                            if let dsl::Stmt::Vote { item1, item2, .. } = s {
+                                if let (Ok(a), Ok(b)) = (resolve_item(item1), resolve_item(item2)) {
+                                    if let Some(p) = a.parent() {
+                                        parents.insert(p);
+                                    }
+                                    if let Some(p) = b.parent() {
+                                        parents.insert(p);
+                                    }
+                                }
+                            }
+                        }
+                        let mut out: Vec<CanonicalItemUrl> = parents.into_iter().collect();
+                        out.sort();
+                        out
+                    };
+
+                    let pre_rankings: HashMap<CanonicalItemUrl, crate::scope_rank::ChildrenRankings> =
+                        if !voted_parent_scopes.is_empty() {
+                            let content = content_for_room(&reduced, &room_key);
+                            voted_parent_scopes
+                                .iter()
+                                .map(|p| {
+                                    (
+                                        p.clone(),
+                                        crate::scope_rank::build_children_rankings(content, p),
+                                    )
+                                })
+                                .collect()
+                        } else {
+                            HashMap::new()
+                        };
+
+                    let mut events_appended: usize = 0;
+
+                    if need_agent_bind {
+                        if let Some(agent_id) = delegate.clone() {
+                            let ab = Event::AgentBound(AgentBound {
+                                ts: now_ms(),
+                                agent: agent_id,
+                                username: principal.clone(),
+                            });
+                            state
+                                .event_log
+                                .append(&ab)
+                                .await
+                                .map_err(|e| (format!("{e}"), None))?;
+                            events_appended += 1;
+                            reduced.apply_event(ab);
+                        }
+                    }
+
+                    let ingest_event = Event::Ingest(Ingest {
+                        ts: v.ts,
+                        id: uuid::Uuid::new_v4().to_string(),
+                        raw: v.raw_text.clone(),
+                        principal: principal.clone(),
+                        delegate: delegate.clone(),
+                        room_id: room_key.clone(),
+                        thread_tag: thread_id.clone(),
+                    });
+
+                    state
+                        .event_log
+                        .append(&ingest_event)
+                        .await
+                        .map_err(|e| (format!("{e}"), None))?;
+                    events_appended += 1;
+                    reduced.apply_event(ingest_event);
+                    drop(reduced);
+
+                    use crate::canonical_path::canonicalize_tag;
+                    let thread_tag_canon = canonicalize_tag(&thread_id);
+                    broadcast_web_refresh(&state, &room_key, &thread_tag_canon).await;
+
+                    let ranking_changes: Option<Vec<slug_types::ScopeRankChanges>> =
+                        if return_rank_diff && !voted_parent_scopes.is_empty() {
+                            let reduced = state.reduced.read().await;
+                            let content = content_for_room(&reduced, &room_key);
+                            let v: Vec<slug_types::ScopeRankChanges> = voted_parent_scopes
+                                .iter()
+                                .filter_map(|p| {
+                                    let before = pre_rankings.get(p)?;
+                                    let after =
+                                        crate::scope_rank::build_children_rankings(content, p);
+                                    compute_scope_rank_changes(p, before, &after, &room_key)
+                                })
+                                .collect();
+                            if v.is_empty() {
+                                None
+                            } else {
+                                Some(v)
+                            }
+                        } else {
+                            None
+                        };
+
+                    let (pair_hint, rank_hint, web_url) = if room_key == "public" {
+                        (
+                            "npx slugsocial public garden pair".to_string(),
+                            "npx slugsocial public garden rank".to_string(),
+                            ForumThreadUrl::from_room_tag("public", &thread_id),
+                        )
+                    } else {
+                        (
+                            format!("npx slugsocial private {room_key} garden pair"),
+                            format!("npx slugsocial private {room_key} garden rank"),
+                            ForumThreadUrl::from_room_tag(&room_key, &thread_id),
+                        )
+                    };
+
+                    Ok(RpcResult::PostOk {
+                        events_appended,
+                        ranking_changes,
+                        threads: vec![format!("#{}", thread_id)],
+                        next: slug_types::NextMoves {
+                            pair: pair_hint,
+                            rank: rank_hint,
+                            web: web_url,
+                        },
+                    })
+                }
+                .await;
+                let _ = reply.send(out);
+            }
+
+            WriteCmd::Redact {
+                post_id,
+                bearer,
+                reply,
+            } => {
+                let out = async {
+                    let mut reduced = state.reduced.write().await;
+                    let principal =
+                        verify_token(&reduced, &bearer).map_err(|(_, m)| (m, None))?;
+                    let post_id = post_id.trim().to_string();
+                    let Some(ing) = reduced.ingests_by_id.get(&post_id).cloned() else {
+                        return Err(("post not found".into(), None));
+                    };
+                    if ing.principal != principal {
+                        return Err(("not your post".into(), None));
+                    }
+                    if reduced.redacted_posts.contains(&post_id) {
+                        return Err(("already redacted".into(), None));
+                    }
+                    let room_key = ing.room_id.trim().to_string();
+                    let scope = scope_from_room_wire(&room_key);
+                    if matches!(scope, ScopeId::Room(_))
+                        && (!reduced.rooms.contains(&room_key)
+                            || !reduced.user_has_cap(&room_key, &principal, crate::events::ThreadCapability::View))
+                    {
+                        return Err(("room not found".into(), None));
+                    }
+
+                    let ev = Event::PostRedacted(PostRedacted {
+                        ts: now_ms(),
+                        post_id: post_id.clone(),
+                        principal: principal.clone(),
+                    });
+                    state
+                        .event_log
+                        .append(&ev)
+                        .await
+                        .map_err(|e| (format!("{e}"), None))?;
+                    reduced.apply_event(ev);
+                    drop(reduced);
+
+                    use crate::canonical_path::canonicalize_tag;
+                    let thread_tag = canonicalize_tag(&ing.thread_tag);
+                    broadcast_web_refresh(&state, &room_key, &thread_tag).await;
+                    Ok(RpcResult::RedactPostOk {})
+                }
+                .await;
+                let _ = reply.send(out);
+            }
+
+            WriteCmd::RoomCreate {
+                slug,
+                bearer,
+                reply,
+            } => {
+                let out = async {
+                    let mut reduced = state.reduced.write().await;
+                    let principal =
+                        verify_token(&reduced, &bearer).map_err(|(_, m)| (m, None))?;
+                    let slug = slug.trim().to_lowercase();
+                    if slug.is_empty() || slug.len() > 64 {
+                        return Err(("slug must be 1-64 characters".into(), None));
+                    }
+                    if !slug.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+                        return Err(("slug must be lowercase alphanumeric with hyphens".into(), None));
+                    }
+                    let short_id = loop {
+                        let id = gen_short_id();
+                        if !reduced.rooms.contains(&format!("{id}/{slug}")) {
+                            break id;
+                        }
+                    };
+                    let room_id = format!("{short_id}/{slug}");
+                    let ts = now_ms();
+                    use crate::events::{GrantAdded, RoomCreated, ThreadCapability};
+                    let tc_ev = Event::RoomCreated(RoomCreated {
+                        ts,
+                        room_id: room_id.clone(),
+                        slug: slug.clone(),
+                        owner: principal.clone(),
+                    });
+                    let ga_ev = Event::GrantAdded(GrantAdded {
+                        ts,
+                        room_id: room_id.clone(),
+                        username: principal.clone(),
+                        capabilities: vec![
+                            ThreadCapability::View,
+                            ThreadCapability::Post,
+                            ThreadCapability::Vote,
+                            ThreadCapability::AddItem,
+                            ThreadCapability::Manage,
+                        ],
+                        granted_by: principal.clone(),
+                    });
+                    state
+                        .event_log
+                        .append(&tc_ev)
+                        .await
+                        .map_err(|e| (format!("{e}"), None))?;
+                    state
+                        .event_log
+                        .append(&ga_ev)
+                        .await
+                        .map_err(|e| (format!("{e}"), None))?;
+                    reduced.apply_event(tc_ev);
+                    reduced.apply_event(ga_ev);
+                    Ok(RpcResult::RoomCreated { room_id })
+                }
+                .await;
+                let _ = reply.send(out);
+            }
+
+            WriteCmd::Grant {
+                room,
+                username,
+                capabilities,
+                bearer,
+                reply,
+            } => {
+                let out = async {
+                    use crate::events::{GrantAdded, ThreadCapability};
+                    use crate::identity::parse_username;
+
+                    let mut reduced = state.reduced.write().await;
+                    let principal =
+                        verify_token(&reduced, &bearer).map_err(|(_, m)| (m, None))?;
+                    if !reduced.user_has_cap(&room, &principal, ThreadCapability::Manage) {
+                        return Err(("requires Manage capability".into(), None));
+                    }
+                    if capabilities.is_empty() {
+                        return Err(("capabilities must not be empty".into(), None));
+                    }
+                    let target = parse_username(&username).map_err(|msg| ("invalid username".into(), Some(msg)))?;
+                    if !reduced.users_by_provider.values().any(|u| u == &target) {
+                        return Err((format!("user @{target} not found"), None));
+                    }
+                    let caps: Vec<crate::events::ThreadCapability> = capabilities
+                        .iter()
+                        .map(|c| parse_capability(c.trim()))
+                        .collect::<Result<_, _>>()
+                        .map_err(|msg| (msg, None))?;
+                    let ga_ev = Event::GrantAdded(GrantAdded {
+                        ts: now_ms(),
+                        room_id: room,
+                        username: target,
+                        capabilities: caps,
+                        granted_by: principal,
+                    });
+                    state
+                        .event_log
+                        .append(&ga_ev)
+                        .await
+                        .map_err(|e| (format!("{e}"), None))?;
+                    reduced.apply_event(ga_ev);
+                    Ok(RpcResult::GrantOk {})
+                }
+                .await;
+                let _ = reply.send(out);
+            }
+
+            WriteCmd::Revoke {
+                room,
+                username,
+                capability,
+                bearer,
+                reply,
+            } => {
+                let out = async {
+                    use crate::events::{GrantRevoked, ThreadCapability};
+                    use crate::identity::parse_username;
+
+                    let mut reduced = state.reduced.write().await;
+                    let principal =
+                        verify_token(&reduced, &bearer).map_err(|(_, m)| (m, None))?;
+                    if !reduced.user_has_cap(&room, &principal, ThreadCapability::Manage) {
+                        return Err(("requires Manage capability".into(), None));
+                    }
+                    let target = parse_username(&username).map_err(|msg| ("invalid username".into(), Some(msg)))?;
+                    if !reduced.users_by_provider.values().any(|u| u == &target) {
+                        return Err((format!("user @{target} not found"), None));
+                    }
+                    let cap = parse_capability(capability.trim()).map_err(|msg| (msg, None))?;
+                    let gr_ev = Event::GrantRevoked(GrantRevoked {
+                        ts: now_ms(),
+                        room_id: room,
+                        username: target,
+                        capabilities: vec![cap],
+                        revoked_by: principal,
+                    });
+                    state
+                        .event_log
+                        .append(&gr_ev)
+                        .await
+                        .map_err(|e| (format!("{e}"), None))?;
+                    reduced.apply_event(gr_ev);
+                    Ok(RpcResult::GrantOk {})
+                }
+                .await;
+                let _ = reply.send(out);
+            }
+
+            WriteCmd::Register {
+                username,
+                provider,
+                provider_id,
+                redeem_invite,
+                reply,
+            } => {
+                let out = async {
+                    let mut reduced = state.reduced.write().await;
+                    let provider_key = (provider.to_lowercase(), provider_id.clone());
+                    if reduced.users_by_provider.contains_key(&provider_key) {
+                        return Err("provider already registered".into());
+                    }
+                    if reduced.users_by_provider.values().any(|u| u == &username) {
+                        return Err("that username is taken — try another".into());
+                    }
+
+                    let ur = Event::UserRegistered(UserRegistered {
+                        ts: now_ms(),
+                        username: username.clone(),
+                        provider: provider.to_lowercase(),
+                        provider_id: provider_id.clone(),
+                    });
+                    let (bearer, ti) = issue_token_for_user(&username);
+                    let ti_ev = Event::TokenIssued(ti);
+
+                    state
+                        .event_log
+                        .append(&ur)
+                        .await
+                        .map_err(|e| format!("{e}"))?;
+                    state
+                        .event_log
+                        .append(&ti_ev)
+                        .await
+                        .map_err(|e| format!("{e}"))?;
+                    reduced.apply_event(ur);
+                    reduced.apply_event(ti_ev.clone());
+                    drop(reduced);
+
+                    if let Some(tok) = redeem_invite {
+                        if let Err(e) = redeem_invite_grant(&state, &tok, &username).await {
+                            tracing::warn!(error = %e, "invite redemption skipped after registration");
+                        }
+                    }
+
+                    Ok(bearer)
+                }
+                .await;
+                let _ = reply.send(out);
+            }
+
+            WriteCmd::OAuthTokenIssue {
+                token_event,
+                redeem_invite,
+                reply,
+            } => {
+                let grantee = match &token_event {
+                    Event::TokenIssued(t) => t.username.clone(),
+                    _ => {
+                        let _ = reply.send(Err("internal: expected TokenIssued".into()));
+                        continue;
+                    }
+                };
+                let out = async {
+                    let mut reduced = state.reduced.write().await;
+                    state
+                        .event_log
+                        .append(&token_event)
+                        .await
+                        .map_err(|e| format!("{e}"))?;
+                    reduced.apply_event(token_event);
+                    drop(reduced);
+
+                    if let Some(tok) = redeem_invite {
+                        if let Err(e) = redeem_invite_grant(&state, &tok, &grantee).await {
+                            tracing::warn!(error = %e, "invite redemption skipped after oauth");
+                        }
+                    }
+                    Ok(())
+                }
+                .await;
+                let _ = reply.send(out);
+            }
+
+            WriteCmd::RedeemInvite {
+                token,
+                grantee_username,
+                reply,
+            } => {
+                let out = redeem_invite_grant(&state, &token, &grantee_username).await;
+                let _ = reply.send(out);
+            }
+        }
+    }
+}

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -15,14 +15,48 @@ pub mod reducer;
 pub mod scope_rank;
 pub mod state;
 pub mod timeago;
+pub mod write_cmd;
+
+use std::collections::HashMap;
+use std::sync::Arc;
 
 use axum::Router;
+use tokio::sync::{broadcast, mpsc, RwLock};
+
+use crate::state::{AppConfig, AppState};
+use crate::write_cmd::WriteCmd;
 use axum::routing::{get, post};
 use tower_http::trace::TraceLayer;
 
-use crate::state::AppState;
-
 pub use reducer::ReducerState;
+
+/// Build application state and start the serialized writer task (required for RPC/auth writes).
+pub fn create_app_state(cfg: AppConfig) -> AppState {
+    let event_log = crate::event_log::EventLog::new(cfg.event_log_path.clone());
+    let (stream_tx, _) = broadcast::channel(64);
+    let (js_tx, _) = broadcast::channel(64);
+    let (write_tx, write_rx) = mpsc::channel::<WriteCmd>(256);
+    let state = AppState {
+        cfg: Arc::new(cfg),
+        event_log: Arc::new(event_log),
+        reduced: Arc::new(RwLock::new(crate::reducer::ReducerState::default())),
+        pending_sessions: Arc::new(RwLock::new(HashMap::new())),
+        invites: Arc::new(RwLock::new(HashMap::new())),
+        stream_tx,
+        js_tx,
+        write_tx,
+    };
+    tokio::spawn(crate::api::write_actor::writer_actor(write_rx, state.clone()));
+    state
+}
+
+/// Spawn the serialized writer. Used by integration tests after seeding reducer state in-process.
+pub fn spawn_writer_actor_for_test(
+    state: AppState,
+    rx: tokio::sync::mpsc::Receiver<WriteCmd>,
+) {
+    tokio::spawn(crate::api::write_actor::writer_actor(rx, state));
+}
 
 pub fn create_app(state: AppState) -> Router {
     Router::new()

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -2,9 +2,9 @@ use axum::Router;
 use tracing_subscriber::EnvFilter;
 
 use slugsocial_server::{
+    create_app, create_app_state,
     event_log::EventLog,
-    create_app,
-    state::{AppConfig, AppState},
+    state::AppConfig,
 };
 
 fn env_var(name: &str) -> Option<String> {
@@ -31,7 +31,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         event_log_path: event_log_path.clone(),
     };
 
-    let state = AppState::new(cfg);
+    let state = create_app_state(cfg);
 
     // Load and reduce existing events.
     let (events, bad) = EventLog::new(event_log_path).load_all().await?;

--- a/server/src/state.rs
+++ b/server/src/state.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use tokio::sync::{broadcast, RwLock};
+use tokio::sync::{broadcast, mpsc, RwLock};
 
-use crate::{event_log::EventLog, events::ThreadCapability, reducer::ReducerState};
+use crate::{event_log::EventLog, events::ThreadCapability, reducer::ReducerState, write_cmd::WriteCmd};
 
 /// Ephemeral invite link (24h TTL, in-memory only; not written to the event log).
 #[derive(Debug, Clone)]
@@ -65,10 +65,19 @@ pub struct AppState {
     pub stream_tx: broadcast::Sender<StreamEvent>,
     /// Broadcast channel for web SSE JavaScript snippets. Capacity = 64.
     pub js_tx: broadcast::Sender<JsSnippet>,
+    /// All durable writes and reducer mutations are serialized through this channel.
+    pub write_tx: mpsc::Sender<WriteCmd>,
 }
 
 impl AppState {
-    pub fn new(cfg: AppConfig) -> Self {
+    /// Build state with a fresh writer channel; call [`crate::spawn_writer_actor_for_test`] after any in-process seeding.
+    pub fn create_for_test(cfg: AppConfig) -> (Self, mpsc::Receiver<WriteCmd>) {
+        let (write_tx, write_rx) = mpsc::channel(256);
+        (Self::new_for_test(cfg, write_tx), write_rx)
+    }
+
+    /// Prefer [`crate::create_app_state`] so the writer task is started and `write_tx` is wired.
+    pub fn new_for_test(cfg: AppConfig, write_tx: mpsc::Sender<WriteCmd>) -> Self {
         let event_log = EventLog::new(cfg.event_log_path.clone());
         let (stream_tx, _) = broadcast::channel(64);
         let (js_tx, _) = broadcast::channel(64);
@@ -80,6 +89,7 @@ impl AppState {
             invites: Arc::new(RwLock::new(HashMap::new())),
             stream_tx,
             js_tx,
+            write_tx,
         }
     }
 }

--- a/server/src/write_cmd.rs
+++ b/server/src/write_cmd.rs
@@ -1,0 +1,58 @@
+use tokio::sync::oneshot;
+
+use slug_types::RpcResult;
+
+pub type WriteCmdResult = Result<RpcResult, (String, Option<String>)>;
+
+pub enum WriteCmd {
+    Post {
+        room: String,
+        thread_tag: String,
+        delegate_opt: Option<String>,
+        text: String,
+        return_rank_diff: bool,
+        bearer: String,
+        reply: oneshot::Sender<WriteCmdResult>,
+    },
+    Redact {
+        post_id: String,
+        bearer: String,
+        reply: oneshot::Sender<WriteCmdResult>,
+    },
+    RoomCreate {
+        slug: String,
+        bearer: String,
+        reply: oneshot::Sender<WriteCmdResult>,
+    },
+    Grant {
+        room: String,
+        username: String,
+        capabilities: Vec<String>,
+        bearer: String,
+        reply: oneshot::Sender<WriteCmdResult>,
+    },
+    Revoke {
+        room: String,
+        username: String,
+        capability: String,
+        bearer: String,
+        reply: oneshot::Sender<WriteCmdResult>,
+    },
+    Register {
+        username: String,
+        provider: String,
+        provider_id: String,
+        redeem_invite: Option<String>,
+        reply: oneshot::Sender<Result<String, String>>,
+    },
+    OAuthTokenIssue {
+        token_event: crate::events::Event,
+        redeem_invite: Option<String>,
+        reply: oneshot::Sender<Result<(), String>>,
+    },
+    RedeemInvite {
+        token: String,
+        grantee_username: String,
+        reply: oneshot::Sender<Result<(), String>>,
+    },
+}

--- a/server/tests/integration.rs
+++ b/server/tests/integration.rs
@@ -2,6 +2,7 @@ use sha2::{Digest, Sha256};
 use slugsocial_server::{
     event_log::EventLog,
     events::{Event, TokenIssued, UserRegistered},
+    spawn_writer_actor_for_test,
     state::{AppConfig, AppState},
 };
 use tempfile::TempDir;
@@ -100,8 +101,9 @@ async fn create_test_server_with_state() -> (SocketAddr, TempDir, EventLog, AppS
         event_log_path: log_path.to_string_lossy().to_string(),
     };
 
-    let state = AppState::new(cfg);
+    let (state, write_rx) = AppState::create_for_test(cfg);
     seed_test_token(&state).await;
+    spawn_writer_actor_for_test(state.clone(), write_rx);
     let app = slugsocial_server::create_app(state.clone());
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the command/event split: handlers forward `WriteCmd` with `oneshot` replies; **all `event_log.append` + `ReducerState` mutation** for these paths runs in one serialized `writer_actor` under a write lock per command.

**Follow-up:** Write paths no longer duplicate validation—handlers only parse `Authorization` (bearer) where needed and enqueue; slug/caps/username/ingest checks run **only** in `write_actor`. `rpc_check` and other read paths still validate under read lock as before.

## Changes

- `write_cmd::WriteCmd` + `api/write_actor.rs` loop.
- `AppState::write_tx`; `create_app_state` spawns the actor (`main.rs` after replay).
- `rpc_post` / `rpc_post_redact` / room admin RPCs / auth registration & OAuth token path use commands; ranking diff + optional `AgentBound` + ingest in actor.
- `GetGlobalRank` uses read lock + cloned scope content (no write lock for read-only ranking).
- Integration tests: `AppState::create_for_test` + `spawn_writer_actor_for_test` after seeding.

## Tests

`cargo test` passes for the workspace.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ebcf2467-5e1a-48d4-bd24-40eb4fd690c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ebcf2467-5e1a-48d4-bd24-40eb4fd690c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

