### PR TITLE
Garden item page: sibling links row grouped by ranking

### DIFF
--- a/server/src/html/garden.rs
+++ b/server/src/html/garden.rs
@@ -12,7 +12,6 @@ use crate::{
     events::ThreadCapability,
     path_types::ItemId,
     reducer::{ContentState, ReducerState, ScopeId},
-    ranking::{connected_components_from_voted_pairs, ranked_items_subset},
     scope_rank::{build_children_rankings, ChildrenRankings},
     state::AppState,
     timeago,
@@ -474,13 +473,6 @@ pub async fn room_ontology_path(
     render_scope_view(state, GardenBrowsePath::Tilde(path), nav, jar, uri).await
 }
 
-#[derive(Debug, Clone)]
-struct SiblingRank {
-    position: usize,
-    component_size: usize,
-    sibling_total: usize,
-}
-
 /// One sibling link in the breadcrumb nav row (label is 1-based index within its ranking group).
 #[derive(Debug, Clone)]
 struct SiblingNavLink {
@@ -514,7 +506,6 @@ struct RankHistoryEntryView {
 struct ItemPageViewModel {
     item: String,
     body: Option<String>,
-    sibling_rank: Option<SiblingRank>,
     sibling_nav: Option<SiblingNavBar>,
     /// False at the tilde ontology root (`~/`): sibling-rank footnote does not apply.
     item_has_parent: bool,
@@ -522,68 +513,6 @@ struct ItemPageViewModel {
     rank_history: Vec<RankHistoryEntryView>,
     /// Forum threads that mention or vote on this item.
     threads: Vec<String>,
-}
-
-fn build_sibling_rank(
-    reduced: &crate::reducer::ReducerState,
-    scope: &ScopeId,
-    item: &ItemId,
-) -> Option<SiblingRank> {
-    let item = item.clone().normalized_storage();
-    let content = content_for_garden_view(reduced, scope);
-    let group = &content.ranking_group;
-    let parent = item.parent()?.normalized_storage();
-    let siblings: Vec<ItemId> = content
-        .item_children
-        .get(&parent)
-        .map(|s| s.iter().cloned().collect())
-        .unwrap_or_default();
-    if siblings.is_empty() {
-        return None;
-    }
-
-    let sibling_total = siblings.len();
-    let scoped_idxs: Vec<usize> = siblings
-        .iter()
-        .filter_map(|it| group.item_to_idx.get(it).copied())
-        .collect();
-    if scoped_idxs.is_empty() {
-        return None;
-    }
-    let current_idx = *group.item_to_idx.get(&item)?;
-    if !scoped_idxs.contains(&current_idx) {
-        return None;
-    }
-
-    let local_to_global: Vec<usize> = scoped_idxs.clone();
-    let global_to_local: std::collections::HashMap<usize, usize> = scoped_idxs
-        .iter()
-        .enumerate()
-        .map(|(local, global)| (*global, local))
-        .collect();
-    let current_local = *global_to_local.get(&current_idx)?;
-    let (comps_local, _) = connected_components_from_voted_pairs(
-        scoped_idxs.len(),
-        group.voted_pairs.iter().filter_map(|(i, j)| {
-            let li = global_to_local.get(i).copied()?;
-            let lj = global_to_local.get(j).copied()?;
-            Some((li, lj))
-        }),
-    );
-    let containing_comp = comps_local
-        .iter()
-        .find(|comp| comp.contains(&current_local))?;
-    let comp_global: Vec<usize> = containing_comp
-        .iter()
-        .filter_map(|li| local_to_global.get(*li).copied())
-        .collect();
-    let ranked = ranked_items_subset(group, &comp_global, 10000, 1e-8);
-    let position = ranked.iter().position(|r| r.item == item)? + 1;
-    Some(SiblingRank {
-        position,
-        component_size: ranked.len(),
-        sibling_total,
-    })
 }
 
 fn build_sibling_nav(
@@ -627,20 +556,24 @@ fn build_sibling_nav(
 
 fn sibling_nav_markup(nav: &ThreadNav, bar: &SiblingNavBar, current_item: &str) -> maud::Markup {
     html! {
-        nav class="ont-sibling-nav" aria-label="siblings under same parent" {
+        nav class="breadcrumb ont-sibling-nav" aria-label="siblings under same parent" {
             @for (gi, group) in bar.groups.iter().enumerate() {
                 @if gi > 0 {
-                    span class="ont-sibling-nav-sep" aria-hidden="true" { "·" }
+                    span class="bc-sep" aria-hidden="true" { " / " }
                 }
                 span class="ont-sibling-nav-group" {
                     @for (i, link) in group.links.iter().enumerate() {
+                        @if i > 0 {
+                            span class="bc-sep ont-sibling-nav-intra" aria-hidden="true" { " " }
+                        }
                         @let n = i + 1;
                         @let href = item_href(&link.path, nav);
+                        @let tip = item_display_path(&link.path);
                         @let is_current = link.path == current_item;
                         @if is_current {
-                            a class="ont-sibling-nav-link is-current" href=(href) aria-current="page" { (n) }
+                            a href=(href) class="bc-current" title=(tip) aria-current="page" { (n) }
                         } @else {
-                            a class="ont-sibling-nav-link" href=(href) { (n) }
+                            a href=(href) title=(tip) { (n) }
                         }
                     }
                 }
@@ -733,7 +666,6 @@ fn build_item_page_view_model(
             .get(&item_key)
             .cloned()
             .or_else(|| reduced.public().item_bodies.get(&item_key).cloned()),
-        sibling_rank: build_sibling_rank(reduced, scope, &item_key),
         sibling_nav,
         item_has_parent,
         child_rankings,
@@ -769,12 +701,7 @@ async fn render_scope_view(
             section class="ont-item-shell" {
                 header class="ont-item-meta" {
                     span class="ont-item-title" { (item_display_path(&model.item)) }
-                    @if let Some(rank) = &model.sibling_rank {
-                        span class="ont-rank-badge" {
-                            (format!("#{} of {}", rank.position, rank.component_size))
-                        }
-                        span class="muted" { (format!("({} siblings)", rank.sibling_total)) }
-                    } @else if model.item_has_parent {
+                    @if model.sibling_nav.is_none() && model.item_has_parent {
                         span class="muted" { "unranked among siblings" }
                     }
                 }
@@ -961,12 +888,12 @@ mod tests {
 
         let model = build_item_page_view_model(&reduced, &ScopeId::Public, "~/topic/a");
         assert_eq!(model.body.as_deref(), Some("alpha"));
-        assert!(model.sibling_rank.is_none());
+        assert!(model.sibling_nav.is_some());
         assert!(model.child_rankings.component_rankings.is_empty());
     }
 
     #[test]
-    fn item_page_model_computes_sibling_rank_in_component() {
+    fn item_page_model_computes_sibling_nav_in_component() {
         let mut reduced = ReducerState::default();
         apply_ingest(
             &mut reduced,
@@ -980,10 +907,6 @@ mod tests {
         );
 
         let model = build_item_page_view_model(&reduced, &ScopeId::Public, "~/topic/a");
-        let rank = model.sibling_rank.expect("expected sibling rank");
-        assert_eq!(rank.position, 1);
-        assert_eq!(rank.component_size, 2);
-        assert_eq!(rank.sibling_total, 3);
         let nav = model.sibling_nav.expect("expected sibling nav");
         assert_eq!(nav.groups.len(), 2);
         assert_eq!(nav.groups[0].links.len(), 2);

--- a/server/src/html/garden.rs
+++ b/server/src/html/garden.rs
@@ -481,6 +481,23 @@ struct SiblingRank {
     sibling_total: usize,
 }
 
+/// One sibling link in the breadcrumb nav row (label is 1-based index within its ranking group).
+#[derive(Debug, Clone)]
+struct SiblingNavLink {
+    path: String,
+}
+
+#[derive(Debug, Clone)]
+struct SiblingNavGroup {
+    links: Vec<SiblingNavLink>,
+}
+
+/// Siblings under the same parent, grouped like child rankings (components then isolates).
+#[derive(Debug, Clone)]
+struct SiblingNavBar {
+    groups: Vec<SiblingNavGroup>,
+}
+
 #[derive(Debug, Clone)]
 struct RankHistoryEntryView {
     ts: i64,
@@ -498,6 +515,7 @@ struct ItemPageViewModel {
     item: String,
     body: Option<String>,
     sibling_rank: Option<SiblingRank>,
+    sibling_nav: Option<SiblingNavBar>,
     /// False at the tilde ontology root (`~/`): sibling-rank footnote does not apply.
     item_has_parent: bool,
     child_rankings: ChildrenRankings,
@@ -568,6 +586,69 @@ fn build_sibling_rank(
     })
 }
 
+fn build_sibling_nav(
+    reduced: &crate::reducer::ReducerState,
+    scope: &ScopeId,
+    current: &ItemId,
+) -> Option<SiblingNavBar> {
+    let current = current.clone().normalized_storage();
+    let parent = current.parent()?.normalized_storage();
+    let content = content_for_garden_view(reduced, scope);
+    let rankings = build_children_rankings(content, &parent);
+    let mut groups: Vec<SiblingNavGroup> = Vec::new();
+    for comp in &rankings.component_rankings {
+        let links: Vec<SiblingNavLink> = comp
+            .ranked
+            .iter()
+            .map(|r| SiblingNavLink {
+                path: r.item.clone().normalized_storage().to_storage_string(),
+            })
+            .collect();
+        if !links.is_empty() {
+            groups.push(SiblingNavGroup { links });
+        }
+    }
+    if !rankings.unranked_items.is_empty() {
+        let links: Vec<SiblingNavLink> = rankings
+            .unranked_items
+            .iter()
+            .map(|u| SiblingNavLink {
+                path: u.clone().normalized_storage().to_storage_string(),
+            })
+            .collect();
+        groups.push(SiblingNavGroup { links });
+    }
+    let sibling_total: usize = groups.iter().map(|g| g.links.len()).sum();
+    if sibling_total <= 1 {
+        return None;
+    }
+    Some(SiblingNavBar { groups })
+}
+
+fn sibling_nav_markup(nav: &ThreadNav, bar: &SiblingNavBar, current_item: &str) -> maud::Markup {
+    html! {
+        nav class="ont-sibling-nav" aria-label="siblings under same parent" {
+            @for (gi, group) in bar.groups.iter().enumerate() {
+                @if gi > 0 {
+                    span class="ont-sibling-nav-sep" aria-hidden="true" { "·" }
+                }
+                span class="ont-sibling-nav-group" {
+                    @for (i, link) in group.links.iter().enumerate() {
+                        @let n = i + 1;
+                        @let href = item_href(&link.path, nav);
+                        @let is_current = link.path == current_item;
+                        @if is_current {
+                            a class="ont-sibling-nav-link is-current" href=(href) aria-current="page" { (n) }
+                        } @else {
+                            a class="ont-sibling-nav-link" href=(href) { (n) }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 fn build_rank_history(
     reduced: &crate::reducer::ReducerState,
     scope: &ScopeId,
@@ -634,6 +715,7 @@ fn build_item_page_view_model(
         .normalized_storage();
     let item_has_parent = item_key.parent().is_some();
     let child_rankings = build_children_rankings(content, &item_key);
+    let sibling_nav = build_sibling_nav(reduced, scope, &item_key);
 
     let rank_history = build_rank_history(reduced, scope, item_key.as_str());
 
@@ -652,6 +734,7 @@ fn build_item_page_view_model(
             .cloned()
             .or_else(|| reduced.public().item_bodies.get(&item_key).cloned()),
         sibling_rank: build_sibling_rank(reduced, scope, &item_key),
+        sibling_nav,
         item_has_parent,
         child_rankings,
         rank_history,
@@ -680,6 +763,9 @@ async fn render_scope_view(
         "view-ontology view-ontology-light",
         html! {
             nav class="breadcrumb" { (scoped_bc_path_for(&browse, &nav)) }
+            @if let Some(ref bar) = model.sibling_nav {
+                (sibling_nav_markup(&nav, bar, &model.item))
+            }
             section class="ont-item-shell" {
                 header class="ont-item-meta" {
                     span class="ont-item-title" { (item_display_path(&model.item)) }
@@ -898,6 +984,10 @@ mod tests {
         assert_eq!(rank.position, 1);
         assert_eq!(rank.component_size, 2);
         assert_eq!(rank.sibling_total, 3);
+        let nav = model.sibling_nav.expect("expected sibling nav");
+        assert_eq!(nav.groups.len(), 2);
+        assert_eq!(nav.groups[0].links.len(), 2);
+        assert_eq!(nav.groups[1].links.len(), 1);
     }
 
     #[test]

--- a/server/src/html/garden.rs
+++ b/server/src/html/garden.rs
@@ -559,7 +559,7 @@ fn sibling_nav_markup(nav: &ThreadNav, bar: &SiblingNavBar, current_item: &str) 
         nav class="breadcrumb ont-sibling-nav" aria-label="siblings under same parent" {
             @for (gi, group) in bar.groups.iter().enumerate() {
                 @if gi > 0 {
-                    span class="bc-sep" aria-hidden="true" { " / " }
+                    span class="ont-sibling-nav-group-sep" aria-hidden="true" { "·" }
                 }
                 span class="ont-sibling-nav-group" {
                     @for (i, link) in group.links.iter().enumerate() {
@@ -571,7 +571,7 @@ fn sibling_nav_markup(nav: &ThreadNav, bar: &SiblingNavBar, current_item: &str) 
                         @let tip = item_display_path(&link.path);
                         @let is_current = link.path == current_item;
                         @if is_current {
-                            a href=(href) class="bc-current" title=(tip) aria-current="page" { (n) }
+                            a href=(href) title=(tip) aria-current="page" { "[" (n) "]" }
                         } @else {
                             a href=(href) title=(tip) { (n) }
                         }

--- a/server/static/theme_default.css
+++ b/server/static/theme_default.css
@@ -801,6 +801,54 @@ details > summary::-webkit-details-marker { display: none; }
 .age-week   a { color: var(--link); }
 .age-old    a { color: var(--meta); }
 
+/* Sibling quick-nav on item pages (same grouping as ranked child groups) */
+nav.ont-sibling-nav {
+  align-items: center;
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 6px;
+  margin: 4px 0 8px;
+  overflow-x: auto;
+  padding: 2px 0;
+  white-space: nowrap;
+}
+span.ont-sibling-nav-sep {
+  color: var(--meta);
+  font-size: 14px;
+  padding: 0 2px;
+  user-select: none;
+}
+span.ont-sibling-nav-group {
+  align-items: center;
+  display: inline-flex;
+  flex-wrap: nowrap;
+  gap: 4px;
+}
+a.ont-sibling-nav-link {
+  background: var(--g3);
+  border: var(--bv) solid;
+  border-color: var(--hi) var(--lo) var(--lo) var(--hi);
+  color: var(--ui);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.2;
+  min-width: 1.6em;
+  padding: 2px 8px;
+  text-align: center;
+  text-decoration: none;
+}
+a.ont-sibling-nav-link:hover {
+  color: var(--signal);
+}
+a.ont-sibling-nav-link.is-current {
+  background: var(--g4);
+  border-color: var(--lo) var(--hi) var(--hi) var(--lo);
+  box-shadow: inset 0 0 0 1px var(--signal);
+  color: var(--signal);
+  cursor: default;
+  font-weight: 800;
+}
+
 /* ================================================================
    ONTOLOGY ITEM PAGE — DARK VARIANT (opt-in via body class)
    ================================================================ */

--- a/server/static/theme_default.css
+++ b/server/static/theme_default.css
@@ -821,6 +821,11 @@ nav.breadcrumb.ont-sibling-nav .ont-sibling-nav-group {
 nav.breadcrumb.ont-sibling-nav span.bc-sep.ont-sibling-nav-intra {
   padding: 0 1px;
 }
+nav.breadcrumb.ont-sibling-nav span.ont-sibling-nav-group-sep {
+  color: var(--meta);
+  padding: 0 6px;
+  user-select: none;
+}
 
 /* ================================================================
    ONTOLOGY ITEM PAGE — DARK VARIANT (opt-in via body class)

--- a/server/static/theme_default.css
+++ b/server/static/theme_default.css
@@ -801,52 +801,25 @@ details > summary::-webkit-details-marker { display: none; }
 .age-week   a { color: var(--link); }
 .age-old    a { color: var(--meta); }
 
-/* Sibling quick-nav on item pages (same grouping as ranked child groups) */
-nav.ont-sibling-nav {
-  align-items: center;
+/* Sibling quick-nav: second breadcrumb row (same link styling as nav.breadcrumb) */
+nav.breadcrumb.ont-sibling-nav {
+  margin-top: 0;
+  width: 100%;
+  max-width: 100%;
   display: flex;
   flex-wrap: nowrap;
-  gap: 6px;
-  margin: 4px 0 8px;
+  align-items: center;
+  gap: 0;
   overflow-x: auto;
-  padding: 2px 0;
   white-space: nowrap;
 }
-span.ont-sibling-nav-sep {
-  color: var(--meta);
-  font-size: 14px;
-  padding: 0 2px;
-  user-select: none;
-}
-span.ont-sibling-nav-group {
-  align-items: center;
+nav.breadcrumb.ont-sibling-nav .ont-sibling-nav-group {
   display: inline-flex;
+  align-items: center;
   flex-wrap: nowrap;
-  gap: 4px;
 }
-a.ont-sibling-nav-link {
-  background: var(--g3);
-  border: var(--bv) solid;
-  border-color: var(--hi) var(--lo) var(--lo) var(--hi);
-  color: var(--ui);
-  font-size: 12px;
-  font-weight: 600;
-  line-height: 1.2;
-  min-width: 1.6em;
-  padding: 2px 8px;
-  text-align: center;
-  text-decoration: none;
-}
-a.ont-sibling-nav-link:hover {
-  color: var(--signal);
-}
-a.ont-sibling-nav-link.is-current {
-  background: var(--g4);
-  border-color: var(--lo) var(--hi) var(--hi) var(--lo);
-  box-shadow: inset 0 0 0 1px var(--signal);
-  color: var(--signal);
-  cursor: default;
-  font-weight: 800;
+nav.breadcrumb.ont-sibling-nav span.bc-sep.ont-sibling-nav-intra {
+  padding: 0 1px;
 }
 
 /* ================================================================

--- a/server/static/theme_default.css
+++ b/server/static/theme_default.css
@@ -73,7 +73,12 @@ nav.breadcrumb {
   width: fit-content;
 }
 nav.breadcrumb a       { color: var(--ui); text-decoration: none; }
-nav.breadcrumb a:hover { color: var(--signal); }
+nav.breadcrumb a:hover {
+  color: var(--link);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
 nav.breadcrumb a.bc-current { color: var(--signal); }
 nav.breadcrumb .bc-sep { color: var(--meta); padding: 0 2px; }
 nav.breadcrumb .bc-side { margin-left: 8px; font-size: 12px; color: var(--meta); }
@@ -1182,6 +1187,13 @@ body.view-ontology.view-ontology-light .ont-item-content pre {
   background: var(--g1);
   border: 1px solid var(--lo);
   color: var(--code-fg);
+}
+/* Breadcrumb bar uses pale --g2; hover must stay darker than paper (not --signal-on-paper edge cases). */
+body.view-ontology.view-ontology-light nav.breadcrumb a:hover {
+  color: var(--link);
+}
+body.view-ontology.view-ontology-light nav.breadcrumb a.bc-current {
+  color: var(--signal);
 }
 body.view-ontology .age-fresh  a { color: #005500; }
 body.view-ontology .age-recent a { color: #003080; }

--- a/server/static/theme_retro.css
+++ b/server/static/theme_retro.css
@@ -127,8 +127,12 @@ body.view-ontology nav.breadcrumb a {
   color: #23a;
   text-decoration: none;
 }
-body.view-ontology nav.breadcrumb a:hover { color: #000; }
-body.view-ontology nav.breadcrumb a.bc-current { color: #000; font-weight: 600; }
+body.view-ontology nav.breadcrumb a:hover {
+  color: #0a4a9e;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+body.view-ontology nav.breadcrumb a.bc-current { color: #111; font-weight: 600; }
 body.view-ontology nav.breadcrumb .bc-sep { color: #888; padding: 0 2px; }
 
 nav.breadcrumb.ont-sibling-nav {

--- a/server/static/theme_retro.css
+++ b/server/static/theme_retro.css
@@ -150,6 +150,11 @@ nav.breadcrumb.ont-sibling-nav .ont-sibling-nav-group {
 nav.breadcrumb.ont-sibling-nav span.bc-sep.ont-sibling-nav-intra {
   padding: 0 1px;
 }
+nav.breadcrumb.ont-sibling-nav span.ont-sibling-nav-group-sep {
+  color: #888;
+  padding: 0 6px;
+  user-select: none;
+}
 
 #detail-pane {
   background: #f5f0e8;

--- a/server/static/theme_retro.css
+++ b/server/static/theme_retro.css
@@ -118,6 +118,52 @@ body.view-ontology #controls {
   border-top: 1px solid #ccc;
 }
 
+nav.ont-sibling-nav {
+  align-items: center;
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 6px;
+  margin: 4px 0 8px;
+  overflow-x: auto;
+  padding: 2px 0;
+  white-space: nowrap;
+}
+span.ont-sibling-nav-sep {
+  color: #888;
+  font-size: 0.85rem;
+  padding: 0 2px;
+  user-select: none;
+}
+span.ont-sibling-nav-group {
+  align-items: center;
+  display: inline-flex;
+  flex-wrap: nowrap;
+  gap: 4px;
+}
+a.ont-sibling-nav-link {
+  background: #ede8df;
+  border: 1px solid #bbb;
+  color: #23a;
+  font-size: 0.78rem;
+  font-weight: 600;
+  line-height: 1.2;
+  min-width: 1.6em;
+  padding: 2px 8px;
+  text-align: center;
+  text-decoration: none;
+}
+a.ont-sibling-nav-link:hover {
+  border-color: #23a;
+}
+a.ont-sibling-nav-link.is-current {
+  background: #d8e4f8;
+  border-color: #23a;
+  box-shadow: inset 0 0 0 1px #23a;
+  color: #000;
+  cursor: default;
+  font-weight: 800;
+}
+
 #detail-pane {
   background: #f5f0e8;
   border-left: 1px solid #ccc;

--- a/server/static/theme_retro.css
+++ b/server/static/theme_retro.css
@@ -118,50 +118,37 @@ body.view-ontology #controls {
   border-top: 1px solid #ccc;
 }
 
-nav.ont-sibling-nav {
-  align-items: center;
-  display: flex;
-  flex-wrap: nowrap;
-  gap: 6px;
-  margin: 4px 0 8px;
-  overflow-x: auto;
-  padding: 2px 0;
-  white-space: nowrap;
-}
-span.ont-sibling-nav-sep {
-  color: #888;
+body.view-ontology nav.breadcrumb {
+  color: #666;
   font-size: 0.85rem;
-  padding: 0 2px;
-  user-select: none;
+  margin: 8px 0 0;
 }
-span.ont-sibling-nav-group {
-  align-items: center;
-  display: inline-flex;
-  flex-wrap: nowrap;
-  gap: 4px;
-}
-a.ont-sibling-nav-link {
-  background: #ede8df;
-  border: 1px solid #bbb;
+body.view-ontology nav.breadcrumb a {
   color: #23a;
-  font-size: 0.78rem;
-  font-weight: 600;
-  line-height: 1.2;
-  min-width: 1.6em;
-  padding: 2px 8px;
-  text-align: center;
   text-decoration: none;
 }
-a.ont-sibling-nav-link:hover {
-  border-color: #23a;
+body.view-ontology nav.breadcrumb a:hover { color: #000; }
+body.view-ontology nav.breadcrumb a.bc-current { color: #000; font-weight: 600; }
+body.view-ontology nav.breadcrumb .bc-sep { color: #888; padding: 0 2px; }
+
+nav.breadcrumb.ont-sibling-nav {
+  margin-top: 0;
+  width: 100%;
+  max-width: 100%;
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  gap: 0;
+  overflow-x: auto;
+  white-space: nowrap;
 }
-a.ont-sibling-nav-link.is-current {
-  background: #d8e4f8;
-  border-color: #23a;
-  box-shadow: inset 0 0 0 1px #23a;
-  color: #000;
-  cursor: default;
-  font-weight: 800;
+nav.breadcrumb.ont-sibling-nav .ont-sibling-nav-group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: nowrap;
+}
+nav.breadcrumb.ont-sibling-nav span.bc-sep.ont-sibling-nav-intra {
+  padding: 0 1px;
 }
 
 #detail-pane {

--- a/server/static/theme_retro_craft.css
+++ b/server/static/theme_retro_craft.css
@@ -510,6 +510,11 @@ nav.breadcrumb.ont-sibling-nav .ont-sibling-nav-group {
 nav.breadcrumb.ont-sibling-nav span.bc-sep.ont-sibling-nav-intra {
   padding: 0 1px;
 }
+nav.breadcrumb.ont-sibling-nav span.ont-sibling-nav-group-sep {
+  color: #8a857a;
+  padding: 0 6px;
+  user-select: none;
+}
 
 body.view-ontology {
   background: #ebe6dc;

--- a/server/static/theme_retro_craft.css
+++ b/server/static/theme_retro_craft.css
@@ -491,51 +491,24 @@ body.view-ontology-light .ont-tab.is-active {
   color: #1a1814;
 }
 
-nav.ont-sibling-nav {
-  align-items: center;
+nav.breadcrumb.ont-sibling-nav {
+  margin-top: 0;
+  width: 100%;
+  max-width: 100%;
   display: flex;
   flex-wrap: nowrap;
-  gap: 6px;
-  margin: 4px 0 8px;
+  align-items: center;
+  gap: 0;
   overflow-x: auto;
-  padding: 2px 0;
   white-space: nowrap;
 }
-span.ont-sibling-nav-sep {
-  color: #8a857a;
-  font-size: 0.85rem;
-  padding: 0 2px;
-  user-select: none;
-}
-span.ont-sibling-nav-group {
-  align-items: center;
+nav.breadcrumb.ont-sibling-nav .ont-sibling-nav-group {
   display: inline-flex;
+  align-items: center;
   flex-wrap: nowrap;
-  gap: 4px;
 }
-a.ont-sibling-nav-link {
-  background: #f0ebe2;
-  border: 1px solid #c8c4bc;
-  color: #1a4a8c;
-  font-size: 0.78rem;
-  font-weight: 600;
-  line-height: 1.2;
-  min-width: 1.6em;
-  padding: 2px 8px;
-  text-align: center;
-  text-decoration: none;
-}
-a.ont-sibling-nav-link:hover {
-  border-color: var(--accent);
-  color: var(--accent);
-}
-a.ont-sibling-nav-link.is-current {
-  background: #ebe6dc;
-  border-color: var(--accent);
-  box-shadow: inset 0 0 0 1px var(--accent);
-  color: #1a1814;
-  cursor: default;
-  font-weight: 800;
+nav.breadcrumb.ont-sibling-nav span.bc-sep.ont-sibling-nav-intra {
+  padding: 0 1px;
 }
 
 body.view-ontology {

--- a/server/static/theme_retro_craft.css
+++ b/server/static/theme_retro_craft.css
@@ -522,6 +522,25 @@ body.view-ontology {
   color-scheme: light;
 }
 body.view-ontology a { color: #1a4a8c; }
+/* Ontology pages are light; craft breadcrumb hover used --ink (light) and vanished on cream. */
+body.view-ontology nav.breadcrumb a {
+  color: #5c574e;
+  text-decoration: none;
+}
+body.view-ontology nav.breadcrumb a:hover {
+  color: #0d3d82;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+body.view-ontology nav.breadcrumb a.bc-current {
+  color: #1a1814;
+  font-weight: 600;
+}
+body.view-ontology nav.breadcrumb .bc-sep {
+  opacity: 0.55;
+  color: #6a655c;
+}
 body.view-ontology #controls {
   background: #f0ebe3;
   border-top: 1px solid #c8c4bc;

--- a/server/static/theme_retro_craft.css
+++ b/server/static/theme_retro_craft.css
@@ -491,6 +491,53 @@ body.view-ontology-light .ont-tab.is-active {
   color: #1a1814;
 }
 
+nav.ont-sibling-nav {
+  align-items: center;
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 6px;
+  margin: 4px 0 8px;
+  overflow-x: auto;
+  padding: 2px 0;
+  white-space: nowrap;
+}
+span.ont-sibling-nav-sep {
+  color: #8a857a;
+  font-size: 0.85rem;
+  padding: 0 2px;
+  user-select: none;
+}
+span.ont-sibling-nav-group {
+  align-items: center;
+  display: inline-flex;
+  flex-wrap: nowrap;
+  gap: 4px;
+}
+a.ont-sibling-nav-link {
+  background: #f0ebe2;
+  border: 1px solid #c8c4bc;
+  color: #1a4a8c;
+  font-size: 0.78rem;
+  font-weight: 600;
+  line-height: 1.2;
+  min-width: 1.6em;
+  padding: 2px 8px;
+  text-align: center;
+  text-decoration: none;
+}
+a.ont-sibling-nav-link:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+a.ont-sibling-nav-link.is-current {
+  background: #ebe6dc;
+  border-color: var(--accent);
+  box-shadow: inset 0 0 0 1px var(--accent);
+  color: #1a1814;
+  cursor: default;
+  font-weight: 800;
+}
+
 body.view-ontology {
   background: #ebe6dc;
   color: #1a1814;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Garden **item** pages show a **sibling quick-nav** row directly under the breadcrumb when the item has a parent and there are **two or more** siblings.

- **Grouping** matches ranked child groups: vote-connected components (rank order), then one block for all **unranked** siblings.
- **Link text** is `1`, `2`, `3`, … within each group; **between groups** a **middot** (·) with spacing.
- **Current sibling**: text **`[n]`** (no `bc-current` / distinct link styling); `aria-current="page"` retained.
- **`title` on each link**: display slug via `item_display_path`.
- **Header**: no redundant `#n of m (k siblings)` when nav is shown; **unranked among siblings** only when parent exists and nav is absent.

## Testing

`cargo test` in `server/` (all passed).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d8d170e-c15c-4931-b58f-08e1ea65be01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d8d170e-c15c-4931-b58f-08e1ea65be01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

