### PR TITLE
Add Cursor Cloud development environment instructions to AGENTS.md

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -51,3 +51,43 @@ Strict **CSP** that blocks `eval` would break the current app. Other projects ma
 | **Reducer projection** | **Derived** | Rebuilt from log on startup; not separately persisted |
 
 If you add a new ephemeral map or start persisting something that was RAM-only, **update this table and the code comments** (`server/src/state.rs` is a good anchor).
+
+---
+
+## Cursor Cloud specific instructions
+
+### Services
+
+**slugsocial-server** — single Rust binary, no external DB or message queue. Data stored in a local JSONL event log.
+
+### Running the dev server
+
+```
+mkdir -p dev-data
+SLUG_DATA_DIR=dev-data SLUG_KEYS=dev:dev PORT=8080 RUST_LOG=info cargo run -p slugsocial-server
+```
+
+For authenticated API testing, you need a mock Google OAuth. Start a mock on a free port (e.g. 9999) that returns a fake `id_token` at `POST /token` and redirects at `GET /o/oauth2/v2/auth`, then pass these env vars to the server:
+
+```
+SLUG_PUBLIC_URL=http://localhost:8080
+SLUG_GOOGLE_AUTH_URL=http://localhost:9999/o/oauth2/v2/auth
+SLUG_GOOGLE_TOKEN_URL=http://localhost:9999/token
+SLUG_GOOGLE_CLIENT_ID=mock
+SLUG_GOOGLE_CLIENT_SECRET=mock
+```
+
+After OAuth completes, the pending-session poll returns a `slug_…` bearer token for API calls.
+
+### Testing
+
+- **Rust tests:** `cargo nextest run --workspace` (163 tests; requires `cargo-nextest`)
+- **Clojure integration + browser tests:** `clojure -M:kaocha` (runs both `:http-integration` and `:browser` suites; the test harness builds release binaries, starts its own server instances with mock OAuth, and runs Playwright browser tests)
+- **Lint:** `cargo clippy --workspace` (warnings are expected; zero errors required)
+
+### Key caveats
+
+- The Clojure test harness (`clojure -M:kaocha`) builds release binaries itself via `cargo build --release`. On a cold workspace this can take ~30s. The binary path is `target/release/slugsocial-server`.
+- `bb dev` (Babashka) is a convenience wrapper around `cargo run` for local dev. It requires `bb` (Babashka) to be installed.
+- Bearer tokens use format `slug_<id>_<secret>` and are verified against the reducer state's `tokens_by_id` map. Raw API-key strings like "dev" won't work; you must complete the OAuth registration flow to get a valid token.
+- Node.js 24 + Playwright chromium are required for browser tests (`npx playwright install chromium`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `agents.md` with development environment documentation for cloud agents, including:

- How to run the dev server (with and without mock OAuth for auth testing)
- Testing commands: `cargo nextest run`, `clojure -M:kaocha`, `cargo clippy`
- Key caveats about bearer token format, Clojure test harness build behavior, and required tooling

This ensures future cloud agents can quickly orient themselves and run the full test suite without re-discovering these details.

**Evidence of working environment:**

[hello_world_demo.log](https://cursor.com/agents/bc-888e0718-876e-41a5-86da-b6b17c2639b8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_demo.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-888e0718-876e-41a5-86da-b6b17c2639b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-888e0718-876e-41a5-86da-b6b17c2639b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

