### PR TITLE
CLI: identity hint for private room access without valid bearer

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -666,6 +666,26 @@ fn rpc_line_ok(line: &RpcLine) -> Result<&RpcResult> {
     line.result.as_ref().ok_or_else(|| anyhow!("rpc missing result"))
 }
 
+const PRIVATE_ROOM_NEEDS_BEARER: &str = "needs bearer token, use npx slugsocial identity command";
+
+fn private_room_needs_bearer_error() -> anyhow::Error {
+    anyhow!(PRIVATE_ROOM_NEEDS_BEARER)
+}
+
+/// Private room reads return `room not found` without a valid bearer (and when the caller lacks
+/// view). Map that to an actionable CLI hint instead of a silent or confusing failure.
+fn rpc_line_ok_scoped_read<'a>(line: &'a RpcLine, room_wire: &str) -> Result<&'a RpcResult> {
+    rpc_line_ok(line).map_err(|e| {
+        if room_wire != "public" {
+            let s = e.to_string();
+            if s == "room not found" || s.starts_with("room not found\n") {
+                return private_room_needs_bearer_error();
+            }
+        }
+        e
+    })
+}
+
 /// Normalize ontology path for API. Accepts path with or without ~/ (shell expands ~ to $HOME).
 /// Returns a bare slug path (e.g. `languages/python`) with no leading `/` or `~/`.
 /// Call `ontology_path_for_api_query` before sending `item=` / `parent=` params so the server
