### PR TITLE
Add previous/next navigation on post detail pages

### DIFF
--- a/server/src/html/forum/paginator.rs
+++ b/server/src/html/forum/paginator.rs
@@ -4,6 +4,29 @@ use super::nav::ThreadNav;
 
 pub(super) const PAGE_SIZE: usize = 10;
 
+/// Prev/next links between chronological posts on a single-post (`/t/tag/N`) page.
+pub(super) fn render_post_permalink_nav(nav: &ThreadNav, tag: &str, index: usize, total: usize) -> Markup {
+    let prev_idx = index.checked_sub(1);
+    let next_idx = if index + 1 < total { Some(index + 1) } else { None };
+    html! {
+        div class="post-nav" {
+            @if let Some(i) = prev_idx {
+                a href=(nav.post_url(tag, i)) class="post-nav-btn" { "← previous" }
+            } @else {
+                a href="#" class="post-nav-btn disabled" { "← previous" }
+            }
+            span class="post-nav-pos muted" {
+                (index + 1) " / " (total)
+            }
+            @if let Some(i) = next_idx {
+                a href=(nav.post_url(tag, i)) class="post-nav-btn" { "next →" }
+            } @else {
+                a href="#" class="post-nav-btn disabled" { "next →" }
+            }
+        }
+    }
+}
+
 pub(super) fn render_thread_paginator(nav: &ThreadNav, tag: &str, offset: usize, total: usize, top: bool) -> Markup {
     let newer_offset = offset.checked_add(PAGE_SIZE).filter(|&o| o < total);
     let older_offset = if offset > 0 {

--- a/server/src/html/forum/post_single.rs
+++ b/server/src/html/forum/post_single.rs
@@ -14,6 +14,7 @@ use crate::state::AppState;
 use super::access::user_can_view_room;
 use super::ingest::ingest_entry_markup;
 use super::nav::ThreadNav;
+use super::paginator::render_post_permalink_nav;
 use super::page::bc_room;
 use super::views::room_not_found_page;
 use crate::html::{bc_threads, layout, now_ms, theme_from_jar, theme_next_from_uri};
@@ -32,17 +33,28 @@ async fn thread_post_view_inner(
     let index: usize = index_str.parse().unwrap_or(0);
     let scope = nav.scope();
     let now = now_ms();
-    let (ing, body_markup) = {
+    let (ing, body_markup, permalink_nav) = {
         let reduced = state.reduced.read().await;
-        let ing = reduced
+        let queue = reduced
             .ingests_by_scope_thread
-            .get(&(scope.clone(), tag.clone()))
+            .get(&(scope.clone(), tag.clone()));
+        let total_posts = queue.map(|q| q.len()).unwrap_or(0);
+        let ing = queue
             .and_then(|q| q.iter().rev().nth(index))
             .and_then(|id| reduced.ingests_by_id.get(id).cloned());
+        let nav_index = ing
+            .as_ref()
+            .and_then(|i| reduced.try_thread_post_index_chronological(&scope, &tag, &i.id))
+            .unwrap_or(index);
         let body = ing.as_ref().map(|i| {
-            ingest_entry_markup(&nav, &tag, index, i, viewer.as_deref(), now, &reduced)
+            ingest_entry_markup(&nav, &tag, nav_index, i, viewer.as_deref(), now, &reduced)
         });
-        (ing, body)
+        let permalink_nav = if total_posts > 1 {
+            Some(render_post_permalink_nav(&nav, &tag, nav_index, total_posts))
+        } else {
+            None
+        };
+        (ing, body, permalink_nav)
     };
 
     let sc = nav.scope();
@@ -64,7 +76,13 @@ async fn thread_post_view_inner(
         html! {
             nav class="breadcrumb" { (bc) }
             @if let (Some(_ing), Some(bm)) = (&ing, &body_markup) {
+                @if let Some(ref pn) = permalink_nav {
+                    (pn)
+                }
                 (bm)
+                @if let Some(pn) = permalink_nav {
+                    (pn)
+                }
             } @else {
                 p class="muted" { "post not found" }
             }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Single-post thread URLs (`/t/{tag}/{index}` and room-scoped `/r/.../t/{tag}/{index}`) now show a navigation bar when the thread has more than one post. **Previous** moves to the chronologically older post; **next** moves to the newer post, matching the same 0-based chronological indexing used elsewhere (thread permalinks, paginator).

The bar appears above and below the post so long posts still have controls after scrolling. Styling reuses the existing `post-nav` / `post-nav-btn` rules from the thread paginator.

## Implementation notes

- `render_post_permalink_nav` in `paginator.rs` builds the control row.
- Post detail markup uses `try_thread_post_index_chronological` for the in-post header index when resolving the ingest succeeds, so the displayed `#N` stays aligned with canonical ordering if the URL index ever diverges.

## Testing

- `cargo test` in `server/` (all tests passed).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d8d170e-c15c-4931-b58f-08e1ea65be01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d8d170e-c15c-4931-b58f-08e1ea65be01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

