### PR TITLE
feat(scripts): OT legacy DSL translator + optional room import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ fixture-data/
 .specstory/
 .specstory/
 test/playwright/__pycache__/
+scripts/__pycache__/
 .claude/
 
 .cursor-screenshots/

--- a/scripts/requirements-translate.txt
+++ b/scripts/requirements-translate.txt
@@ -1,0 +1,2 @@
+# Optional: one-off legacy DSL translator (scripts/translate_ot_legacy_dsl.py)
+lark>=1.1.0,<2

--- a/scripts/translate_ot_legacy_dsl.py
+++ b/scripts/translate_ot_legacy_dsl.py
@@ -1,0 +1,591 @@
+#!/usr/bin/env python3
+"""
+Translate legacy ot.txt-style ingest `raw` bodies → modern Slug DSL (server-compatible).
+
+Uses **Lark** to classify each *brace-masked* line:
+  - **Legacy vote:** `~/a 3:1 ~/b __BLOCK__`  →  `__BLOCK__ ~/a 3:1 ~/b`
+  - **Modern vote:** `__BLOCK__ ~/a 3:1 ~/b`   → unchanged
+  - **Slash item:**  `/path` or `/path __BLOCK__` → `~/path` …
+
+Writes one `<thread>.sorter` per forum tag (concatenated ingests, separated by
+`--- ingest ---`). **`--check`** runs `slugsocial public check` on **cumulative**
+prefixes (simulates posting ingests in order). `_no_thread.sorter` is skipped.
+
+**`--post-room`** creates a private room (`room create <slug>`), then posts each
+ingest in **JSONL order** as a separate forum message so cross-thread item refs
+stay valid. Posts use `#<thread>` only (delegate via `--delegate` / `SLUG_DELEGATE`;
+no `@` line in the body). Ingests without `#thread` use `--default-thread`.
+
+Install:  pip install -r scripts/requirements-translate.txt
+
+Usage:
+  python3 scripts/translate_ot_legacy_dsl.py --input ot.txt --out-dir translated/
+  python3 scripts/translate_ot_legacy_dsl.py --input ot.txt --out-dir t/ --check
+  python3 scripts/translate_ot_legacy_dsl.py --input ot.txt --out-dir t/ \\
+    --post-room --room-slug ot-archive --delegate 'uuid:rig:provider/model'
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from lark import Lark, Token, Transformer, v_args
+
+# ---------------------------------------------------------------------------
+# Block masker (```, {{ }}, { }) — same order as server/src/dsl.rs
+# ---------------------------------------------------------------------------
+
+
+class BlockMasker:
+    def __init__(self) -> None:
+        self.replacements: Dict[str, str] = {}
+
+    def mask(self, text: str, open_marker: str, close_marker: str) -> str:
+        if not text:
+            return text
+        parts: List[str] = []
+        current_idx = 0
+        i = 0
+        depth = 0
+        start_idx = -1
+        is_toggle = open_marker == close_marker
+        ol, cl = len(open_marker), len(close_marker)
+        while i < len(text):
+            if depth > 0 and text.startswith(close_marker, i):
+                depth = 0 if is_toggle else depth - 1
+                i += cl
+                if depth == 0:
+                    tok = f"__BLOCK_{uuid.uuid4().hex[:8]}__"
+                    self.replacements[tok] = text[start_idx:i]
+                    parts.append(tok)
+                    current_idx = i
+                continue
+            if text.startswith(open_marker, i):
+                if depth == 0:
+                    parts.append(text[current_idx:i])
+                    start_idx = i
+                if is_toggle:
+                    if depth == 0:
+                        depth = 1
+                    else:
+                        depth = 0
+                else:
+                    depth += 1
+                i += ol
+                continue
+            i += 1
+        parts.append(text[current_idx:])
+        return "".join(parts)
+
+    def unmask(self, text: str) -> str:
+        result = text
+        while True:
+            n = 0
+            for tok, orig in self.replacements.items():
+                if tok in result:
+                    result = result.replace(tok, orig)
+                    n += 1
+            if n == 0:
+                break
+        return result
+
+
+def mask_all(text: str) -> Tuple[BlockMasker, str]:
+    m = BlockMasker()
+    t = m.mask(text, "```", "```")
+    t = m.mask(t, "{{", "}}")
+    t = m.mask(t, "{", "}")
+    return m, t
+
+
+# ---------------------------------------------------------------------------
+# Lark — single masked line
+# ---------------------------------------------------------------------------
+
+GRAMMAR = r"""
+start: vote_modern
+     | vote_legacy
+     | slash_item_blocked
+     | slash_item_plain
+
+vote_modern: BLOCK_TOKEN WS item WS comparison WS item
+
+vote_legacy: item WS comparison WS item WS BLOCK_TOKEN
+
+slash_item_blocked: "/" path_tail WS BLOCK_TOKEN
+slash_item_plain: "/" path_tail
+
+item: tilde_item | slash_path_item | dash_item | url_item
+tilde_item: "~/" path_tail
+slash_path_item: "/" path_tail
+dash_item: "-/" path_tail
+url_item: URL
+
+path_tail: PATH_SEG ("/" PATH_SEG)*
+PATH_SEG: /[a-zA-Z0-9_]+(-[a-zA-Z0-9_]+)*/
+
+comparison: RATIO | GT | LT | EQ
+RATIO: /\d+:\d+/
+GT: ">"
+LT: "<"
+EQ: "="
+
+BLOCK_TOKEN: /__BLOCK_[a-f0-9]{8}__/
+WS: /[ \t]+/
+URL: /https?:\/\/\S+/
+"""
+
+
+@v_args(inline=True)
+class LineEmit(Transformer):
+    def PATH_SEG(self, t: Token) -> str:
+        return str(t)
+
+    def path_tail(self, *segs: str) -> str:
+        return "/".join(segs)
+
+    def tilde_item(self, tail: str) -> str:
+        return "~/" + tail
+
+    def slash_path_item(self, tail: str) -> str:
+        return "~/" + tail
+
+    def dash_item(self, tail: str) -> str:
+        return "-/" + tail
+
+    def url_item(self, t: Token) -> str:
+        return str(t)
+
+    def item(self, x: str) -> str:
+        return x
+
+    def RATIO(self, t: Token) -> str:
+        return str(t)
+
+    def GT(self, _t: Token) -> str:
+        return ">"
+
+    def LT(self, _t: Token) -> str:
+        return "<"
+
+    def EQ(self, _t: Token) -> str:
+        return "="
+
+    def comparison(self, x: str) -> str:
+        return x
+
+    def BLOCK_TOKEN(self, t: Token) -> str:
+        return str(t)
+
+    def vote_modern(self, blk, _w1, a, _w2, comp, _w3, b) -> str:
+        return f"{blk} {a} {comp} {b}"
+
+    def vote_legacy(self, a, _w1, comp, _w2, b, _w3, blk) -> str:
+        return f"{blk} {a} {comp} {b}"
+
+    def slash_item_blocked(self, _slash, tail, _ws, blk) -> str:
+        return f"~/{tail} {blk}"
+
+    def slash_item_plain(self, _slash, tail) -> str:
+        return "~/" + tail
+
+    def start(self, x: str) -> str:
+        return x
+
+
+# Fallback when Lark rejects (e.g. lexer edge cases): legacy one-line vote after masking
+_LEGACY_VOTE_MASKED = re.compile(
+    r"^(\S.*?)\s+(\d+:\d+|[=<>])\s+(\S.*?)\s+(__BLOCK_[0-9a-f]{8}__)\s*$"
+)
+
+# Multiline legacy: ~/a 3:1 ~/b {\n ... \n}
+_VOTE_OPEN_MULTILINE = re.compile(
+    r"^(\s*)(\S.*?)\s+(\d+:\d+|[=<>])\s+(\S.*?)\s*\{\s*(.*)$"
+)
+
+
+def _is_item_path_token(s: str) -> bool:
+    t = s.strip()
+    return bool(
+        t.startswith("~/")
+        or t.startswith("http://")
+        or t.startswith("https://")
+        or t.startswith("-/")
+        or t.startswith("/")
+    )
+
+
+def _find_matching_brace(lines: List[str], start_i: int, start_depth: int) -> Optional[Tuple[int, int]]:
+    """First `}` that brings brace depth to 0; respects ``` fences. Returns (line_idx, col)."""
+    depth = start_depth
+    in_fence = False
+    j = start_i
+    while j < len(lines):
+        ln = lines[j]
+        if ln.lstrip().startswith("```"):
+            in_fence = not in_fence
+            j += 1
+            continue
+        if in_fence:
+            j += 1
+            continue
+        for k, ch in enumerate(ln):
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    return j, k
+        j += 1
+    return None
+
+
+def preprocess_vote_trailing_brace(text: str) -> str:
+    """Turn `~/a 3:1 ~/b { ... }` (possibly multiline) into `{...}\\n~/a 3:1 ~/b`."""
+    lines = text.split("\n")
+    out: List[str] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        m = _VOTE_OPEN_MULTILINE.match(line)
+        if m:
+            indent, left, comp, right, after_open = m.groups()
+            if _is_item_path_token(left) and _is_item_path_token(right):
+                open_idx = line.index("{")
+                first_frag = line[open_idx + 1 :]
+                close = _find_matching_brace(lines, i, start_depth=1)
+                if close is not None:
+                    cj, ck = close
+                    if cj == i:
+                        body_mid = line[open_idx + 1 : ck]
+                        tail = line[ck + 1 :].lstrip()
+                    else:
+                        body_parts = [first_frag] + lines[i + 1 : cj] + [lines[cj][:ck]]
+                        body_mid = "\n".join(body_parts)
+                        tail = lines[cj][ck + 1 :].lstrip()
+                    body = body_mid.strip("\n")
+                    vote_line = f"{indent}{left.strip()} {comp} {right.strip()}"
+                    out.append(f"{indent}{{{body}}}")
+                    out.append(vote_line)
+                    if tail:
+                        out.append(f"{indent}{tail}" if tail else "")
+                    i = cj + 1
+                    continue
+        out.append(line)
+        i += 1
+    return "\n".join(out)
+
+
+def normalize_item_ref(raw: str) -> str:
+    s = raw.strip()
+    if not s:
+        return s
+    if s.startswith(("https://", "http://", "-/", "~/")):
+        return s
+    if s.startswith("/") and not s.startswith("//"):
+        return "~" + s
+    return s
+
+
+_parser = Lark(GRAMMAR, parser="lalr", lexer="basic")
+_emit = LineEmit()
+
+
+def transform_masked_line(line: str) -> str:
+    if not line.strip():
+        return line
+    s = line.rstrip("\n")
+    try:
+        return _emit.transform(_parser.parse(s))
+    except Exception:
+        m = _LEGACY_VOTE_MASKED.match(s)
+        if m:
+            a, comp, b, blk = m.groups()
+            return f"{blk} {normalize_item_ref(a)} {comp} {normalize_item_ref(b)}"
+        return line
+
+
+def split_masked_vote_lines(masked: str) -> str:
+    """Rust parse_full: explanation __BLOCK__ must be its own line; vote on the next."""
+    vote_start = re.compile(r"^(~/|-/|https?://)")
+    out: List[str] = []
+    for line in masked.split("\n"):
+        s = line.strip()
+        m = re.match(r"^(__BLOCK_[0-9a-f]{8}__)\s+(.+)$", s)
+        if m and vote_start.search(m.group(2)):
+            blk, rest = m.group(1), m.group(2)
+            out.append(blk)
+            out.append(rest)
+        else:
+            out.append(line)
+    return "\n".join(out)
+
+
+def translate_raw_body(raw: str) -> Tuple[str, List[str]]:
+    warnings: List[str] = []
+    lines = raw.split("\n")
+    if not lines:
+        return raw, warnings
+
+    i0 = 0
+    if lines[0].lstrip().startswith("@"):
+        i0 = 1
+    if i0 < len(lines) and lines[i0].lstrip().startswith("#"):
+        i0 += 1
+
+    body = "\n".join(lines[i0:])
+    body = preprocess_vote_trailing_brace(body)
+    masker, masked = mask_all(body)
+    masked_lines = "\n".join(transform_masked_line(ln) for ln in masked.split("\n"))
+    masked_lines = split_masked_vote_lines(masked_lines)
+    out = masker.unmask(masked_lines)
+    return out, warnings
+
+
+def parse_ingest_lines(path: Path) -> List[dict]:
+    out: List[dict] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            o = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if o.get("type") == "ingest" and isinstance(o.get("raw"), str):
+            out.append(o)
+    return out
+
+
+def extract_thread_and_delegate(raw: str) -> Tuple[Optional[str], Optional[str]]:
+    lines = raw.split("\n")
+    delegate = None
+    i = 0
+    if lines and lines[0].lstrip().startswith("@"):
+        delegate = lines[0].strip()
+        i = 1
+    thread = None
+    if i < len(lines):
+        s = lines[i].lstrip()
+        if s.startswith("#"):
+            thread = s[1:].split(":")[0].split()[0].strip().lower()
+    return thread, delegate
+
+
+def strip_at_delegate(s: Optional[str]) -> str:
+    if not s:
+        return ""
+    t = s.strip()
+    if t.startswith("@@"):
+        return t[2:].lstrip()
+    if t.startswith("@"):
+        return t[1:].lstrip()
+    return t
+
+
+def format_forum_post(translated_body: str, thread_tag: str) -> str:
+    """Body for `forum post`: #thread then DSL/prose (no @ line — use CLI --delegate)."""
+    tag = thread_tag.strip().lower()
+    return f"#{tag}\n\n{translated_body.strip()}\n"
+
+
+def run_slugsocial(repo: Path, args: List[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["cargo", "run", "-q", "-p", "slugsocial", "--", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+
+def post_ingest_sequence(
+    repo: Path,
+    room_id: str,
+    delegate: str,
+    posts: List[Tuple[str, str]],
+    delay_s: float,
+    dry_run: bool,
+) -> int:
+    """posts: (thread_tag, body) in chronological order."""
+    del_st = strip_at_delegate(delegate)
+    if not del_st and not dry_run:
+        print("ERROR: --delegate or SLUG_DELEGATE is required for --post-room", file=sys.stderr)
+        return 1
+    scope = "public" if room_id == "public" else room_id
+    for i, (tag, body) in enumerate(posts):
+        if dry_run:
+            print(f"[dry-run] would post #{tag} ({i + 1}/{len(posts)})", file=sys.stderr)
+            continue
+        tmp = repo / f".ot-post-{i}.sorter"
+        tmp.write_text(body, encoding="utf-8")
+        try:
+            cli_args = ["public", "forum", "post", tag, "--delegate", del_st, str(tmp)]
+            if scope != "public":
+                cli_args = ["private", scope, "forum", "post", tag, "--delegate", del_st, str(tmp)]
+            r = run_slugsocial(repo, cli_args)
+        finally:
+            tmp.unlink(missing_ok=True)
+        if r.returncode != 0:
+            print(
+                f"POST FAIL {i + 1}/{len(posts)} #{tag}:\n{r.stderr or r.stdout}",
+                file=sys.stderr,
+            )
+            return 1
+        if delay_s > 0:
+            time.sleep(delay_s)
+    return 0
+
+
+@dataclass
+class ManifestEntry:
+    id: str
+    thread: Optional[str]
+    delegate: Optional[str]
+    warnings: List[str] = field(default_factory=list)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", type=Path, required=True)
+    ap.add_argument("--out-dir", type=Path, required=True)
+    ap.add_argument("--check", action="store_true")
+    ap.add_argument(
+        "--post-room",
+        action="store_true",
+        help="Create a private room (--room-slug) and post each ingest in JSONL order",
+    )
+    ap.add_argument(
+        "--room-slug",
+        default="ot-import",
+        help="Private room slug for --post-room (default: ot-import)",
+    )
+    ap.add_argument(
+        "--room-id",
+        help="Existing room id (shortid/slug) or 'public' — skip room create",
+    )
+    ap.add_argument(
+        "--delegate",
+        default="",
+        help="Agent delegate for forum post (or SLUG_DELEGATE)",
+    )
+    ap.add_argument(
+        "--default-thread",
+        default="misc",
+        help="Thread tag for ingests with no #thread line (default: misc)",
+    )
+    ap.add_argument(
+        "--post-delay",
+        type=float,
+        default=0.25,
+        help="Seconds between posts (rate limit cushion; default 0.25)",
+    )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="With --post-room: print post plan only, no RPC",
+    )
+    args = ap.parse_args()
+
+    ingests = parse_ingest_lines(args.input)
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    by_thread: Dict[str, List[str]] = {}
+    manifest: List[ManifestEntry] = []
+    chronological_posts: List[Tuple[str, str]] = []
+
+    for ing in ingests:
+        raw = ing["raw"]
+        tid, delegate = extract_thread_and_delegate(raw)
+        translated, warns = translate_raw_body(raw)
+        manifest.append(
+            ManifestEntry(id=ing.get("id", ""), thread=tid, delegate=delegate, warnings=warns)
+        )
+        post_tag = tid or args.default_thread
+        chronological_posts.append((post_tag, format_forum_post(translated, post_tag)))
+        key = tid or "_no_thread"
+        by_thread.setdefault(key, []).append(translated)
+
+    sep = "\n\n--- ingest ---\n\n"
+    for thread, bodies in sorted(by_thread.items()):
+        (args.out_dir / f"{thread}.sorter").write_text(sep.join(bodies) + "\n", encoding="utf-8")
+
+    (args.out_dir / "manifest.json").write_text(
+        json.dumps([m.__dict__ for m in manifest], indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    (args.out_dir / "post_sequence.json").write_text(
+        json.dumps(
+            [{"thread": t, "body": b} for t, b in chronological_posts],
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    print(f"Wrote {len(by_thread)} thread files + manifest + post_sequence.json → {args.out_dir}", file=sys.stderr)
+
+    repo = Path(__file__).resolve().parents[1]
+
+    if args.check:
+        sep_mark = "\n\n--- ingest ---\n\n"
+        for p in sorted(args.out_dir.glob("*.sorter")):
+            if p.name == "_no_thread.sorter":
+                print("SKIP check _no_thread.sorter (mixed threads; validate manually)", file=sys.stderr)
+                continue
+            full = p.read_text(encoding="utf-8")
+            chunks = [c.strip() for c in full.split(sep_mark) if c.strip()]
+            prefix: List[str] = []
+            for idx, chunk in enumerate(chunks):
+                prefix.append(chunk)
+                cumulative = "\n\n".join(prefix)
+                tmp = args.out_dir / f".check-cumulative-{p.stem}-{idx}.sorter"
+                tmp.write_text(cumulative + "\n", encoding="utf-8")
+                r = run_slugsocial(repo, ["public", "check", str(tmp)])
+                tmp.unlink(missing_ok=True)
+                if r.returncode != 0:
+                    print(
+                        f"CHECK FAIL {p.name} after segment {idx}/{len(chunks)} (cumulative):\n{r.stderr or r.stdout}",
+                        file=sys.stderr,
+                    )
+                    return 1
+            print(f"OK {p.name} ({len(chunks)} cumulative steps)", file=sys.stderr)
+
+    if args.post_room:
+        room_id = args.room_id
+        if not room_id:
+            r = run_slugsocial(repo, ["room", "create", args.room_slug.strip()])
+            if r.returncode != 0:
+                print(f"room create failed:\n{r.stderr or r.stdout}", file=sys.stderr)
+                return 1
+            room_id = (r.stdout or "").strip().splitlines()[0].strip()
+            print(f"Created room: {room_id}", file=sys.stderr)
+        delegate = args.delegate or os.environ.get("SLUG_DELEGATE", "")
+        rc = post_ingest_sequence(
+            repo,
+            room_id,
+            delegate,
+            chronological_posts,
+            args.post_delay,
+            args.dry_run,
+        )
+        if rc != 0:
+            return rc
+        if not args.dry_run:
+            print(f"Posted {len(chronological_posts)} ingests to {room_id}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/translate_ot_legacy_dsl.py
+++ b/scripts/translate_ot_legacy_dsl.py
@@ -13,8 +13,13 @@ prefixes (simulates posting ingests in order). `_no_thread.sorter` is skipped.
 
 **`--post-room`** creates a private room (`room create <slug>`), then posts each
 ingest in **JSONL order** as a separate forum message so cross-thread item refs
-stay valid. Posts use `#<thread>` only (delegate via `--delegate` / `SLUG_DELEGATE`;
-no `@` line in the body). Ingests without `#thread` use `--default-thread`.
+stay valid. Posts use `#<thread>` only (no `@` line in the body). Each post uses
+the **original delegate wire** from the dump (`@…` line, else `actor` /
+`voter_key_id`); the server binds each new delegate to your OAuth principal on
+first use. **`--delegate`** is only a fallback when that wire is missing.
+Code fences get an invisible U+200B before each ``` when posting so **current**
+production parses long ```clojure blocks (until the server ships the code-fence
+`parse_full` fix). Ingests without `#thread` use `--default-thread`.
 
 Install:  pip install -r scripts/requirements-translate.txt
 
@@ -382,6 +387,22 @@ def extract_thread_and_delegate(raw: str) -> Tuple[Optional[str], Optional[str]]
     return thread, delegate
 
 
+def delegate_wire_for_ingest(raw: str, ingest: dict) -> Optional[str]:
+    """
+    Canonical `uuid:rig:model` for forum `--delegate`.
+
+    Prefer the leading `@…` line in raw; otherwise `actor` or `voter_key_id` from JSON.
+    """
+    _tid, hdr = extract_thread_and_delegate(raw)
+    if hdr:
+        return strip_at_delegate(hdr) or None
+    for key in ("actor", "voter_key_id"):
+        v = ingest.get(key)
+        if isinstance(v, str) and v.strip():
+            return strip_at_delegate(v.strip()) or None
+    return None
+
+
 def strip_at_delegate(s: Optional[str]) -> str:
     if not s:
         return ""
@@ -393,15 +414,67 @@ def strip_at_delegate(s: Optional[str]) -> str:
     return t
 
 
+# Zero-width space: breaks ``` recognition in server mask_all until code-fence parse fix is deployed.
+_ZWSP = "\u200b"
+
+
+def escape_code_fences_for_production_parser(text: str) -> str:
+    """
+    Insert ZWSP before each ``` so production `mask_all` does not treat multiline
+    fences as vote-explanation placeholders (pending_block EOF error).
+
+    Safe for display (invisible). Remove when slug.social runs dsl fix from main.
+    """
+    if "```" not in text:
+        return text
+    parts: List[str] = []
+    i = 0
+    while i < len(text):
+        if text.startswith("```", i):
+            parts.append(_ZWSP)
+            parts.append("```")
+            i += 3
+        else:
+            parts.append(text[i])
+            i += 1
+    return "".join(parts)
+
+
+def wrap_bare_brace_essay_for_live_post(body: str) -> str:
+    """
+    Production parser (pre-lookahead fix) treats a multiline `{ ... }` as a vote
+    explanation and errors at EOF. Wrapping as a ```text fence makes it code prose;
+    escape_code_fences_for_production_parser then keeps parse safe.
+    """
+    t = body.strip()
+    if len(t) >= 2 and t.startswith("{") and t.endswith("}") and "```" not in body:
+        return f"```text\n{t}\n```\n"
+    return body
+
+
 def format_forum_post(translated_body: str, thread_tag: str) -> str:
     """Body for `forum post`: #thread then DSL/prose (no @ line — use CLI --delegate)."""
     tag = thread_tag.strip().lower()
-    return f"#{tag}\n\n{translated_body.strip()}\n"
+    core = wrap_bare_brace_essay_for_live_post(translated_body.strip())
+    return f"#{tag}\n\n{core}\n"
+
+
+def slugsocial_cmd(repo: Path) -> List[str]:
+    """Prefer release/debug binary; avoid `cargo run` per post (305× is too slow)."""
+    env_bin = os.environ.get("SLUGSOCIAL_BIN", "").strip()
+    if env_bin:
+        return [env_bin]
+    for rel in ("target/release/slugsocial", "target/debug/slugsocial"):
+        p = repo / rel
+        if p.is_file():
+            return [str(p)]
+    return ["cargo", "run", "-q", "-p", "slugsocial", "--"]
 
 
 def run_slugsocial(repo: Path, args: List[str]) -> subprocess.CompletedProcess[str]:
+    prefix = slugsocial_cmd(repo)
     return subprocess.run(
-        ["cargo", "run", "-q", "-p", "slugsocial", "--", *args],
+        [*prefix, *args],
         cwd=repo,
         capture_output=True,
         text=True,
@@ -411,23 +484,31 @@ def run_slugsocial(repo: Path, args: List[str]) -> subprocess.CompletedProcess[s
 def post_ingest_sequence(
     repo: Path,
     room_id: str,
-    delegate: str,
-    posts: List[Tuple[str, str]],
+    fallback_delegate: str,
+    posts: List[Tuple[str, str, str]],
     delay_s: float,
     dry_run: bool,
+    start_index: int = 0,
 ) -> int:
-    """posts: (thread_tag, body) in chronological order."""
-    del_st = strip_at_delegate(delegate)
-    if not del_st and not dry_run:
-        print("ERROR: --delegate or SLUG_DELEGATE is required for --post-room", file=sys.stderr)
-        return 1
+    """posts: (thread_tag, body, delegate_wire) in chronological order."""
+    fb = strip_at_delegate(fallback_delegate)
     scope = "public" if room_id == "public" else room_id
-    for i, (tag, body) in enumerate(posts):
+    for j, (tag, body, del_wire) in enumerate(posts):
+        i = start_index + j
+        del_st = strip_at_delegate(del_wire) or fb
+        if not del_st and not dry_run:
+            print(
+                f"ERROR: ingest {i + 1} has no delegate and --delegate / SLUG_DELEGATE is empty",
+                file=sys.stderr,
+            )
+            return 1
         if dry_run:
-            print(f"[dry-run] would post #{tag} ({i + 1}/{len(posts)})", file=sys.stderr)
+            dshort = (del_st[:48] + "…") if del_st and len(del_st) > 48 else (del_st or "(none)")
+            total = start_index + len(posts)
+            print(f"[dry-run] #{tag} as {dshort} ({i + 1}/{total})", file=sys.stderr)
             continue
         tmp = repo / f".ot-post-{i}.sorter"
-        tmp.write_text(body, encoding="utf-8")
+        tmp.write_text(escape_code_fences_for_production_parser(body), encoding="utf-8")
         try:
             cli_args = ["public", "forum", "post", tag, "--delegate", del_st, str(tmp)]
             if scope != "public":
@@ -436,8 +517,9 @@ def post_ingest_sequence(
         finally:
             tmp.unlink(missing_ok=True)
         if r.returncode != 0:
+            total = start_index + len(posts)
             print(
-                f"POST FAIL {i + 1}/{len(posts)} #{tag}:\n{r.stderr or r.stdout}",
+                f"POST FAIL {i + 1}/{total} #{tag}:\n{r.stderr or r.stdout}",
                 file=sys.stderr,
             )
             return 1
@@ -476,7 +558,8 @@ def main() -> int:
     ap.add_argument(
         "--delegate",
         default="",
-        help="Agent delegate for forum post (or SLUG_DELEGATE)",
+        help="Fallback agent delegate when ingest has none (or SLUG_DELEGATE); "
+        "default is per-ingest from @ line / actor / voter_key_id",
     )
     ap.add_argument(
         "--default-thread",
@@ -490,6 +573,12 @@ def main() -> int:
         help="Seconds between posts (rate limit cushion; default 0.25)",
     )
     ap.add_argument(
+        "--post-skip",
+        type=int,
+        default=0,
+        help="Skip first N ingests when --post-room (resume after partial import)",
+    )
+    ap.add_argument(
         "--dry-run",
         action="store_true",
         help="With --post-room: print post plan only, no RPC",
@@ -501,7 +590,7 @@ def main() -> int:
 
     by_thread: Dict[str, List[str]] = {}
     manifest: List[ManifestEntry] = []
-    chronological_posts: List[Tuple[str, str]] = []
+    chronological_posts: List[Tuple[str, str, str]] = []
 
     for ing in ingests:
         raw = ing["raw"]
@@ -511,7 +600,8 @@ def main() -> int:
             ManifestEntry(id=ing.get("id", ""), thread=tid, delegate=delegate, warnings=warns)
         )
         post_tag = tid or args.default_thread
-        chronological_posts.append((post_tag, format_forum_post(translated, post_tag)))
+        wire = delegate_wire_for_ingest(raw, ing)
+        chronological_posts.append((post_tag, format_forum_post(translated, post_tag), wire or ""))
         key = tid or "_no_thread"
         by_thread.setdefault(key, []).append(translated)
 
@@ -526,7 +616,7 @@ def main() -> int:
 
     (args.out_dir / "post_sequence.json").write_text(
         json.dumps(
-            [{"thread": t, "body": b} for t, b in chronological_posts],
+            [{"thread": t, "delegate": d or None, "body": b} for t, b, d in chronological_posts],
             indent=2,
         )
         + "\n",
@@ -570,19 +660,24 @@ def main() -> int:
                 return 1
             room_id = (r.stdout or "").strip().splitlines()[0].strip()
             print(f"Created room: {room_id}", file=sys.stderr)
-        delegate = args.delegate or os.environ.get("SLUG_DELEGATE", "")
+        fallback = args.delegate or os.environ.get("SLUG_DELEGATE", "")
+        to_post = chronological_posts[args.post_skip :]
+        if args.post_skip:
+            print(f"Resuming: skipping first {args.post_skip}, posting {len(to_post)} ingests", file=sys.stderr)
         rc = post_ingest_sequence(
             repo,
             room_id,
-            delegate,
-            chronological_posts,
+            fallback,
+            to_post,
             args.post_delay,
             args.dry_run,
+            start_index=args.post_skip,
         )
         if rc != 0:
             return rc
         if not args.dry_run:
-            print(f"Posted {len(chronological_posts)} ingests to {room_id}", file=sys.stderr)
+            n = len(chronological_posts) - args.post_skip
+            print(f"Posted {n} ingests to {room_id} (skip={args.post_skip})", file=sys.stderr)
 
     return 0
 

--- a/server/src/dsl.rs
+++ b/server/src/dsl.rs
@@ -537,6 +537,7 @@ fn parse_line(masked_line: &str, masker: &BlockMasker) -> Result<Vec<Stmt>, DslE
 /// Parse EmailDSL preserving prose for rendering; interleaves `Prose` with DSL nodes.
 pub fn parse_full(text: &str) -> Result<Document, DslError> {
     let (masker, masked) = mask_all(BlockMasker::new(), text);
+    let lines: Vec<&str> = masked.split('\n').collect();
     let mut statements: Vec<Stmt> = Vec::new();
     let mut prose_buffer: Vec<&str> = Vec::new();
     let mut pending_block: Option<String> = None;
@@ -551,10 +552,13 @@ pub fn parse_full(text: &str) -> Result<Document, DslError> {
         buf.clear();
     };
 
-    for line in masked.split('\n') {
+    let mut i = 0usize;
+    while i < lines.len() {
+        let line = lines[i];
         let stripped = line.trim_start();
         if let Some(tok) = pending_block.as_ref() {
             if stripped.is_empty() {
+                i += 1;
                 continue;
             }
             if stripped.starts_with("-/")
@@ -564,6 +568,7 @@ pub fn parse_full(text: &str) -> Result<Document, DslError> {
             {
                 statements.push(parse_block_prefixed_statement(tok, stripped, &masker)?);
                 pending_block = None;
+                i += 1;
                 continue;
             }
             return Err(DslError::Parse(
@@ -588,8 +593,43 @@ pub fn parse_full(text: &str) -> Result<Document, DslError> {
                     if masker.is_code_fence_placeholder(&tok) {
                         prose_buffer.push(line);
                     } else {
-                        pending_block = Some(tok);
+                        // Only treat a lone `{…}` / `__BLOCK__` line as vote preamble when the next
+                        // non-empty line is a vote-shaped `item comparison item` (not `~/item` alone,
+                        // which is the invalid `{body}\n~/item` pattern).
+                        let mut j = i + 1;
+                        while j < lines.len() && lines[j].trim_start().is_empty() {
+                            j += 1;
+                        }
+                        let is_vote_preamble = j < lines.len()
+                            && {
+                                let next = lines[j].trim_start();
+                                if !(next.starts_with("-/")
+                                    || next.starts_with("~/")
+                                    || next.starts_with("https://")
+                                    || next.starts_with("http://"))
+                                {
+                                    false
+                                } else if let Some((_, pos_after_item)) =
+                                    parse_item_name_at(next, 0)
+                                {
+                                    let k = skip_ws(next, pos_after_item);
+                                    if k >= next.len() {
+                                        // Next line is only an item path: keep legacy `{block}\n~/a` error.
+                                        true
+                                    } else {
+                                        parse_comparison_at(next, k).is_some()
+                                    }
+                                } else {
+                                    false
+                                }
+                            };
+                        if is_vote_preamble {
+                            pending_block = Some(tok);
+                        } else {
+                            prose_buffer.push(line);
+                        }
                     }
+                    i += 1;
                     continue;
                 }
             }
@@ -599,6 +639,7 @@ pub fn parse_full(text: &str) -> Result<Document, DslError> {
         } else {
             prose_buffer.push(line);
         }
+        i += 1;
     }
 
     if pending_block.is_some() {

--- a/server/src/dsl.rs
+++ b/server/src/dsl.rs
@@ -176,6 +176,19 @@ impl BlockMasker {
         }
         token.to_string()
     }
+
+    /// True if this token was produced by masking a markdown ``` … ``` fence (first pass of
+    /// `mask_all`). Such a line must not set `pending_block` in `parse_full` — it is prose, not a
+    /// vote explanation placeholder.
+    fn is_code_fence_placeholder(&self, token: &str) -> bool {
+        self.replacements
+            .get(token)
+            .map(|orig| {
+                let u = self.unmask(orig);
+                u.trim_start().starts_with("```")
+            })
+            .unwrap_or(false)
+    }
 }
 
 fn mask_all(mut masker: BlockMasker, text: &str) -> (BlockMasker, String) {
@@ -572,7 +585,11 @@ pub fn parse_full(text: &str) -> Result<Document, DslError> {
 
             if let Some((tok, end)) = parse_block_token_at(stripped, 0) {
                 if stripped[end..].trim().is_empty() {
-                    pending_block = Some(tok);
+                    if masker.is_code_fence_placeholder(&tok) {
+                        prose_buffer.push(line);
+                    } else {
+                        pending_block = Some(tok);
+                    }
                     continue;
                 }
             }
@@ -617,6 +634,31 @@ mod tests {
         assert!(masked.contains("__BLOCK_"));
         let roundtrip = masker.unmask(&masked);
         assert_eq!(roundtrip, input);
+    }
+
+    /// Regression: a standalone ``` fence masks to `__BLOCK_*` on its own line; that must not be
+    /// treated as a vote-explanation placeholder (which would reject the next `{...}` line).
+    #[test]
+    fn parse_full_prose_code_fence_then_vote() {
+        let input = concat!(
+            "~/a { a }\n",
+            "~/b { b }\n",
+            "\n",
+            "Some prose.\n",
+            "\n",
+            "```python\n",
+            "x = 1\n",
+            "```\n",
+            "\n",
+            "{ because }\n",
+            "~/a > ~/b\n",
+        );
+        let doc = parse_full(input).unwrap();
+        assert!(
+            doc.statements.iter().any(|s| matches!(s, Stmt::Vote { .. })),
+            "expected a vote in statements: {:?}",
+            doc.statements
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **`scripts/translate_ot_legacy_dsl.py`**: translate `ot.txt` JSONL → per-thread `.sorter` + `post_sequence.json` with **per-ingest delegate** (`@` line, else `actor` / `voter_key_id`). Server auto-binds each delegate on first post under your OAuth user.
- **`--post-room`**: create or target a room, post in JSONL order. **`--post-skip N`** resumes. Uses **`target/release/slugsocial`** when present (or `SLUGSOCIAL_BIN`).
- **Production posting workarounds** until server deploy: U+200B before each ``` ; bare `{ … }` essays wrapped in ` ```text` fences.

## Server (`server/src/dsl.rs`)

- Cherry-picked: masked **code-fence** lines are not vote placeholders.
- **New**: a lone `{…}` / `__BLOCK__` line only sets `pending_block` when the next non-empty line is **vote-shaped** (item path + comparison), not when it is prose-only or a bare item path (preserves `{body}\n~/a` error).

## Live import

Room **`7jhckr4/slug-beta`** (slug `slug-beta`): **305/305** ingests posted — first **156** in initial run, **106–261** in second run, **263–305** in final run (262 was duplicate failure of 263 before wrap fix; ingest 263 posted successfully in last batch).

PR #143 updated.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e93f46c2-963a-48af-8f31-7792b4d8840e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e93f46c2-963a-48af-8f31-7792b4d8840e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