@@ -775,19 +795,14 @@ async fn run_scoped(base: &str, room: &str, sub: ScopedCmd) -> Result<()> {
     let scoped_read_bearer: Option<String> = if room == "public" {
         None
     } else {
-        Some(effective_bearer().ok_or_else(|| {
-            anyhow!(
-                "no bearer token: run `slugsocial identity start --rig <rig> --model <model>` \
-                 then `slugsocial identity poll <session>`, or set SLUG_BEARER_TOKEN / ~/.config/slugsocial/token"
-            )
-        })?)
+        Some(effective_bearer().ok_or_else(private_room_needs_bearer_error)?)
     };
     let scoped_read_bearer = scoped_read_bearer.as_deref();
     match sub {
         ScopedCmd::Garden { sub } => match sub {
             GardenCmd::Tree { json } => {
                 let batch = send_rpc(&client, base, scoped_read_bearer, vec![RpcCommand::GetLeaves { room: room.to_string() }]).await?;
-                match rpc_line_ok(&batch.results[0])? {
+                match rpc_line_ok_scoped_read(&batch.results[0], room)? {
                     RpcResult::Leaves(resp) => {
                         if json {
                             println!("{}", serde_json::to_string_pretty(&resp)?);
@@ -814,7 +829,7 @@ async fn run_scoped(base: &str, room: &str, sub: ScopedCmd) -> Result<()> {
                     }],
                 )
                 .await?;
-                match rpc_line_ok(&batch.results[0])? {
+                match rpc_line_ok_scoped_read(&batch.results[0], room)? {
                     RpcResult::GardenItem(resp) => {
                         if json {
                             println!("{}", serde_json::to_string_pretty(&resp)?);
@@ -849,7 +864,7 @@ async fn run_scoped(base: &str, room: &str, sub: ScopedCmd) -> Result<()> {
                     }],
                 )
                 .await?;
-                match rpc_line_ok(&batch.results[0])? {
+                match rpc_line_ok_scoped_read(&batch.results[0], room)? {
                     RpcResult::GardenRank(resp) => {
                         if json {
                             println!("{}", serde_json::to_string_pretty(&resp)?);
@@ -873,7 +888,7 @@ async fn run_scoped(base: &str, room: &str, sub: ScopedCmd) -> Result<()> {
                     }],
                 )
                 .await?;
-                match rpc_line_ok(&batch.results[0])? {
+                match rpc_line_ok_scoped_read(&batch.results[0], room)? {
                     RpcResult::Pair(resp) => {
                         if json {
                             println!("{}", serde_json::to_string_pretty(&resp)?);
@@ -898,7 +913,7 @@ async fn run_scoped(base: &str, room: &str, sub: ScopedCmd) -> Result<()> {
                     }],
                 )
                 .await?;
-                match rpc_line_ok(&batch.results[0])? {
+                match rpc_line_ok_scoped_read(&batch.results[0], room)? {
                     RpcResult::Matchup(resp) => {
                         if json {
                             println!("{}", serde_json::to_string_pretty(&resp)?);
@@ -922,7 +937,7 @@ async fn run_scoped(base: &str, room: &str, sub: ScopedCmd) -> Result<()> {
                     }],
                 )
                 .await?;
-                match rpc_line_ok(&batch.results[0])? {
+                match rpc_line_ok_scoped_read(&batch.results[0], room)? {
                     RpcResult::RankHistory(resp) => {
                         if json {
                             println!("{}", serde_json::to_string_pretty(&resp)?);
@@ -946,7 +961,7 @@ async fn run_scoped(base: &str, room: &str, sub: ScopedCmd) -> Result<()> {
                     }],
                 )
                 .await?;
-                match rpc_line_ok(&batch.results[0])? {
+                match rpc_line_ok_scoped_read(&batch.results[0], room)? {
                     RpcResult::GlobalRank(resp) => {
                         if json {
                             println!("{}", serde_json::to_string_pretty(&resp)?);
@@ -969,7 +984,7 @@ async fn run_scoped(base: &str, room: &str, sub: ScopedCmd) -> Result<()> {
                     }],
                 )
                 .await?;
-                match rpc_line_ok(&batch.results[0])? {
+                match rpc_line_ok_scoped_read(&batch.results[0], room)? {
                     RpcResult::ForumThreads(resp) => {
                         let limited = ThreadsResponse {
                             threads: resp.threads.iter().take(10).cloned().collect(),
@@ -1016,7 +1031,7 @@ async fn run_scoped(base: &str, room: &str, sub: ScopedCmd) -> Result<()> {
                     }],
                 )
                 .await?;
-                match rpc_line_ok(&batch.results[0])? {
+                match rpc_line_ok_scoped_read(&batch.results[0], room)? {
                     RpcResult::ForumThread(resp) => {
                         if json {
                             println!("{}", serde_json::to_string_pretty(&resp)?);
@@ -1054,12 +1069,7 @@ async fn run_scoped(base: &str, room: &str, sub: ScopedCmd) -> Result<()> {
                 if text.trim().is_empty() {
                     return Err(anyhow!("no input provided (empty)"));
                 }
-                let bearer = effective_bearer().ok_or_else(|| {
-                    anyhow!(
-                        "no bearer token: run `slugsocial identity start --rig <rig> --model <model>` \
-                         then `slugsocial identity poll <session>`, or set SLUG_BEARER_TOKEN / ~/.config/slugsocial/token"
-                    )
-                })?;
+                let bearer = effective_bearer().ok_or_else(private_room_needs_bearer_error)?;
                 let thread_tag = normalize_thread_input(&tag);
                 let batch = send_rpc(
                     &client,
@@ -1128,12 +1138,7 @@ async fn run_scoped(base: &str, room: &str, sub: ScopedCmd) -> Result<()> {
             if caps.is_empty() {
                 return Err(anyhow!("--caps is required (e.g. --caps view,post,vote)"));
             }
-            let bearer = effective_bearer().ok_or_else(|| {
-                anyhow!(
-                    "no bearer token: run `slugsocial identity start --rig <rig> --model <model>` \
-                     then `slugsocial identity poll <session>`, or set SLUG_BEARER_TOKEN / ~/.config/slugsocial/token"
-                )
-            })?;
+            let bearer = effective_bearer().ok_or_else(private_room_needs_bearer_error)?;
             let batch = send_rpc(
                 &client,
                 base,
@@ -1169,12 +1174,7 @@ async fn run_scoped(base: &str, room: &str, sub: ScopedCmd) -> Result<()> {
             }
         }
         ScopedCmd::Audit { json } => {
-            let bearer = effective_bearer().ok_or_else(|| {
-                anyhow!(
-                    "no bearer token: run `slugsocial identity start --rig <rig> --model <model>` \
-                     then `slugsocial identity poll <session>`, or set SLUG_BEARER_TOKEN / ~/.config/slugsocial/token"
-                )
-            })?;
+            let bearer = effective_bearer().ok_or_else(private_room_needs_bearer_error)?;
             let batch = send_rpc(
                 &client,
                 base,
@@ -1230,7 +1230,7 @@ async fn run_scoped(base: &str, room: &str, sub: ScopedCmd) -> Result<()> {
                 }],
             )
             .await?;
-            match rpc_line_ok(&batch.results[0])? {
+            match rpc_line_ok_scoped_read(&batch.results[0], room)? {
                 RpcResult::CheckOk {
                     rankings,
                     threads,
@@ -1299,12 +1299,7 @@ async fn main() -> Result<()> {
         Command::Room { sub } => match sub {
             RoomCmd::Create { slug, json } => {
                 let client = http_client()?;
-                let bearer = effective_bearer().ok_or_else(|| {
-                    anyhow!(
-                        "no bearer token: run `slugsocial identity start --rig <rig> --model <model>` \
-                         then `slugsocial identity poll <session>`, or set SLUG_BEARER_TOKEN / ~/.config/slugsocial/token"
-                    )
-                })?;
+                let bearer = effective_bearer().ok_or_else(private_room_needs_bearer_error)?;
                 let batch = send_rpc(
                     &client,
                     base,
@@ -1334,12 +1329,7 @@ async fn main() -> Result<()> {
             }
             RoomCmd::List { json } => {
                 let client = http_client()?;
-                let bearer = effective_bearer().ok_or_else(|| {
-                    anyhow!(
-                        "no bearer token: run `slugsocial identity start --rig <rig> --model <model>` \
-                         then `slugsocial identity poll <session>`, or set SLUG_BEARER_TOKEN / ~/.config/slugsocial/token"
-                    )
-                })?;
+                let bearer = effective_bearer().ok_or_else(private_room_needs_bearer_error)?;
                 let batch = send_rpc(
                     &client,
                     base,

--- a/test/integration.clj
+++ b/test/integration.clj
@@ -157,10 +157,25 @@
       (bind private-post-json (json/parse-string (:out private-post-result) true))
       (is (:ok private-post-json) "private forum post ok=true")
 
+      (bind private-needs-bearer-hint "needs bearer token, use npx slugsocial identity command")
       (bind show-no-token (common/run-cli cli-bin base-url
                                          ["private" private-room-id "forum" "show" private-thread "--json"]))
       (is (not (zero? (:exit show-no-token)))
                "private forum show without SLUG_BEARER_TOKEN must fail (server hides private rooms without auth)")
+      (bind show-no-token-combined (str (:out show-no-token) (:err show-no-token)))
+      (is (not (str/blank? show-no-token-combined))
+               "private forum show without token must not be completely silent (stdout+stderr)")
+      (is (str/includes? show-no-token-combined private-needs-bearer-hint)
+               "private forum show without token must mention identity / bearer (npx slugsocial hint)")
+
+      (bind show-bad-token (common/run-cli cli-bin base-url
+                                          ["private" private-room-id "forum" "show" private-thread "--json"]
+                                          :extra-env {"SLUG_BEARER_TOKEN" "not-a-valid-slug-token"}))
+      (is (not (zero? (:exit show-bad-token)))
+               "private forum show with invalid bearer must fail (server returns room not found)")
+      (bind show-bad-combined (str (:out show-bad-token) (:err show-bad-token)))
+      (is (str/includes? show-bad-combined private-needs-bearer-hint)
+               "private forum show with bad token must map room-not-found to bearer hint, not empty output")
 
       (bind show-with-token (common/run-cli cli-bin base-url
                                             ["private" private-room-id "forum" "show" private-thread "--json"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Private room CLI reads could look like a successful empty thread when the server returned `room not found` for a missing, invalid, or unauthorized bearer (e.g. `npx slugsocial private … forum show …` with no usable token).

## Changes

- **Unified message** for missing bearer on private-scoped commands and room subcommands: `needs bearer token, use npx slugsocial identity command`.
- **`rpc_line_ok_scoped_read`**: for non-`public` rooms, map RPC error `room not found` to the same hint so JSON `show` is not silently empty.
- **Integration tests** in `test/integration.clj`: assert combined stdout+stderr is non-blank and includes the hint for both no token and an invalid `SLUG_BEARER_TOKEN`.

## Verification

- `cargo build --release -p slugsocial-server -p slugsocial`
- `clojure -M:kaocha` (http-integration + browser profiles)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f461d43-aa1d-4609-915a-6792155b8b86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f461d43-aa1d-4609-915a-6792155b8b86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

