### PR TITLE
Garden + forum: 100k item preview, 20k forum post preview, clearer UI

### DIFF
--- a/server/src/api/rpc.rs
+++ b/server/src/api/rpc.rs
@@ -514,7 +514,6 @@ fn rpc_forum_thread_detail(
         .collect();
 
     let total = filtered.len();
-    const MAX_BODY: usize = 2000;
     let items: Vec<ThreadItem> = filtered
         .into_iter()
         .skip(offset)
@@ -528,10 +527,19 @@ fn rpc_forum_thread_detail(
             };
             let (body, truncated) = if redacted {
                 (String::new(), false)
-            } else if ing.raw.len() > MAX_BODY {
-                (ing.raw[..MAX_BODY].to_string(), true)
             } else {
-                (ing.raw.clone(), false)
+                let char_len = ing.raw.chars().count();
+                if char_len > MAX_FORUM_POST_PREVIEW_CHARS {
+                    let byte_end = ing
+                        .raw
+                        .char_indices()
+                        .nth(MAX_FORUM_POST_PREVIEW_CHARS)
+                        .map(|(i, _)| i)
+                        .unwrap_or(ing.raw.len());
+                    (ing.raw[..byte_end].to_string(), true)
+                } else {
+                    (ing.raw.clone(), false)
+                }
             };
             ThreadItem::Post {
                 id: ing.id.clone(),

--- a/server/src/html/forum/ingest.rs
+++ b/server/src/html/forum/ingest.rs
@@ -3,6 +3,7 @@ use crate::form_template::template_json_compact;
 use crate::reducer::{scope_from_room_wire, ReducerState};
 use maud::{html, Markup};
 use serde_json::json;
+use slug_types::MAX_FORUM_POST_PREVIEW_CHARS;
 
 use crate::html::js_string_literal;
 use crate::html::ui_action::{HtmlUiAction, UI_RPC_FIELD};
@@ -147,23 +148,51 @@ pub(super) fn ingest_entry_markup(
             }
         }
     } else {
-        let truncated = ing.raw.len() > 2000;
-        let display_body = if truncated { &ing.raw[..2000] } else { &ing.raw[..] };
+        let char_len = ing.raw.chars().count();
+        let truncated = char_len > MAX_FORUM_POST_PREVIEW_CHARS;
+        let display_body = if truncated {
+            let byte_end = ing
+                .raw
+                .char_indices()
+                .nth(MAX_FORUM_POST_PREVIEW_CHARS)
+                .map(|(i, _)| i)
+                .unwrap_or(ing.raw.len());
+            &ing.raw[..byte_end]
+        } else {
+            &ing.raw[..]
+        };
+        let entry_class = if truncated {
+            "ingest-entry ingest-entry-truncated"
+        } else {
+            "ingest-entry"
+        };
         html! {
-            div class="ingest-entry" data-ingest-id=(ing.id) {
+            div class=(entry_class) data-ingest-id=(ing.id) {
                 (post_header_row(nav, tag, post_idx, ing, viewer, now, show_delete))
                 (render_linkified_with_embeds_in_scope(display_body, nav.garden_root_url()))
                 @if truncated {
-                    @let rpc_full = template_json_compact(&json!({
-                        "action": "expand_post_full",
-                        "room": nav.room_wire,
-                        "thread_tag": tag,
-                        "post_index": post_idx,
-                    })).unwrap();
-                    @let onclick_full = thread_ui_fetch_onclick(&rpc_full);
-                    a href="#" class="show-full-link"
-                      onclick=(onclick_full) {
-                        "[show full post]"
+                    div class="post-truncation-banner" role="note" {
+                        p.post-truncation-title { "Long post — preview ends here" }
+                        p class="post-truncation-meta muted" {
+                            "Showing first "
+                            (MAX_FORUM_POST_PREVIEW_CHARS)
+                            " of "
+                            (char_len)
+                            " characters (body continues below the fold)."
+                        }
+                        @let rpc_full = template_json_compact(&json!({
+                            "action": "expand_post_full",
+                            "room": nav.room_wire,
+                            "thread_tag": tag,
+                            "post_index": post_idx,
+                        })).unwrap();
+                        @let onclick_full = thread_ui_fetch_onclick(&rpc_full);
+                        p.post-truncation-action {
+                            a href="#" class="show-full-link"
+                              onclick=(onclick_full) {
+                                "[show full post]"
+                            }
+                        }
                     }
                 }
             }

--- a/server/static/theme_default.css
+++ b/server/static/theme_default.css
@@ -522,6 +522,28 @@ div.ingest-entry {
   min-width: 100%;
   max-width: 100%;
 }
+div.ingest-entry-truncated {
+  border-left: 4px solid var(--signal);
+}
+div.post-truncation-banner {
+  background: var(--g3);
+  border-top: 2px dashed var(--lo);
+  padding: 8px 10px 10px;
+}
+p.post-truncation-title {
+  color: var(--signal);
+  font-size: 13px;
+  font-weight: bold;
+  margin: 0 0 4px;
+}
+p.post-truncation-meta {
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0 0 8px;
+}
+p.post-truncation-action {
+  margin: 0;
+}
 /* Slug links in pre: always link-colored, no underline */
 pre a.pre-link {
   color: var(--link);

--- a/server/static/theme_retro_craft.css
+++ b/server/static/theme_retro_craft.css
@@ -109,6 +109,28 @@ div.ingest-entry {
   min-width: 0;
   width: 100%;
 }
+div.ingest-entry-truncated {
+  border-left: 4px solid var(--accent);
+}
+div.post-truncation-banner {
+  background: rgba(0, 0, 0, 0.15);
+  border-top: 2px dashed var(--line);
+  padding: 0.5rem 0.65rem 0.65rem;
+}
+p.post-truncation-title {
+  color: var(--accent);
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin: 0 0 0.35rem;
+}
+p.post-truncation-meta {
+  font-size: 0.78rem;
+  line-height: 1.35;
+  margin: 0 0 0.5rem;
+}
+p.post-truncation-action {
+  margin: 0;
+}
 div.ingest-meta {
   border-bottom: 1px solid var(--line);
   padding: 0.35rem 0.65rem;

--- a/test/browser_ui_morph.clj
+++ b/test/browser_ui_morph.clj
@@ -46,10 +46,10 @@
 
      (let [alice-token (oauth/fetch-bearer-token! base-url :username "alice")
            thread-tag "ui-morph-long"
-           ;; Truncation kicks in when ing.raw len > 2000 (forum markup).
+           ;; Truncation kicks in when char count > 20,000 (forum markup).
            tail "END_UI_MORPH_TAIL_MARKER"
            long-body (str "# " thread-tag "\n\n"
-                          (str/join (repeat 400 "abcdefghij"))
+                          (str/join (repeat 3000 "abcdefghij"))
                           tail)
            post-resp (oauth/http-post-json
                       (str base-url "/api/v0/rpc")

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -11,6 +11,9 @@ pub use paths::{
 /// Max characters returned for a garden item body unless `full=true` / `--full` (API + CLI).
 pub const MAX_ITEM_BODY_PREVIEW_CHARS: usize = 100_000;
 
+/// Max characters shown for a forum post in HTML and thread RPC until expanded (`expand_post_full`).
+pub const MAX_FORUM_POST_PREVIEW_CHARS: usize = 20_000;
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ApiError {
     pub ok: bool,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- **Garden CLI/API**: Item body preview limit is **100,000** characters (`MAX_ITEM_BODY_PREVIEW_CHARS`); CLI prints a clear banner when truncated.
- **Forum web UI**: Post preview limit raised from **2,000** to **20,000** characters (`MAX_FORUM_POST_PREVIEW_CHARS`, 10×). Preview slicing uses **Unicode character counts** (safe for multi-byte text).
- **Forum UX**: Truncated posts get class `ingest-entry-truncated` (accent left border), a **“Long post — preview ends here”** banner with character counts, then **[show full post]**.
- **Thread RPC**: `GetForumThread` uses the same 20k preview + truncation flag so JSON matches the HTML behavior.

## Testing
- `cargo test` (workspace) passes.
- `test/browser_ui_morph.clj` seed post extended so truncation still exercises `expand_post_full`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd30433b-a1e8-45ec-abe4-42b1e0d2580f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd30433b-a1e8-45ec-abe4-42b1e0d2580f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

