### PR TITLE
feat(html): native title tooltips on ~/ garden links

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -18,6 +18,7 @@ The web app is **not** a SPA with a JSON API for every interaction. Many mutatio
 
 - **End-to-end tests** that only assert HTTP status bodies miss DOM updates. Morph paths are covered by **Playwright / Spel** tests under `test/browser_*.clj` and `clojure -M -m test.runner …` (see `scripts/clj-test.sh`).
 - Shareable URLs are normal GET routes (e.g. `/t/:tag`, thread post views). **Expand/collapse** and similar controls are **actions**, not bookmarkable GET endpoints; they use the same `POST /ui` + `__rpc__` pattern where applicable.
+- Forum and garden item bodies use **`~/…` linkification** (`linkify_slugs_with_prefix` in `server/src/html/mod.rs`). When **`item_bodies`** is in scope, matching ontology links get a native **`title`** tooltip with a **truncated body preview** (hover in the browser).
 
 ---
 

--- a/server/src/html/forum/ingest.rs
+++ b/server/src/html/forum/ingest.rs
@@ -164,10 +164,11 @@ pub(crate) fn ingest_entry_markup(
         } else {
             "ingest-entry"
         };
+        let item_bodies = reduced.content_for_scope(&nav.scope()).map(|c| &c.item_bodies);
         html! {
             div class=(entry_class) data-ingest-id=(ing.id) {
                 (post_header_row(nav, tag, post_idx, ing, viewer, now, show_delete))
-                (render_linkified_with_embeds_in_scope(display_body, nav.garden_root_url()))
+                (render_linkified_with_embeds_in_scope(display_body, nav.garden_root_url(), item_bodies))
                 @if truncated {
                     div class="post-truncation-banner" role="note" {
                         p.post-truncation-title { "Long post — preview ends here" }

--- a/server/src/html/forum/thread_morph.rs
+++ b/server/src/html/forum/thread_morph.rs
@@ -1,4 +1,5 @@
 use maud::html;
+use std::collections::HashMap;
 
 use crate::canonical_path::canonicalize_tag;
 use crate::reducer::{scope_from_room_wire, ScopeId};
@@ -47,6 +48,9 @@ pub(crate) async fn thread_ui_expand_post_full(
     if reduced.redacted_posts.contains(&ing.id) {
         return crate::html::ui_js_warn("post not found");
     }
+    let item_bodies: Option<HashMap<crate::path_types::ItemId, String>> = reduced
+        .content_for_scope(&scope)
+        .map(|c| c.item_bodies.clone());
     let ing_id = ing.id.clone();
     drop(reduced);
 
@@ -61,7 +65,11 @@ pub(crate) async fn thread_ui_expand_post_full(
                 now,
                 viewer == Some(ing.principal.as_str()),
             ))
-            (render_linkified_with_embeds_in_scope(&ing.raw, nav.garden_root_url()))
+            (render_linkified_with_embeds_in_scope(
+                &ing.raw,
+                nav.garden_root_url(),
+                item_bodies.as_ref(),
+            ))
         }
     };
 
@@ -108,13 +116,20 @@ pub(crate) async fn thread_ui_expand_redacted_post(
     if !reduced.redacted_posts.contains(&ing.id) {
         return crate::html::ui_js_warn("post not found");
     }
+    let item_bodies: Option<HashMap<crate::path_types::ItemId, String>> = reduced
+        .content_for_scope(&scope)
+        .map(|c| c.item_bodies.clone());
     let ing_id = ing.id.clone();
     drop(reduced);
 
     let full_html = html! {
         div class="ingest-entry ingest-redacted-expanded" data-ingest-id=(ing_id) {
             (redacted_header_row(&nav, &tag, post_index, &ing, now, true))
-            (render_linkified_with_embeds_in_scope(&ing.raw, nav.garden_root_url()))
+            (render_linkified_with_embeds_in_scope(
+                &ing.raw,
+                nav.garden_root_url(),
+                item_bodies.as_ref(),
+            ))
         }
     };
 

--- a/server/src/html/garden.rs
+++ b/server/src/html/garden.rs
@@ -1094,7 +1094,11 @@ async fn render_scope_view(
                 }
                 @if let Some(body) = &model.body {
                     div class="ont-item-content" {
-                        (render_linkified_with_embeds_in_scope(body, nav.garden_root_url()))
+                        (render_linkified_with_embeds_in_scope(
+                            body,
+                            nav.garden_root_url(),
+                            Some(&scope_content.item_bodies),
+                        ))
                     }
                 } @else if external_empty_body {
                     div class="ont-item-content ont-external-empty" {

--- a/server/src/html/mod.rs
+++ b/server/src/html/mod.rs
@@ -8,7 +8,7 @@ use axum::{
 use axum_extra::extract::cookie::CookieJar;
 use maud::{html, Markup, DOCTYPE};
 use serde::Deserialize;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 mod auth;
 mod breadcrumb_path;
@@ -511,8 +511,49 @@ fn escape_html(s: &str) -> String {
     out
 }
 
+/// Max characters from an item body placed in a `title` tooltip (native hover).
+const ITEM_LINK_TITLE_MAX_CHARS: usize = 500;
+
+fn collapse_whitespace_for_title(s: &str) -> String {
+    let mut out = String::with_capacity(s.len().min(ITEM_LINK_TITLE_MAX_CHARS + 8));
+    let mut last_was_space = true;
+    for c in s.chars() {
+        if c.is_whitespace() {
+            if !last_was_space {
+                out.push(' ');
+                last_was_space = true;
+            }
+        } else {
+            out.push(c);
+            last_was_space = false;
+        }
+    }
+    out.trim().to_string()
+}
+
+fn item_body_title_snippet(body: &str) -> Option<String> {
+    let s = collapse_whitespace_for_title(body);
+    if s.is_empty() {
+        return None;
+    }
+    let truncated: String = s.chars().take(ITEM_LINK_TITLE_MAX_CHARS).collect();
+    let ellipsis = if s.chars().count() > ITEM_LINK_TITLE_MAX_CHARS {
+        "…"
+    } else {
+        ""
+    };
+    Some(format!("{truncated}{ellipsis}"))
+}
+
 /// Replace ~/path slugs in raw text with clickable links.
-pub(super) fn linkify_slugs_with_prefix(raw: &str, garden_prefix: &str) -> String {
+///
+/// When `item_bodies` is set, matching ontology items get a `title` attribute with a truncated
+/// body preview for native browser tooltips (forum posts, item pages).
+pub(super) fn linkify_slugs_with_prefix(
+    raw: &str,
+    garden_prefix: &str,
+    item_bodies: Option<&HashMap<crate::path_types::ItemId, String>>,
+) -> String {
     let escaped = escape_html(raw);
     let mut out = String::with_capacity(escaped.len() + 64);
     let mut i = 0;
@@ -531,7 +572,23 @@ pub(super) fn linkify_slugs_with_prefix(raw: &str, garden_prefix: &str) -> Strin
                 out.push_str(&escape_html(garden_prefix.trim_end_matches('/')));
                 out.push('/');
                 out.push_str(path);
-                out.push_str(r#"" class="pre-link">~/"#);
+                out.push('"');
+                out.push_str(r#" class="pre-link""#);
+                if let Some(bodies) = item_bodies {
+                    let tilde_ref = format!("~/{}", path);
+                    let key = slug_types::canonicalize_item(&tilde_ref);
+                    if let Some(id) = crate::path_types::ItemId::parse(&key) {
+                        if let Some(body) = bodies.get(&id) {
+                            if let Some(snippet) = item_body_title_snippet(body) {
+                                out.push_str(r#" title=""#);
+                                out.push_str(&escape_html(&snippet));
+                                out.push('"');
+                            }
+                        }
+                    }
+                }
+                out.push('>');
+                out.push_str("~/");
                 out.push_str(path);
                 out.push_str("</a>");
                 i += 2 + path_len;
@@ -659,10 +716,14 @@ fn extract_embed_frames(raw: &str) -> Vec<EmbedFrame> {
     out
 }
 
-pub(super) fn render_linkified_with_embeds_in_scope(raw: &str, garden_prefix: &str) -> Markup {
+pub(super) fn render_linkified_with_embeds_in_scope(
+    raw: &str,
+    garden_prefix: &str,
+    item_bodies: Option<&HashMap<crate::path_types::ItemId, String>>,
+) -> Markup {
     let embeds = extract_embed_frames(raw);
     html! {
-        pre { (maud::PreEscaped(linkify_slugs_with_prefix(raw, garden_prefix))) }
+        pre { (maud::PreEscaped(linkify_slugs_with_prefix(raw, garden_prefix, item_bodies))) }
         @if !embeds.is_empty() {
             div class="rich-embeds" {
                 @for e in embeds {
@@ -730,5 +791,32 @@ pub(super) fn recency_class(now_ms: i64, ts_ms: i64) -> &'static str {
         "age-week" // < 1 week
     } else {
         "age-old" // >= 1 week
+    }
+}
+
+#[cfg(test)]
+mod linkify_title_tests {
+    use super::*;
+    use crate::path_types::ItemId;
+    use std::collections::HashMap;
+
+    #[test]
+    fn tilde_link_gets_title_from_item_bodies() {
+        let mut bodies = HashMap::new();
+        let key = ItemId::parse(&slug_types::canonicalize_item("~/foo/bar")).unwrap();
+        bodies.insert(key, "Hello  world\nline".to_string());
+        let html = linkify_slugs_with_prefix(
+            "see ~/foo/bar ok",
+            "/r/x/~",
+            Some(&bodies),
+        );
+        assert!(html.contains("title=\"Hello world line\""));
+        assert!(html.contains("href=\"/r/x/~/foo/bar\""));
+    }
+
+    #[test]
+    fn no_title_when_body_missing_or_empty() {
+        let html = linkify_slugs_with_prefix("x ~/a/b y", "/~", Some(&HashMap::new()));
+        assert!(!html.contains(" title="));
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Forum posts and garden item pages now emit a **`title` attribute** on linkified `~/…` garden URLs when the server has an **item body** for that path in the current scope. Hovering shows a **native browser tooltip**: whitespace-collapsed preview, capped at **500 characters**.

## Implementation

- `linkify_slugs_with_prefix` accepts optional `item_bodies`; resolves `~/path` via `slug_types::canonicalize_item` + `ItemId::parse` for map lookup.
- `render_linkified_with_embeds_in_scope` passes the map through from forum ingest markup, thread morph (expand full / expand redacted), and garden item view.
- Morph handlers **clone** `item_bodies` before releasing the reducer lock so HTML construction does not borrow across `drop(reduced)`.
- `agents.md`: one bullet under Browser UI contract.
- Unit tests: `html::linkify_title_tests`.

## Changelog (live)

Posted to public `#changelog` on slug.social after push.

## Limitations (intentional for phase 1)

- Native tooltips only (no rich layout).
- Only `~/…` links in preformatted bodies; external identity URLs unchanged.
- Tooltip text is plain (HTML in bodies is escaped in attributes as usual).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e93f46c2-963a-48af-8f31-7792b4d8840e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e93f46c2-963a-48af-8f31-7792b4d8840e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

