### PR TITLE
Post detail: breadcrumb includes post index, remove redundant heading

### DIFF
--- a/server/src/html/forum/feed.rs
+++ b/server/src/html/forum/feed.rs
@@ -223,7 +223,7 @@ pub async fn home(
         "view-thread",
         html! {
             (strip)
-            nav class="breadcrumb" { (bc_threads(None)) }
+            nav class="breadcrumb" { (bc_threads(None, None)) }
             @if !room_ids.is_empty() {
                 h2 { "your rooms" }
                 ul class="thread-feed" {

--- a/server/src/html/forum/page.rs
+++ b/server/src/html/forum/page.rs
@@ -29,7 +29,12 @@ pub(super) fn auth_strip(
     }
 }
 
-pub(super) fn bc_room(nav: &ThreadNav, room_slug: &str, thread_tag: Option<&str>) -> Markup {
+pub(super) fn bc_room(
+    nav: &ThreadNav,
+    room_slug: &str,
+    thread_tag: Option<&str>,
+    focused_post: Option<usize>,
+) -> Markup {
     html! {
         a href="/" { "slug.social" }
         @if let Some(t) = thread_tag {
@@ -38,7 +43,12 @@ pub(super) fn bc_room(nav: &ThreadNav, room_slug: &str, thread_tag: Option<&str>
                 nav.room_url(),
                 false,
             ))
-            (bc_segment(&format!("#{t}"), &nav.thread_url(t), true))
+            @if let Some(idx) = focused_post {
+                (bc_segment(&format!("#{t}"), &nav.thread_url(t), false))
+                (bc_segment(&format!("post #{idx}"), &nav.post_url(t, idx), true))
+            } @else {
+                (bc_segment(&format!("#{t}"), &nav.thread_url(t), true))
+            }
         } @else {
             (bc_segment(
                 &format!("room:{room_slug}"),

--- a/server/src/html/forum/post_single.rs
+++ b/server/src/html/forum/post_single.rs
@@ -32,7 +32,7 @@ async fn thread_post_view_inner(
     let index: usize = index_str.parse().unwrap_or(0);
     let scope = nav.scope();
     let now = now_ms();
-    let (ing, subtitle, body_markup) = {
+    let (ing, body_markup) = {
         let reduced = state.reduced.read().await;
         let ing = reduced
             .ingests_by_scope_thread
@@ -42,19 +42,19 @@ async fn thread_post_view_inner(
         let body = ing.as_ref().map(|i| {
             ingest_entry_markup(&nav, &tag, index, i, viewer.as_deref(), now, &reduced)
         });
-        (ing, None::<String>, body)
+        (ing, body)
     };
 
     let sc = nav.scope();
     let bc: Markup = match &sc {
-        ScopeId::Public => bc_threads(Some(&tag)),
+        ScopeId::Public => bc_threads(Some(&tag), Some(index)),
         ScopeId::Room(rid) => {
             let slug = if let Some((_, s)) = rid.split_once('/') {
                 s
             } else {
                 rid.as_str()
             };
-            bc_room(&nav, slug, Some(&tag))
+            bc_room(&nav, slug, Some(&tag), Some(index))
         }
     };
 
@@ -63,7 +63,6 @@ async fn thread_post_view_inner(
         "view-thread",
         html! {
             nav class="breadcrumb" { (bc) }
-            h2 { "#" (tag) @if let Some(sub) = &subtitle { ": " (sub) } " / post #" (index) }
             @if let (Some(_ing), Some(bm)) = (&ing, &body_markup) {
                 (bm)
             } @else {

--- a/server/src/html/forum/views.rs
+++ b/server/src/html/forum/views.rs
@@ -125,14 +125,14 @@ async fn thread_view_inner(
     let paginator_bot = render_thread_paginator(&nav, &tag, offset, total, false);
 
     let bc: Markup = match &sc {
-        ScopeId::Public => bc_threads(Some(&tag)),
+        ScopeId::Public => bc_threads(Some(&tag), None),
         ScopeId::Room(rid) => {
             let slug = if let Some((_, s)) = rid.split_once('/') {
                 s
             } else {
                 rid.as_str()
             };
-            bc_room(&nav, slug, Some(&tag))
+            bc_room(&nav, slug, Some(&tag), None)
         }
     };
 
@@ -279,7 +279,7 @@ pub async fn room_page(
         "view-thread",
         html! {
             (strip)
-            nav class="breadcrumb" { (bc_room(&nav, slug_display, None)) }
+            nav class="breadcrumb" { (bc_room(&nav, slug_display, None, None)) }
             (members_markup)
             h3 { "threads" }
             (render_thread_feed(Some(&nav), "room-thread-feed", &rows, now))

--- a/server/src/html/mod.rs
+++ b/server/src/html/mod.rs
@@ -389,18 +389,24 @@ fn bc_path(path: &OntologyPath) -> Markup {
     }
 }
 
-/// Render the thread path breadcrumb: `slug.social / #tag`
+/// Render the thread path breadcrumb: `slug.social / #tag` or `… / #tag / post #N` on a single post.
 /// Root link toggles to `/~` only at thread-root (`/`).
-pub(super) fn bc_threads(thread_tag: Option<&str>) -> Markup {
+pub(super) fn bc_threads(thread_tag: Option<&str>, focused_post: Option<usize>) -> Markup {
     let root_href = if thread_tag.is_some() { "/" } else { "/~" };
+    let root_is_current = thread_tag.is_none();
     html! {
-        @if thread_tag.is_none() {
+        @if root_is_current {
             a href=(root_href) class="bc-current" { "slug.social" }
         } @else {
             a href=(root_href) { "slug.social" }
         }
         @if let Some(tag) = thread_tag {
-            (bc_segment(&format!("#{tag}"), &format!("/t/{tag}"), true))
+            @if let Some(idx) = focused_post {
+                (bc_segment(&format!("#{tag}"), &format!("/t/{tag}"), false))
+                (bc_segment(&format!("post #{idx}"), &format!("/t/{tag}/{idx}"), true))
+            } @else {
+                (bc_segment(&format!("#{tag}"), &format!("/t/{tag}"), true))
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Single post pages** (`/t/:tag/:index` and room equivalents) no longer show an `h2` that duplicated the breadcrumb (tag + post index).
- **Breadcrumbs** on those pages now include a final segment `post #N` (current, self-linked) after the `#tag` link, so the trail matches the focused post.

## Implementation

- Extended `bc_threads` and `bc_room` with an optional `focused_post: Option<usize>`; thread list views pass `None`, post detail passes `Some(index)`.
- Document `<title>` is unchanged (`#tag / post #N`) for bookmarks and tabs.

## Testing

- `cargo test` in `server/` (all passed).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d5da97a-0b58-421d-9d61-56f1a95f4683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d5da97a-0b58-421d-9d61-56f1a95f4683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

