### PR TITLE
Delete room from manage panel (UI + RPC) with Playwright test

### DIFF
--- a/server/src/api/rpc.rs
+++ b/server/src/api/rpc.rs
@@ -237,6 +237,26 @@ pub async fn rpc_post_redact(
         .map_err(|_| ("writer dropped".into(), None))?
 }
 
+pub async fn rpc_room_delete(
+    state: &AppState,
+    headers: &HeaderMap,
+    room: String,
+) -> Result<RpcResult, RpcErr> {
+    let bearer = parse_bearer(headers).map_err(|(_, m)| (m, None))?;
+    let (tx, rx) = oneshot::channel();
+    state
+        .write_tx
+        .send(WriteCmd::RoomDelete {
+            room: room.trim().to_string(),
+            bearer,
+            reply: tx,
+        })
+        .await
+        .map_err(|_| ("writer unavailable".into(), None))?;
+    rx.await
+        .map_err(|_| ("writer dropped".into(), None))?
+}
+
 async fn rpc_post(
     state: &AppState,
     headers: &HeaderMap,
@@ -1103,6 +1123,10 @@ pub async fn handle_rpc_batch(
                     }
                 }
             }
+            RpcCommand::RoomDelete { room } => match rpc_room_delete(&state, &headers, room).await {
+                Ok(r) => line_ok(r),
+                Err((e, h)) => line_err(e, h),
+            },
             RpcCommand::RoomRevoke {
                 room,
                 username,

--- a/server/src/api/ui_html.rs
+++ b/server/src/api/ui_html.rs
@@ -15,7 +15,7 @@ use crate::{
     api::{
         auth::{resolve_web_session, WebSession},
         handle_rpc_batch,
-        rpc::{rpc_post_redact, rpc_post_with_bearer},
+        rpc::{rpc_post_redact, rpc_post_with_bearer, rpc_room_delete},
     },
     canonical_path::canonicalize_tag,
     html::{
@@ -154,11 +154,29 @@ async fn dispatch_ui_action(
                 drop(reduced);
                 return ui_js_warn("forbidden").into_response();
             }
-            let markup = room_members_section_markup(&reduced, &room_wire, expanded);
+            let markup = room_members_section_markup(&reduced, &room_wire, expanded, user);
             drop(reduced);
             JsBuilder::new()
                 .morph_selector("#room-members-section", markup)
                 .into_response()
+        }
+        HtmlUiAction::DeleteRoom { room } => {
+            let Some(session) = session else {
+                return js_redirect("/login").into_response();
+            };
+            let room = room.trim().to_string();
+            if room.is_empty() {
+                return ui_js_warn("missing room").into_response();
+            }
+            let h = headers_from_bearer(&session.bearer);
+            match rpc_room_delete(state, &h, room).await {
+                Ok(RpcResult::RoomDeletedOk {}) => js_redirect("/").into_response(),
+                Ok(_) => (StatusCode::BAD_REQUEST, "unexpected response").into_response(),
+                Err((msg, hint)) => {
+                    let detail = hint.as_deref().unwrap_or("");
+                    js_error("#errors", &msg, detail).into_response()
+                }
+            }
         }
         HtmlUiAction::SetNewThreadComposeExpanded { room_wire, expanded } => {
             let room_wire = room_wire.trim().to_string();

--- a/server/src/api/write_actor.rs
+++ b/server/src/api/write_actor.rs
@@ -7,7 +7,7 @@ use tokio::sync::mpsc;
 
 use crate::{
     dsl,
-    events::{AgentBound, Event, GrantAdded, Ingest, PostRedacted, UserRegistered},
+    events::{AgentBound, Event, GrantAdded, Ingest, PostRedacted, RoomDeleted, UserRegistered},
     html::JsBuilder,
     identity::parse_agent,
     path_types::CanonicalItemUrl,
@@ -520,6 +520,44 @@ pub async fn writer_actor(mut rx: mpsc::Receiver<WriteCmd>, state: AppState) {
                     reduced.apply_event(tc_ev);
                     reduced.apply_event(ga_ev);
                     Ok(RpcResult::RoomCreated { room_id })
+                }
+                .await;
+                let _ = reply.send(out);
+            }
+
+            WriteCmd::RoomDelete { room, bearer, reply } => {
+                let out = async {
+                    use crate::events::ThreadCapability;
+
+                    let mut reduced = state.reduced.write().await;
+                    let principal =
+                        verify_token(&reduced, &bearer).map_err(|(_, m)| (m, None))?;
+                    let room = room.trim().to_string();
+                    if !reduced.rooms.contains(&room) {
+                        return Err(("unknown room".into(), None));
+                    }
+                    if !reduced.user_has_cap(&room, &principal, ThreadCapability::Manage) {
+                        return Err(("requires Manage capability".into(), None));
+                    }
+                    let ev = Event::RoomDeleted(RoomDeleted {
+                        ts: now_ms(),
+                        room_id: room.clone(),
+                        deleted_by: principal,
+                    });
+                    state
+                        .event_log
+                        .append(&ev)
+                        .await
+                        .map_err(|e| (format!("{e}"), None))?;
+                    reduced.apply_event(ev);
+                    drop(reduced);
+
+                    {
+                        let mut inv = state.invites.write().await;
+                        inv.retain(|_, v| v.room_id != room);
+                    }
+
+                    Ok(RpcResult::RoomDeletedOk {})
                 }
                 .await;
                 let _ = reply.send(out);

--- a/server/src/events.rs
+++ b/server/src/events.rs
@@ -17,6 +17,7 @@ pub enum Event {
     TokenIssued(TokenIssued),
     AgentBound(AgentBound),
     RoomCreated(RoomCreated),
+    RoomDeleted(RoomDeleted),
     GrantAdded(GrantAdded),
     GrantRevoked(GrantRevoked),
     InviteMinted(InviteMinted),
@@ -68,6 +69,14 @@ pub struct RoomCreated {
     pub room_id: String,
     pub slug: String,
     pub owner: String,
+}
+
+/// Private room removed permanently (requires Manage; logged for replay).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RoomDeleted {
+    pub ts: i64,
+    pub room_id: String,
+    pub deleted_by: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/server/src/html/forum/access.rs
+++ b/server/src/html/forum/access.rs
@@ -14,3 +14,7 @@ pub(crate) fn user_can_view_room(reduced: &ReducerState, room_id: &str, username
 pub(crate) fn user_can_post_room(reduced: &ReducerState, room_id: &str, username: &str) -> bool {
     reduced.user_has_cap(room_id, username, ThreadCapability::Post)
 }
+
+pub(crate) fn user_can_manage_room(reduced: &ReducerState, room_id: &str, username: &str) -> bool {
+    reduced.user_has_cap(room_id, username, ThreadCapability::Manage)
+}

--- a/server/src/html/forum/room_members.rs
+++ b/server/src/html/forum/room_members.rs
@@ -5,6 +5,8 @@ use maud::{html, Markup};
 
 use crate::html::ui_action::{HtmlUiAction, UI_RPC_FIELD};
 
+use super::access::user_can_manage_room;
+
 #[derive(Clone)]
 pub(super) struct RoomMemberRow {
     pub(super) username: String,
@@ -72,11 +74,13 @@ pub(crate) fn room_members_section_markup(
     reduced: &ReducerState,
     room_id: &str,
     members_expanded: bool,
+    viewer: Option<&str>,
 ) -> Markup {
     let members = room_members_for_room(reduced, room_id);
     if members.is_empty() {
         return html! {};
     }
+    let can_delete = viewer.is_some_and(|u| user_can_manage_room(reduced, room_id, u));
     html! {
         div id="room-members-section" {
             @if members_expanded {
@@ -91,6 +95,16 @@ pub(crate) fn room_members_section_markup(
                 }
                 section class="room-members-panel" {
                     (room_members_inner(&members))
+                    @if can_delete {
+                        form method="POST" action="/ui" onsubmit="return confirm('Delete this room permanently? This cannot be undone.');" {
+                            input type="hidden" name=(UI_RPC_FIELD) value=(template_json_compact(&HtmlUiAction::DeleteRoom {
+                                room: room_id.to_string(),
+                            }).expect("static json"));
+                            p class="room-delete-actions" {
+                                button type="submit" class="danger" data-testid="delete-room" { "delete room" }
+                            }
+                        }
+                    }
                 }
             } @else {
                 form method="POST" action="/ui" {

--- a/server/src/html/forum/views.rs
+++ b/server/src/html/forum/views.rs
@@ -259,7 +259,8 @@ pub async fn room_page(
         drop(reduced);
         return (StatusCode::NOT_FOUND, "room not found").into_response();
     };
-    let members_markup = room_members_section_markup(&reduced, &room_id, false);
+    let members_markup =
+        room_members_section_markup(&reduced, &room_id, false, user.as_deref());
     let forum_cli = format!("npx slugsocial private {room_id} forum list");
     let garden_cli = format!("npx slugsocial private {room_id} garden tree");
     let audit_cli = format!("npx slugsocial private {room_id} audit");

--- a/server/src/html/mod.rs
+++ b/server/src/html/mod.rs
@@ -301,6 +301,7 @@ pub(super) fn layout(title: &str, view: &str, body: Markup, views: Option<u64>, 
                 @if let Some(n) = views {
                     span class="view-meta muted" { " · " (n) " views" }
                 }
+                div id="errors" {}
                 (body)
                 div id="controls" {
                     a href="https://github.com/sortersocial/slug" id="src-link" { "src" }

--- a/server/src/html/ui_action.rs
+++ b/server/src/html/ui_action.rs
@@ -44,6 +44,10 @@ pub enum HtmlUiAction {
         #[serde(default)]
         expanded: bool,
     },
+    /// Delete the private room (Manage only); redirects to `/` on success.
+    DeleteRoom {
+        room: String,
+    },
     /// Morph `#new-thread-ui-slot` inner — compose open or collapsed (`room_wire: "public"` for home).
     SetNewThreadComposeExpanded {
         room_wire: String,

--- a/server/src/reducer.rs
+++ b/server/src/reducer.rs
@@ -173,6 +173,9 @@ pub enum RoomTimelineKind {
         owner: String,
         slug: String,
     },
+    RoomDeleted {
+        deleted_by: String,
+    },
     GrantAdded {
         username: String,
         granted_by: String,
@@ -597,6 +600,39 @@ impl ReducerState {
         self.content.insert(scope, cs);
     }
 
+    /// Drop all reducer state keyed by a private room id (forum, garden scope, invites, grants).
+    fn purge_private_room(&mut self, room_id: &str) {
+        let scope = ScopeId::Room(room_id.to_string());
+        self.rooms.remove(room_id);
+        self.grants.remove(room_id);
+        self.room_timeline.remove(room_id);
+        self.invites.retain(|_, inv| inv.room_id != room_id);
+        self.content.remove(&scope);
+        self.forum_threads.retain(|(s, _), _| s != &scope);
+        self.ingests_by_scope_thread.retain(|(s, _), _| s != &scope);
+
+        let mut to_drop: Vec<String> = self
+            .ingests_by_id
+            .iter()
+            .filter(|(_, ing)| ing.room_id.trim() == room_id)
+            .map(|(id, _)| id.clone())
+            .collect();
+        to_drop.sort();
+        to_drop.dedup();
+        for id in to_drop {
+            if let Some(ing) = self.ingests_by_id.remove(&id) {
+                self.posts_by_actor
+                    .entry(ing.principal)
+                    .and_modify(|q| {
+                        q.retain(|x| x != &id);
+                    });
+            }
+            self.ingests_ordered.retain(|x| x != &id);
+            self.redacted_posts.remove(&id);
+            self.post_redact_ts.remove(&id);
+        }
+    }
+
     pub fn apply_event(&mut self, event: Event) {
         match event {
             Event::UserRegistered(ur) => {
@@ -629,6 +665,21 @@ impl ReducerState {
                             slug: rc.slug.clone(),
                         },
                     });
+            }
+            Event::RoomDeleted(rd) => {
+                let room_id = rd.room_id.clone();
+                if self.rooms.contains(&room_id) {
+                    self.room_timeline
+                        .entry(room_id.clone())
+                        .or_default()
+                        .push(RoomTimelineEntry {
+                            ts: rd.ts,
+                            kind: RoomTimelineKind::RoomDeleted {
+                                deleted_by: rd.deleted_by.clone(),
+                            },
+                        });
+                }
+                self.purge_private_room(&room_id);
             }
             Event::Ingest(mut ing) => {
                 ing.thread_tag = canonicalize_tag(&ing.thread_tag);

--- a/server/src/write_cmd.rs
+++ b/server/src/write_cmd.rs
@@ -24,6 +24,11 @@ pub enum WriteCmd {
         bearer: String,
         reply: oneshot::Sender<WriteCmdResult>,
     },
+    RoomDelete {
+        room: String,
+        bearer: String,
+        reply: oneshot::Sender<WriteCmdResult>,
+    },
     Grant {
         room: String,
         username: String,

--- a/server/static/theme_default.css
+++ b/server/static/theme_default.css
@@ -271,6 +271,16 @@ section.compose textarea:focus {
   color: var(--signal);
   font-family: var(--font-code);
 }
+.room-delete-actions {
+  margin-top: 12px;
+}
+button.danger {
+  border-color: var(--hi) var(--lo) var(--lo) var(--hi);
+  color: var(--signal);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 4px 10px;
+}
 .room-links {
   margin-top: 0;
 }

--- a/server/tests/integration.rs
+++ b/server/tests/integration.rs
@@ -150,6 +150,73 @@ async fn test_room_create_rpc() {
     );
 }
 
+#[tokio::test]
+async fn test_room_delete_rpc() {
+    let (addr, _tmp, _log, _handle) = create_test_server().await;
+    let client = reqwest::Client::new();
+    let bearer = test_bearer();
+
+    let create = rpc_batch(
+        &client,
+        addr,
+        Some(&bearer),
+        serde_json::json!([{
+            "RoomCreate": { "slug": "rpc-delete-me" }
+        }]),
+    )
+    .await;
+    let room_id = create["results"][0]["result"]["RoomCreated"]["room_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let del = rpc_batch(
+        &client,
+        addr,
+        Some(&bearer),
+        serde_json::json!([{
+            "RoomDelete": { "room": room_id }
+        }]),
+    )
+    .await;
+    assert_eq!(del["results"][0]["ok"], true, "{:?}", del["results"][0]);
+    assert!(
+        del["results"][0]["result"]["RoomDeletedOk"].is_object(),
+        "expected RoomDeletedOk: {:?}",
+        del["results"][0]
+    );
+
+    let list = rpc_batch(&client, addr, Some(&bearer), serde_json::json!(["RoomList"])).await;
+    let rooms = list["results"][0]["result"]["RoomList"]["rooms"]
+        .as_array()
+        .unwrap();
+    assert!(
+        !rooms.iter().any(|r| r.as_str() == Some(room_id.as_str())),
+        "deleted room should not appear in RoomList"
+    );
+
+    let thread = rpc_batch(
+        &client,
+        addr,
+        Some(&bearer),
+        serde_json::json!([{
+            "GetForumThread": {
+                "room": room_id,
+                "thread_tag": "x",
+                "offset": null,
+                "limit": null,
+                "since": null,
+                "before": null,
+                "actor": null,
+                "post_id": null
+            }
+        }]),
+    )
+    .await;
+    assert_eq!(thread["results"][0]["ok"], false);
+    assert_eq!(thread["results"][0]["error"], "room not found");
+}
+
 /// Private room reads use `authorize_room_read`, which returns "room not found" when no bearer is sent
 /// (same as unknown room). The CLI must attach the saved token for `private … forum show` etc.
 #[tokio::test]

--- a/test/browser_room_delete.clj
+++ b/test/browser_room_delete.clj
@@ -1,0 +1,98 @@
+(ns test.browser-room-delete
+  "Playwright (Spel): expand members panel, confirm delete room, land on home with room gone."
+  (:require [babashka.fs :as fs]
+            [cheshire.core :as json]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is]]
+            [com.blockether.spel.core :as core]
+            [com.blockether.spel.locator :as locator]
+            [com.blockether.spel.page :as page]
+            [test.common :as common]
+            [test.oauth :as oauth]))
+
+(defn- wait-for-text [pg selector expected timeout-ms]
+  (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+    (loop []
+      (let [text (locator/text-content (page/locator pg selector))]
+        (if (and (string? text) (str/includes? text expected))
+          true
+          (if (< (System/currentTimeMillis) deadline)
+            (do (Thread/sleep 200) (recur))
+            false))))))
+
+(defn delete-room-flow! []
+  (println "\n━━━ browser delete room (manage panel + POST /ui) ━━━\n")
+
+  (common/letlocals
+   (bind build (common/run-cargo-build-release! ["slugsocial-server"]))
+   (is (zero? (:exit build)) "cargo build succeeds")
+   (bind server-bin "target/release/slugsocial-server")
+
+   (bind tmp-dir (str (fs/create-temp-dir {:prefix "slug-browser-room-delete-"})))
+   (bind slug-port (common/pick-port))
+   (bind google-port (common/pick-port))
+   (bind base-url (str "http://127.0.0.1:" slug-port))
+   (bind google-url (str "http://127.0.0.1:" google-port))
+
+   (bind !server (atom nil))
+   (bind !google (atom nil))
+   (bind server-env (common/slug-server-env tmp-dir base-url google-url slug-port))
+   (try
+     (reset! !google (oauth/start-mock-google google-port
+                                              :google-users ["google-user-alice"]))
+     (reset! !server (common/start-server server-bin server-env))
+     (is (common/wait-for-server base-url 10000) "server responds to /healthz")
+
+     (let [alice-token (oauth/fetch-bearer-token! base-url :username "alice")
+           slug "pw-delete-room"
+           create (oauth/http-post-json
+                   (str base-url "/api/v0/rpc")
+                   [{"RoomCreate" {"slug" slug}}]
+                   :headers {"Authorization" (str "Bearer " alice-token)})
+           create-json (json/parse-string (:body create) false)
+           _ (is (true? (get-in create-json ["results" 0 "ok"])) "room created via rpc")
+           room-id (get-in create-json ["results" 0 "result" "RoomCreated" "room_id"])
+           _ (is (string? room-id) "room id present")
+           [room-short room-slug] (str/split room-id #"/" 2)
+           room-path (str "/r/" room-short "/" room-slug)]
+       (core/with-playwright [pw]
+         (core/with-browser [browser (core/launch-chromium pw {:headless true :channel "chrome"})]
+           (core/with-context [ctx (core/new-context browser)]
+             (core/with-page [pg (core/new-page-from-context ctx)]
+               (page/navigate pg (str base-url "/login"))
+               (is (wait-for-text pg "body" "@alice" 15000) "alice session after login")
+               (page/navigate pg (str base-url room-path))
+               (is (wait-for-text pg "body" "members & permissions" 15000)
+                   "room page shows members toggle")
+               ;; Do not use bare `.form-toggle`: the new-thread slot uses the same class.
+               (locator/click (page/locator pg "#room-members-section button.form-toggle"))
+               (is (wait-for-text pg "[data-testid=\"delete-room\"]" "delete room" 10000)
+                   "delete room button visible for manager")
+               (page/once-dialog pg (fn [d]
+                                      (is (= "confirm" (page/dialog-type d)) "browser confirm dialog")
+                                      (page/dialog-accept! d)))
+               (locator/click (page/locator pg "[data-testid=\"delete-room\"]"))
+               (is (wait-for-text pg "body" "slug.social" 15000)
+                   "redirected to home after delete")
+               (let [list-resp (oauth/http-post-json
+                                (str base-url "/api/v0/rpc")
+                                ["RoomList"]
+                                :headers {"Authorization" (str "Bearer " alice-token)})
+                     list-json (json/parse-string (:body list-resp) false)
+                     rooms (vec (get-in list-json ["results" 0 "result" "RoomList" "rooms"]))]
+                 (is (true? (get-in list-json ["results" 0 "ok"])) "RoomList ok after delete")
+                 (is (not (some #{room-id} rooms))
+                     "deleted room absent from RoomList")))))))
+
+     (finally
+       (when-some [s @!server] (common/kill-server s))
+       (when-some [g @!google] ((:stop-fn g)))
+       (fs/delete-tree tmp-dir)))
+
+   nil))
+
+(defn delete-room-via-ui-test [& _args]
+  (delete-room-flow!))
+
+(deftest browser-delete-room-check
+  (delete-room-flow!))

--- a/tests.edn
+++ b/tests.edn
@@ -15,7 +15,8 @@
    :source-paths ["."]
    :ns-patterns ["^test\\.browser-sse$"
                  "^test\\.browser-ui-morph$"
-                 "^test\\.browser-post-redact$"]
+                 "^test\\.browser-post-redact$"
+                 "^test\\.browser-room-delete$"]
    :kaocha.filter/skip-meta [:skip]
    :parallel? false}]
  :plugins [:kaocha.plugin/junit-xml]

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -362,6 +362,10 @@ pub enum RpcCommand {
     },
     /// List rooms the authenticated principal has access to.
     RoomList,
+    /// Permanently delete a private room and all of its forum and garden data (requires Manage).
+    RoomDelete {
+        room: String,
+    },
     GetGlobalRank {
         room: String,
         #[serde(default)]
@@ -446,6 +450,7 @@ pub enum RpcResult {
     },
     RoomAudit(RoomAuditResponse),
     RoomList(RoomListResponse),
+    RoomDeletedOk {},
     GrantOk {},
     GlobalRank(GlobalRankResponse),
     Pair(PairResponse),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **delete room** control to the expanded **members & permissions** panel on private room pages. Deletion requires **Manage** and uses a browser `confirm()` before submitting.

## Implementation

- New durable event `RoomDeleted` plus reducer logic to remove the room id, grants, invites (replay map), forum/garden scope content, and all ingests for that room.
- `WriteCmd::RoomDelete` / `RpcCommand::RoomDelete` → `RoomDeletedOk` for CLI/API parity.
- `HtmlUiAction::DeleteRoom` handled by `POST /ui` (session bearer), redirects to `/` on success.
- Global `#errors` region in the page layout so failed UI actions can surface messages consistently.

## Tests

- **Spel / Playwright** (`test/browser_room_delete.clj`): expand members panel, accept confirm, assert redirect and `RoomList` no longer contains the room. Registered in Kaocha `:browser` suite (`tests.edn`).
- **Rust integration** `test_room_delete_rpc`: RPC delete, list, and `GetForumThread` returns room not found.

Branch: `cursor/delete-room-button-1c5b` → `main`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12c5e7ba-f3d7-47bc-a794-94f4f4681c5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12c5e7ba-f3d7-47bc-a794-94f4f4681c5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

