### PR TITLE
Fix public forum thread SSE morph showing “thread not found”

### DIFF
--- a/server/src/html/forum/feed.rs
+++ b/server/src/html/forum/feed.rs
@@ -161,9 +161,11 @@ pub async fn thread_feed_region_markup(
     viewer: Option<&str>,
 ) -> Markup {
     let tag = canonicalize_tag(tag);
+    // `room_id` is the wire form (`short/slug` or `"public"`). `broadcast_web_refresh` passes
+    // `Some("public")` for the public forum; `ThreadNav::from_room_id` only accepts `short/slug`.
     let Some(nav) = (match room_id {
+        Some("public") | None => Some(ThreadNav::public()),
         Some(room_id) => ThreadNav::from_room_id(room_id),
-        None => Some(ThreadNav::public()),
     }) else {
         return html! { div id="thread-feed-region" { p class="muted" { "thread not found" } } };
     };

--- a/server/tests/integration.rs
+++ b/server/tests/integration.rs
@@ -939,6 +939,76 @@ async fn test_sse_stream_emits_evalable_js_after_post() {
 }
 
 #[tokio::test]
+async fn test_sse_public_thread_morph_includes_post_body_not_thread_not_found() {
+    let (addr, _tmp, _log, _state, _handle) = create_test_server_with_state().await;
+    let client = reqwest::Client::new();
+    let bearer = test_bearer();
+
+    let thread_tag = "sse-public-live";
+    let seed_text = "seed public thread for sse";
+
+    let rpc = ui_post_ingest_rpc("public", thread_tag, seed_text);
+    let _post = client
+        .post(format!("http://{addr}/ui"))
+        .header("Authorization", format!("Bearer {bearer}"))
+        .form(&[("__rpc__", rpc.as_str())])
+        .send()
+        .await
+        .unwrap();
+
+    let thread_path = format!("/t/{thread_tag}");
+    let sse_resp = client
+        .get(format!(
+            "http://{addr}/sse?path={}",
+            urlencoding::encode(&thread_path)
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert!(sse_resp.status().is_success());
+
+    let reply_text = "hello over sse from another tab";
+    let rpc2 = ui_post_ingest_rpc("public", thread_tag, reply_text);
+    let _post2 = client
+        .post(format!("http://{addr}/ui"))
+        .header("Authorization", format!("Bearer {bearer}"))
+        .form(&[("__rpc__", rpc2.as_str())])
+        .send()
+        .await
+        .unwrap();
+
+    let mut body = String::new();
+    let mut sse_resp = sse_resp;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while std::time::Instant::now() < deadline {
+        match tokio::time::timeout(std::time::Duration::from_millis(500), sse_resp.chunk()).await {
+            Ok(Ok(Some(chunk))) => {
+                body.push_str(&String::from_utf8_lossy(&chunk));
+                if body.contains("thread-feed-region") && body.contains(reply_text) {
+                    break;
+                }
+            }
+            Ok(Ok(None)) => break,
+            Ok(Err(err)) => panic!("sse read failed: {err}"),
+            Err(_) => {}
+        }
+    }
+    assert!(
+        body.contains(reply_text),
+        "sse morph should include new post text; got: {}",
+        if body.len() > 2000 {
+            format!("...{}", &body[body.len() - 2000..])
+        } else {
+            body.clone()
+        }
+    );
+    assert!(
+        !body.contains("thread not found"),
+        "public thread morph must not use broken nav (thread not found)"
+    );
+}
+
+#[tokio::test]
 async fn test_index_page() {
     // HTML routes are offline during the auth-v3 refactor.
 }

--- a/test/browser_sse.clj
+++ b/test/browser_sse.clj
@@ -114,8 +114,82 @@
 
    nil))
 
+(defn sse-public-browser-flow! []
+  "Regression: SSE morph for `/t/:tag` must use public ThreadNav (not `Some(\"public\")` → thread not found)."
+  (println "\n━━━ browser SSE public-thread check ━━━\n")
+
+  (common/letlocals
+   (bind build (common/run-cargo-build-release! ["slugsocial-server"]))
+   (is (zero? (:exit build)) "cargo build succeeds")
+   (bind server-bin "target/release/slugsocial-server")
+
+   (bind tmp-dir (str (fs/create-temp-dir {:prefix "slug-browser-sse-pub-"})))
+   (bind slug-port (common/pick-port))
+   (bind google-port (common/pick-port))
+   (bind base-url (str "http://127.0.0.1:" slug-port))
+   (bind google-url (str "http://127.0.0.1:" google-port))
+
+   (bind !server (atom nil))
+   (bind !google (atom nil))
+   (bind server-env (common/slug-server-env tmp-dir base-url google-url slug-port))
+   (try
+     (reset! !google (oauth/start-mock-google google-port
+                                              :google-users ["google-user-alice" "google-user-bob"]))
+     (reset! !server (common/start-server server-bin server-env))
+     (is (common/wait-for-server base-url 10000) "server responds to /healthz")
+
+     (let [_alice-token (oauth/fetch-bearer-token! base-url :username "alice")
+           _bob-token   (oauth/fetch-bearer-token! base-url :username "bob")
+           thread-tag    "pub-sse-live"
+           thread-url    (str base-url "/t/" thread-tag)]
+       (core/with-playwright [pw]
+         (core/with-browser [browser (core/launch-chromium pw {:headless true :channel "chrome"})]
+           (core/with-context [alice-ctx (core/new-context browser)]
+             (core/with-context [bob-ctx (core/new-context browser)]
+               (core/with-page [alice-pg (core/new-page-from-context alice-ctx)]
+                 (core/with-page [bob-pg (core/new-page-from-context bob-ctx)]
+                   (login-user! alice-pg base-url "alice")
+                   (login-user! bob-pg base-url "bob")
+
+                   (page/navigate alice-pg base-url)
+                   (page/wait-for-load-state alice-pg :load)
+                   (is (wait-for-text alice-pg "#new-thread-ui-slot" "+" 30000)
+                       "home has new-thread slot")
+                   (locator/click (page/locator alice-pg "#new-thread-ui-slot button.form-toggle"))
+                   (is (wait-for-text alice-pg "#new-thread-compose" "create thread / post" 30000)
+                       "compose expanded on home")
+                   (locator/fill (page/locator alice-pg "#new-thread-tag") thread-tag)
+                   (locator/fill (page/locator alice-pg "#new-thread-compose textarea") "seed public thread")
+                   (locator/click (page/locator alice-pg "#new-thread-form button[type='submit']"))
+                   (page/wait-for-url alice-pg thread-url {:timeout 90000.0})
+                   (page/wait-for-load-state alice-pg :load)
+                   (is (wait-for-text alice-pg "#thread-feed-region" "seed public thread" 45000)
+                       "alice sees first post on public thread")
+
+                   (page/navigate bob-pg thread-url)
+                   (page/wait-for-load-state bob-pg :load)
+                   (is (wait-for-text bob-pg "#thread-feed-region" "seed public thread" 45000)
+                       "bob sees seeded body before live update")
+
+                   (locator/fill (page/locator alice-pg "#thread-compose textarea")
+                                 "hello public thread over sse")
+                   (locator/click (page/locator alice-pg "#thread-compose button[type='submit']"))
+
+                   (is (wait-for-text bob-pg "#thread-feed-region" "hello public thread over sse" 45000)
+                       "bob sees alice reply via sse without refresh (public /t)"))))))))
+
+     (finally
+       (when-some [s @!server] (common/kill-server s))
+       (when-some [g @!google] ((:stop-fn g)))
+       (fs/delete-tree tmp-dir)))
+
+   nil))
+
 (defn private-thread-sse-browser-test [& _args]
   (sse-browser-flow!))
 
 (deftest browser-sse-private-thread-check
   (sse-browser-flow!))
+
+(deftest browser-sse-public-thread-check
+  (sse-public-browser-flow!))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When viewing a public forum thread (`/t/:tag`), the browser opens `EventSource('/sse?path=' + current URL)`. After someone else posts, `broadcast_web_refresh` pushes JS that morphs `#thread-feed-region` using `thread_feed_region_markup(state, Some("public"), ...)`.

That helper tried `ThreadNav::from_room_id("public")`, which fails because public rooms use the literal `"public"` wire id, not `short/slug`. The markup fell through to **thread not found**, replacing the real thread until refresh.

## Fix

Treat `Some("public")` the same as `None` (public scope) when resolving `ThreadNav`.

## Tests

- **Rust:** `test_sse_public_thread_morph_includes_post_body_not_thread_not_found` — subscribes to SSE on `/t/...`, POSTs a second ingest via `/ui`, asserts the streamed JS contains the new post text and not `thread not found`.
- **Clojure (Spel):** `browser-sse-public-thread-check` — Alice seeds a public thread from `/`, Bob watches `/t/...`, Alice replies; Bob sees the new body without refresh.

Branch: `cursor/fix-public-sse-thread-morph-6bf4`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a97c5d32-6b24-405a-8fc7-d66836136bf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a97c5d32-6b24-405a-8fc7-d66836136bf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

