### PR TITLE
Reject 0:0 votes in DSL; align garden pair/rank path validation

### DIFF
--- a/server/src/api/helpers.rs
+++ b/server/src/api/helpers.rs
@@ -51,6 +51,30 @@ pub fn parse_parent_specs(parent: Option<&String>) -> Vec<String> {
     s.split(',').map(|x| x.trim().to_string()).filter(|x| !x.is_empty()).collect()
 }
 
+/// Validate multi-parent garden scopes against [`ContentState`]: every explicit parent path must be a
+/// known item id or at least have appeared as a parent with children in the graph (matches
+/// `GetGardenRank` semantics).
+pub fn validate_garden_parent_scope_paths(
+    content: &crate::reducer::ContentState,
+    specs: &[String],
+    is_global_rank_parent: bool,
+) -> Result<(), (String, Option<String>)> {
+    if is_global_rank_parent || specs.is_empty() {
+        return Ok(());
+    }
+    let none_exist = specs.iter().all(|spec| {
+        let Some(canon) = ItemId::parse(spec) else { return true };
+        !content.items.contains(&canon) && !content.item_children.contains_key(&canon)
+    });
+    if none_exist {
+        return Err((
+            "path not found".into(),
+            Some(format!("{} does not exist", specs.join(", "))),
+        ));
+    }
+    Ok(())
+}
+
 /// Apply offset+limit pagination to the flattened component rankings.
 pub fn paginate_rankings(
     components: Vec<RankComponent>,

--- a/server/src/api/rpc.rs
+++ b/server/src/api/rpc.rs
@@ -27,7 +27,8 @@ use crate::{
 use super::auth::{parse_bearer, verify_bearer_principal};
 use super::helpers::{
     compute_connectivity_stats, is_pair_voted, now_ms, paginate_rankings, parse_parent_specs,
-    pick_random_distinct_item_pair, resolve_item, vote_touches_path,
+    pick_random_distinct_item_pair, resolve_item, validate_garden_parent_scope_paths,
+    vote_touches_path,
 };
 use super::validate::validate_ingest_document;
 
@@ -148,19 +149,7 @@ fn build_rank_response_for_content(
     let specs = parse_parent_specs(parent_owned.as_ref());
     let is_global = parent.map(|p| p.trim() == "~").unwrap_or(false);
 
-    if !is_global && !specs.is_empty() {
-        let none_exist = specs.iter().all(|spec| {
-            let Some(canon) = ItemId::parse(spec) else { return true };
-            !content.items.contains(&canon) && !content.item_children.contains_key(&canon)
-        });
-        if none_exist {
-            return Err((
-                "path not found".into(),
-                Some(format!("{} does not exist", specs.join(", "))),
-            ));
-        }
-    }
-
+    validate_garden_parent_scope_paths(content, &specs, is_global)?;
     let depth = depth.max(1);
     let rankings = if is_global {
         let all_items: Vec<ItemId> = content.items.iter().cloned().collect();
@@ -704,6 +693,8 @@ async fn rpc_get_pair(state: &AppState, room: String, parent_path: String) -> Re
             Some(parent_path.clone())
         };
         let specs = parse_parent_specs(tmp.as_ref());
+        validate_garden_parent_scope_paths(content, &specs, false)?;
+
         if specs.is_empty() {
             content.ranking_group.idx_to_item.clone()
         } else {

--- a/server/src/dsl.rs
+++ b/server/src/dsl.rs
@@ -435,6 +435,11 @@ fn parse_item_statement(stripped: &str, masker: &BlockMasker) -> Result<Stmt, Ds
     // Otherwise parse comparison then "/item2" then REQUIRED body.
     let ((ratio_left, ratio_right), mut k) = parse_comparison_at(s, i)
         .ok_or_else(|| DslError::Parse(format!("invalid comparison near: {}", &s[i..])))?;
+    if ratio_left == 0 && ratio_right == 0 {
+        return Err(DslError::Parse(
+            "vote ratio 0:0 is invalid; use 1:1 for a tie or omit the vote".to_string(),
+        ));
+    }
     k = skip_ws(s, k);
     let (item2, mut m) = parse_item_name_at(s, k)
         .ok_or_else(|| DslError::Parse("invalid rhs item name".to_string()))?;
@@ -621,6 +626,18 @@ mod tests {
                 ratio_right: 1,
                 explanation: "because".to_string()
             }]
+        );
+    }
+
+    #[test]
+    fn parse_vote_rejects_zero_zero_ratio() {
+        let err = parse_full("~/a 0:0 ~/b {tie placeholder}").unwrap_err();
+        let msg = match err {
+            DslError::Parse(m) => m,
+        };
+        assert!(
+            msg.contains("0:0"),
+            "expected 0:0 rejection message, got: {msg}"
         );
     }
 

--- a/server/tests/basic.rs
+++ b/server/tests/basic.rs
@@ -506,21 +506,30 @@ fn reducer_malformed_ingest_is_skipped_no_panic() {
 }
 
 #[test]
-fn reducer_zero_zero_vote_ratio_normalizes_to_one_one() {
+fn dsl_parse_rejects_zero_zero_vote_ratio() {
+    let err = slugsocial_server::dsl::parse_full(
+        "~/t/a {a}\n~/t/b {b}\n~/t/a 0:0 ~/t/b {zero}\n",
+    )
+    .expect_err("0:0 vote must be rejected by the parser");
+    let msg = match err {
+        slugsocial_server::dsl::DslError::Parse(m) => m,
+    };
+    assert!(
+        msg.contains("0:0"),
+        "expected message about invalid 0:0 ratio, got: {msg}"
+    );
+
     let mut state = ReducerState::default();
     state.apply_event(ingest_event(
         1,
         "~/t/a {a}\n~/t/b {b}\n~/t/a 0:0 ~/t/b {zero}\n",
     ));
-    let group = &state.public().ranking_group;
-    let a_idx = group.item_to_idx[&item_id("https://slug.social/~/t/a")];
-    let b_idx = group.item_to_idx[&item_id("https://slug.social/~/t/b")];
-    // 0:0 should normalize to 1:1 — both directions should have weight
-    assert!(group.edges.contains_key(&(a_idx, b_idx)));
-    assert!(group.edges.contains_key(&(b_idx, a_idx)));
-    let w_ab = group.edges[&(a_idx, b_idx)];
-    let w_ba = group.edges[&(b_idx, a_idx)];
-    assert!((w_ab - w_ba).abs() < 1e-9, "0:0 should produce equal weights");
+    let content = state.public();
+    assert!(
+        content.items.is_empty() && content.ranking_group.idx_to_item.is_empty(),
+        "parse failure must skip entire ingest; got items={:?}",
+        content.items.len(),
+    );
 }
 
 #[test]

--- a/server/tests/integration.rs
+++ b/server/tests/integration.rs
@@ -1287,6 +1287,80 @@ async fn test_garden_item_pair_matchup_include_threads() {
     assert_eq!(first_thread, "sorting-hat", "vote should cite thread");
 }
 
+/// `GetGardenRank` and `GetPair` must agree on whether a parent path "exists" (empty garden).
+#[tokio::test]
+async fn test_garden_pair_and_rank_path_not_found_consistent() {
+    let (addr, _tmp, _log, _handle) = create_test_server().await;
+    let client = reqwest::Client::new();
+    let bad_parent = "https://slug.social/~/no_such_garden_parent_for_scope_test";
+
+    let rank = rpc_batch(
+        &client,
+        addr,
+        None,
+        serde_json::json!([{
+            "GetGardenRank": {
+                "room": "public",
+                "parent_path": bad_parent,
+                "depth": 1
+            }
+        }]),
+    )
+    .await;
+    let rank_line = &rank["results"][0];
+    assert_eq!(rank_line["ok"], false, "GetGardenRank: {:?}", rank_line);
+    assert_eq!(rank_line["error"], "path not found");
+
+    let pair = rpc_batch(
+        &client,
+        addr,
+        None,
+        serde_json::json!([{
+            "GetPair": {
+                "room": "public",
+                "parent_path": bad_parent
+            }
+        }]),
+    )
+    .await;
+    let pair_line = &pair["results"][0];
+    assert_eq!(pair_line["ok"], false, "GetPair: {:?}", pair_line);
+    assert_eq!(pair_line["error"], "path not found");
+
+    let ingest = rpc_batch(
+        &client,
+        addr,
+        Some(&test_bearer()),
+        serde_json::json!([{
+            "Post": {
+                "room": "public",
+                "thread_tag": "scope-a",
+                "delegate": "00000000-0000-0000-0000-000000000000:test:local/test",
+                "text": "~/no_such_garden_parent_for_scope_test/x {a}\n~/no_such_garden_parent_for_scope_test/y {b}\n",
+                "return_rank_diff": false
+            }
+        }]),
+    )
+    .await;
+    assert_eq!(ingest["results"][0]["ok"], true, "ingest: {:?}", ingest);
+
+    let pair2 = rpc_batch(
+        &client,
+        addr,
+        None,
+        serde_json::json!([{
+            "GetPair": {
+                "room": "public",
+                "parent_path": bad_parent
+            }
+        }]),
+    )
+    .await;
+    let pair2_line = &pair2["results"][0];
+    assert_eq!(pair2_line["ok"], true, "GetPair after parent materialized: {:?}", pair2_line);
+    assert!(pair2_line["result"]["Pair"].is_object());
+}
+
 #[tokio::test]
 async fn test_search_page_and_results() {
     // HTML search pages are offline during the auth-v3 refactor.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **DSL:** Vote ratios `0:0` are now a parse error with guidance to use `1:1` for a tie or omit the vote. A document containing `0:0` fails entirely (same as other parse failures), so no partial ingest applies.
- **API:** `validate_garden_parent_scope_paths` shares the same existence rules as `GetGardenRank`. `GetPair` calls it before resolving the pool, so an unknown parent returns **path not found** instead of **need at least 2 items under parent**.

## Tests

- Unit: `parse_vote_rejects_zero_zero_ratio` in `dsl.rs`; reducer ingest test `dsl_parse_rejects_zero_zero_vote_ratio` in `basic.rs`.
- Integration: `test_garden_pair_and_rank_path_not_found_consistent` asserts matching errors for rank vs pair on a bogus parent, then that pair succeeds after ingesting children under that parent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6742426e-c5ba-44f2-b183-6addd37aad20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6742426e-c5ba-44f2-b183-6addd37aad20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

