### PR TITLE
Raise garden item body preview to 100k; clearer CLI truncation

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -273,7 +273,7 @@ enum GardenCmd {
 
     /// Body text for an item plus threads that mention it (connective tissue to forum).
     ///
-    /// Bodies longer than 10,000 characters are truncated by default.
+    /// Bodies longer than 100,000 characters are truncated by default.
     /// Use --full to retrieve the complete body.
     Body {
         /// Ontology path without shell `~` (e.g. `languages/python`). The CLI sends `~/…` to the API.
@@ -282,7 +282,7 @@ enum GardenCmd {
         /// Output as JSON for agent parsing
         #[arg(long)]
         json: bool,
-        /// Return the full body without truncation (default: bodies >10k chars are truncated)
+        /// Return the full body without truncation (default: bodies >100k chars are truncated)
         #[arg(long)]
         full: bool,
     },
@@ -365,7 +365,23 @@ fn print_item_response(resp: &ItemResponse) {
         println!("(no body)");
     }
     if resp.truncated {
-        eprintln!("[truncated: showing first 10,000 of {} chars — use --full for complete body]", resp.body_len);
+        let w = 72_usize;
+        let bar = "=".repeat(w);
+        eprintln!();
+        eprintln!("{bar}");
+        eprintln!(
+            "*** BODY TRUNCATED ***  first {} of {} characters shown",
+            MAX_ITEM_BODY_PREVIEW_CHARS, resp.body_len
+        );
+        eprintln!("The text above ends abruptly — more content exists on the server.");
+        eprintln!("Re-run this command with `--full` to print the complete body.");
+        eprintln!("{bar}");
+        eprintln!();
+        println!();
+        println!(
+            "^^^ OUTPUT CUT ABOVE ({}/{} chars) — use --full for the rest ^^^",
+            MAX_ITEM_BODY_PREVIEW_CHARS, resp.body_len
+        );
     }
     if !resp.threads.is_empty() {
         println!();

--- a/server/src/api/rpc.rs
+++ b/server/src/api/rpc.rs
@@ -864,14 +864,17 @@ pub async fn handle_rpc_batch(
                         Some(format!("{} does not exist", GardenItemUrl::from_storage_str(&item_str, &room))),
                     )
                 } else {
-                    const MAX_ITEM_BODY: usize = 10_000;
                     let want_full = full.unwrap_or(false);
                     let (body, truncated, body_len) = match content.item_bodies.get(&item) {
                         None => (None, false, 0),
                         Some(raw) => {
                             let char_len = raw.chars().count();
-                            if !want_full && char_len > MAX_ITEM_BODY {
-                                let byte_end = raw.char_indices().nth(MAX_ITEM_BODY).map(|(i, _)| i).unwrap_or(raw.len());
+                            if !want_full && char_len > MAX_ITEM_BODY_PREVIEW_CHARS {
+                                let byte_end = raw
+                                    .char_indices()
+                                    .nth(MAX_ITEM_BODY_PREVIEW_CHARS)
+                                    .map(|(i, _)| i)
+                                    .unwrap_or(raw.len());
                                 (Some(raw[..byte_end].to_string()), true, char_len)
                             } else {
                                 (Some(raw.clone()), false, 0)

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -8,6 +8,9 @@ pub use paths::{
     ForumThreadUrl, GardenItemUrl, RelativePath, TildeOntologyPath, TildePath,
 };
 
+/// Max characters returned for a garden item body unless `full=true` / `--full` (API + CLI).
+pub const MAX_ITEM_BODY_PREVIEW_CHARS: usize = 100_000;
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ApiError {
     pub ok: bool,
@@ -187,6 +190,7 @@ pub struct ItemResponse {
     pub item: GardenItemUrl,
     pub body: Option<String>,
     /// True when the body was truncated due to size. Fetch with `?full=true` for the complete body.
+    /// The limit is `MAX_ITEM_BODY_PREVIEW_CHARS` in the `slug_types` crate.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub truncated: bool,
     /// Total character length of the full body (present when truncated=true).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- **10× higher preview threshold**: Garden item bodies now truncate only above **100,000 characters** (was 10,000). The limit lives in `slug-types` as `MAX_ITEM_BODY_PREVIEW_CHARS` so the API and CLI stay aligned.
- **More obvious CLI output**: When a body is truncated, stderr prints a bordered banner (`BODY TRUNCATED`, counts, reminder to use `--full`), and stdout gets an extra separator line so the cut is hard to miss.

## Testing
- `cargo build` and `cargo test` (workspace) pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd30433b-a1e8-45ec-abe4-42b1e0d2580f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd30433b-a1e8-45ec-abe4-42b1e0d2580f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

