### PR TITLE
fix(dsl): parse_full treats masked code fences as prose

### DIFF
--- a/server/src/dsl.rs
+++ b/server/src/dsl.rs
@@ -176,6 +176,19 @@ impl BlockMasker {
         }
         token.to_string()
     }
+
+    /// True if this token was produced by masking a markdown ``` … ``` fence (first pass of
+    /// `mask_all`). Such a line must not set `pending_block` in `parse_full` — it is prose, not a
+    /// vote explanation placeholder.
+    fn is_code_fence_placeholder(&self, token: &str) -> bool {
+        self.replacements
+            .get(token)
+            .map(|orig| {
+                let u = self.unmask(orig);
+                u.trim_start().starts_with("```")
+            })
+            .unwrap_or(false)
+    }
 }
 
 fn mask_all(mut masker: BlockMasker, text: &str) -> (BlockMasker, String) {
@@ -572,7 +585,11 @@ pub fn parse_full(text: &str) -> Result<Document, DslError> {
 
             if let Some((tok, end)) = parse_block_token_at(stripped, 0) {
                 if stripped[end..].trim().is_empty() {
-                    pending_block = Some(tok);
+                    if masker.is_code_fence_placeholder(&tok) {
+                        prose_buffer.push(line);
+                    } else {
+                        pending_block = Some(tok);
+                    }
                     continue;
                 }
             }
@@ -617,6 +634,31 @@ mod tests {
         assert!(masked.contains("__BLOCK_"));
         let roundtrip = masker.unmask(&masked);
         assert_eq!(roundtrip, input);
+    }
+
+    /// Regression: a standalone ``` fence masks to `__BLOCK_*` on its own line; that must not be
+    /// treated as a vote-explanation placeholder (which would reject the next `{...}` line).
+    #[test]
+    fn parse_full_prose_code_fence_then_vote() {
+        let input = concat!(
+            "~/a { a }\n",
+            "~/b { b }\n",
+            "\n",
+            "Some prose.\n",
+            "\n",
+            "```python\n",
+            "x = 1\n",
+            "```\n",
+            "\n",
+            "{ because }\n",
+            "~/a > ~/b\n",
+        );
+        let doc = parse_full(input).unwrap();
+        assert!(
+            doc.statements.iter().any(|s| matches!(s, Stmt::Vote { .. })),
+            "expected a vote in statements: {:?}",
+            doc.statements
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`parse_full` masks markdown ``` fences before `{` bodies. A multiline fence becomes a masked line that is only a `__BLOCK_*` token. That path incorrectly set `pending_block` (reserved for vote explanations), so a later `{explanation}` line before `~/a > ~/b` triggered **expected vote statement after leading explanation block**.

## Change

- Add `BlockMasker::is_code_fence_placeholder`: if the token’s stored original unmasks to text starting with ```, treat the line as prose instead of setting `pending_block`.
- Add `parse_full_prose_code_fence_then_vote` regression test.

## Note

`cargo run -p slugsocial -- public check` validates against the **remote** server; local `parse_full` is exercised by `cargo test -p slugsocial-server`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e93f46c2-963a-48af-8f31-7792b4d8840e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e93f46c2-963a-48af-8f31-7792b4d8840e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

