### PR TITLE
Tokenize prose refs for garden URL links

### DIFF
--- a/server/src/dsl.rs
+++ b/server/src/dsl.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 
-use rand::Rng;
-
 /// Parsed DSL document.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Document {
@@ -39,31 +37,57 @@ pub enum DslError {
 /// Matches the legacy Python parser behavior:
 /// - Supports toggle markers (open == close), e.g. ```...```
 /// - Supports nested markers (open != close), e.g. { ... { ... } ... }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockKind {
+    CodeFence,
+    DoubleBrace,
+    Brace,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MaskedBlock {
+    kind: BlockKind,
+}
+
 #[derive(Debug, Default, Clone)]
 pub struct BlockMasker {
     pub replacements: HashMap<String, String>,
+    blocks: HashMap<String, MaskedBlock>,
+    next_id: u32,
 }
 
 impl BlockMasker {
     pub fn new() -> Self {
         Self {
             replacements: HashMap::new(),
+            blocks: HashMap::new(),
+            next_id: 0,
         }
     }
 
-    fn new_token(&mut self) -> String {
-        let mut rng = rand::thread_rng();
-        let n: u32 = rng.gen();
-        let token = format!("__BLOCK_{:08x}__", n);
-        // Extremely unlikely collision; if it happens, regenerate.
-        if self.replacements.contains_key(&token) {
-            return self.new_token();
+    fn new_token(&mut self, haystack: &str) -> String {
+        loop {
+            let token = format!("__BLOCK_{:08x}__", self.next_id);
+            self.next_id = self.next_id.wrapping_add(1);
+            if !self.replacements.contains_key(&token) && !haystack.contains(&token) {
+                return token;
+            }
         }
-        token
     }
 
     /// Replace outermost balanced blocks with tokens.
     pub fn mask(&mut self, text: &str, open_marker: &str, close_marker: &str) -> String {
+        self.mask_kind(text, open_marker, close_marker, BlockKind::Brace)
+    }
+
+    /// Replace outermost balanced blocks with typed deterministic tokens.
+    pub fn mask_kind(
+        &mut self,
+        text: &str,
+        open_marker: &str,
+        close_marker: &str,
+        kind: BlockKind,
+    ) -> String {
         if text.is_empty() {
             return text.to_string();
         }
@@ -97,9 +121,10 @@ impl BlockMasker {
                     // Found end of outermost block
                     let s = start_idx.max(0) as usize;
                     let original_block = &text[s..i];
-                    let token = self.new_token();
+                    let token = self.new_token(text);
                     self.replacements
                         .insert(token.clone(), original_block.to_string());
+                    self.blocks.insert(token.clone(), MaskedBlock { kind });
                     result_parts.push(token);
                     current_idx = i;
                 }
@@ -176,13 +201,22 @@ impl BlockMasker {
         }
         token.to_string()
     }
+
+    pub fn block_kind(&self, token: &str) -> Option<BlockKind> {
+        self.blocks.get(token).map(|b| b.kind)
+    }
 }
 
 fn mask_all(mut masker: BlockMasker, text: &str) -> (BlockMasker, String) {
     // Mask hierarchy: Code -> Double Brace -> Single Brace.
-    let t = masker.mask(text, "```", "```");
-    let t = masker.mask(&t, "{{", "}}");
-    let t = masker.mask(&t, "{", "}");
+    let t = masker.mask_kind(text, "```", "```", BlockKind::CodeFence);
+    let t = masker.mask_kind(&t, "{{", "}}", BlockKind::DoubleBrace);
+    let t = masker.mask_kind(&t, "{", "}", BlockKind::Brace);
+    (masker, t)
+}
+
+fn mask_code_fences(mut masker: BlockMasker, text: &str) -> (BlockMasker, String) {
+    let t = masker.mask_kind(text, "```", "```", BlockKind::CodeFence);
     (masker, t)
 }
 
@@ -253,7 +287,34 @@ fn skip_ws(s: &str, mut i: usize) -> usize {
     i
 }
 
-fn parse_item_name_at(s: &str, i: usize) -> Option<(String, usize)> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProseToken {
+    Text(String),
+    ItemRef(String),
+}
+
+fn trim_prose_item_ref_end(s: &str, mut end: usize) -> usize {
+    while end > 0 {
+        let Some((idx, c)) = s[..end].char_indices().next_back() else {
+            break;
+        };
+        if matches!(
+            c,
+            '.' | ',' | ';' | ':' | '!' | '?' | ')' | ']' | '}' | '"' | '\''
+        ) {
+            end = idx;
+        } else {
+            break;
+        }
+    }
+    end
+}
+
+fn parse_item_name_at_with_mode(
+    s: &str,
+    i: usize,
+    trim_trailing_punctuation: bool,
+) -> Option<(String, usize)> {
     let bytes = s.as_bytes();
     if i >= bytes.len() {
         return None;
@@ -270,6 +331,12 @@ fn parse_item_name_at(s: &str, i: usize) -> Option<(String, usize)> {
         }
         if j <= i {
             return None;
+        }
+        if trim_trailing_punctuation {
+            j = trim_prose_item_ref_end(s, j);
+            if j <= i {
+                return None;
+            }
         }
         return Some((s[i..j].to_string(), j));
     }
@@ -295,6 +362,12 @@ fn parse_item_name_at(s: &str, i: usize) -> Option<(String, usize)> {
         }
         if j <= i + 2 {
             return None;
+        }
+        if trim_trailing_punctuation {
+            j = trim_prose_item_ref_end(s, j);
+            if j <= i + 2 {
+                return None;
+            }
         }
         let raw = &s[i..j];
         if !is_item_name(raw) {
@@ -334,6 +407,46 @@ fn parse_item_name_at(s: &str, i: usize) -> Option<(String, usize)> {
         return None;
     }
     Some((format!("~/{}", name), j))
+}
+
+fn parse_item_name_at(s: &str, i: usize) -> Option<(String, usize)> {
+    parse_item_name_at_with_mode(s, i, false)
+}
+
+pub fn parse_prose_item_ref_at(s: &str, i: usize) -> Option<(String, usize)> {
+    parse_item_name_at_with_mode(s, i, true)
+}
+
+pub fn tokenize_prose_item_refs(text: &str) -> Vec<ProseToken> {
+    if text.is_empty() {
+        return Vec::new();
+    }
+    let (masker, masked) = mask_code_fences(BlockMasker::new(), text);
+    let mut tokens = Vec::new();
+    let mut text_start = 0usize;
+    let mut i = 0usize;
+
+    while i < masked.len() {
+        if let Some((raw, end)) = parse_prose_item_ref_at(&masked, i) {
+            if text_start < i {
+                tokens.push(ProseToken::Text(masker.unmask(&masked[text_start..i])));
+            }
+            tokens.push(ProseToken::ItemRef(masker.unmask(&raw)));
+            i = end;
+            text_start = i;
+            continue;
+        }
+
+        let Some((_, c)) = masked[i..].char_indices().next() else {
+            break;
+        };
+        i += c.len_utf8();
+    }
+
+    if text_start < masked.len() {
+        tokens.push(ProseToken::Text(masker.unmask(&masked[text_start..])));
+    }
+    tokens
 }
 
 fn parse_block_token_at(s: &str, i: usize) -> Option<(String, usize)> {
@@ -620,6 +733,57 @@ mod tests {
     }
 
     #[test]
+    fn blockmasker_tokens_are_deterministic_and_typed() {
+        let input = "x ```code``` y {body}";
+        let (masker, masked) = mask_all(BlockMasker::new(), input);
+        assert!(masked.contains("__BLOCK_00000000__"));
+        assert!(masked.contains("__BLOCK_00000001__"));
+        assert_eq!(
+            masker.block_kind("__BLOCK_00000000__"),
+            Some(BlockKind::CodeFence)
+        );
+        assert_eq!(
+            masker.block_kind("__BLOCK_00000001__"),
+            Some(BlockKind::Brace)
+        );
+        assert_eq!(masker.unmask(&masked), input);
+    }
+
+    #[test]
+    fn prose_tokenizer_finds_tilde_dash_and_raw_url_refs() {
+        let tokens =
+            tokenize_prose_item_refs("see ~/a/b then -/example.com/x and https://Example.com/A/B.");
+        assert_eq!(
+            tokens,
+            vec![
+                ProseToken::Text("see ".to_string()),
+                ProseToken::ItemRef("~/a/b".to_string()),
+                ProseToken::Text(" then ".to_string()),
+                ProseToken::ItemRef("-/example.com/x".to_string()),
+                ProseToken::Text(" and ".to_string()),
+                ProseToken::ItemRef("https://Example.com/A/B".to_string()),
+                ProseToken::Text(".".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn prose_tokenizer_does_not_linkify_inside_code_fences() {
+        let tokens = tokenize_prose_item_refs(
+            "before ```json\n{\"url\":\"https://example.com\"}\n``` after ~/x",
+        );
+        assert_eq!(
+            tokens,
+            vec![
+                ProseToken::Text(
+                    "before ```json\n{\"url\":\"https://example.com\"}\n``` after ".to_string()
+                ),
+                ProseToken::ItemRef("~/x".to_string()),
+            ]
+        );
+    }
+
+    #[test]
     fn parse_item_with_body_strips_outer_braces() {
         let input = "~/rust { Systems language }";
         let doc = parse_full(input).unwrap();
@@ -640,6 +804,19 @@ mod tests {
             doc.statements,
             vec![Stmt::Item {
                 title: "~/item/in/url".to_string(),
+                body: Some("```json\n{\"test\": true}\n```".to_string()),
+            }]
+        );
+    }
+
+    #[test]
+    fn parse_external_dash_item_with_singleton_fenced_json_body() {
+        let input = "-/example.com/itembody/slug ```json\n{\"test\": true}\n```";
+        let doc = parse_full(input).unwrap();
+        assert_eq!(
+            doc.statements,
+            vec![Stmt::Item {
+                title: "-/example.com/itembody/slug".to_string(),
                 body: Some("```json\n{\"test\": true}\n```".to_string()),
             }]
         );

--- a/server/src/dsl.rs
+++ b/server/src/dsl.rs
@@ -517,6 +517,12 @@ fn parse_block_prefixed_statement(
     tail: &str,
     masker: &BlockMasker,
 ) -> Result<Stmt, DslError> {
+    if masker.block_kind(block_token) == Some(BlockKind::CodeFence) {
+        return Err(DslError::Parse(
+            "vote explanations must use `{ ... }`; code fences belong inside body blocks"
+                .to_string(),
+        ));
+    }
     // vote: block item_ref comparison item_ref
     let s = tail.trim_start();
     if s.is_empty() {
@@ -578,6 +584,11 @@ fn parse_item_definition_statement(stripped: &str, masker: &BlockMasker) -> Resu
     }
 
     if let Some((tok, end)) = parse_block_token_at(stripped, i) {
+        if masker.block_kind(&tok) == Some(BlockKind::CodeFence) {
+            return Err(DslError::Parse(
+                "item bodies must use `{ ... }`; code fences belong inside body blocks".to_string(),
+            ));
+        }
         let body = masker.extract_body(&tok);
         let tail = stripped[end..].trim();
         if !tail.is_empty() {
@@ -688,6 +699,10 @@ pub fn parse_full(text: &str) -> Result<Document, DslError> {
 
             if let Some((tok, end)) = parse_block_token_at(stripped, 0) {
                 if stripped[end..].trim().is_empty() {
+                    if masker.block_kind(&tok) == Some(BlockKind::CodeFence) {
+                        prose_buffer.push(line);
+                        continue;
+                    }
                     pending_block = Some(tok);
                     continue;
                 }
@@ -813,8 +828,8 @@ mod tests {
     }
 
     #[test]
-    fn parse_item_with_fenced_json_body_preserves_braces() {
-        let input = "~/item/in/url ```json\n{\"test\": true}\n```";
+    fn parse_item_with_braced_fenced_json_body_preserves_braces() {
+        let input = "~/item/in/url {\n```json\n{\"test\": true}\n```\n}";
         let doc = parse_full(input).unwrap();
         assert_eq!(
             doc.statements,
@@ -826,13 +841,45 @@ mod tests {
     }
 
     #[test]
-    fn parse_external_dash_item_with_singleton_fenced_json_body() {
-        let input = "-/example.com/itembody/slug ```json\n{\"test\": true}\n```";
+    fn parse_rejects_singleton_fenced_json_item_body() {
+        let input = "~/item/in/url ```json\n{\"test\": true}\n```";
+        let err = parse_full(input).unwrap_err().to_string();
+        assert!(
+            err.contains("item bodies must use"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_keeps_standalone_code_fence_as_prose() {
+        let input = "```json\n{\"test\": true}\n```";
+        let doc = parse_full(input).unwrap();
+        assert_eq!(
+            doc.statements,
+            vec![Stmt::Prose {
+                text: input.to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn parse_rejects_code_fence_vote_explanation() {
+        let input = "```json\n{\"why\": true}\n```\n~/a 2:1 ~/b";
+        let err = parse_full(input).unwrap_err().to_string();
+        assert!(
+            err.contains("vote explanations must start"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_raw_url_item_with_braced_fenced_json_body() {
+        let input = "https://example.com/itembody/slug {\n```json\n{\"test\": true}\n```\n}";
         let doc = parse_full(input).unwrap();
         assert_eq!(
             doc.statements,
             vec![Stmt::Item {
-                title: "-/example.com/itembody/slug".to_string(),
+                title: "https://example.com/itembody/slug".to_string(),
                 body: Some("```json\n{\"test\": true}\n```".to_string()),
             }]
         );

--- a/server/src/dsl.rs
+++ b/server/src/dsl.rs
@@ -324,6 +324,9 @@ fn parse_item_name_at_with_mode(
     if s[i..].starts_with("https://") || s[i..].starts_with("http://") {
         let mut j = i;
         while j < bytes.len() {
+            if trim_trailing_punctuation && bytes[j] == b'\n' {
+                break;
+            }
             if bytes[j..].starts_with(b"__BLOCK_") || is_ws_byte(bytes[j]) {
                 break;
             }
@@ -763,6 +766,19 @@ mod tests {
                 ProseToken::Text(" and ".to_string()),
                 ProseToken::ItemRef("https://Example.com/A/B".to_string()),
                 ProseToken::Text(".".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn prose_tokenizer_stops_raw_urls_at_newlines() {
+        let tokens = tokenize_prose_item_refs("https://example.com/a/b.\n-/example.com/a/b");
+        assert_eq!(
+            tokens,
+            vec![
+                ProseToken::ItemRef("https://example.com/a/b".to_string()),
+                ProseToken::Text(".\n".to_string()),
+                ProseToken::ItemRef("-/example.com/a/b".to_string()),
             ]
         );
     }

--- a/server/src/external_resolver.rs
+++ b/server/src/external_resolver.rs
@@ -256,7 +256,7 @@ fn children_to_dsl(children: &[ResolvedChild]) -> String {
             .filter(|s| !s.trim().is_empty())
             .unwrap_or(child.title.as_str());
         if body.trim_start().starts_with("```") {
-            out.push_str(&format!("{} {}\n\n", child.url, body.trim()));
+            out.push_str(&format!("{} {{\n{}\n}}\n\n", child.url, body.trim()));
         } else {
             out.push_str(&format!(
                 "{} {{\n{}\n}}\n\n",
@@ -378,7 +378,8 @@ mod tests {
             title: "#1 title".into(),
             body: Some("```json\n{\"test\": true}\n```".into()),
         }]);
-        assert!(dsl.contains("https://github.com/o/r/issues/1 ```json"));
+        assert!(dsl.contains("https://github.com/o/r/issues/1 {\n```json"));
         assert!(dsl.contains("{\"test\": true}"));
+        assert!(dsl.contains("```\n}\n"));
     }
 }

--- a/server/src/html/breadcrumb_path.rs
+++ b/server/src/html/breadcrumb_path.rs
@@ -88,16 +88,12 @@ impl ExternalOntologyPath {
             .filter(|x| !x.is_empty())
             .map(|x| x.to_string())
             .collect();
-        let segments = if segments == ["."] {
-            vec![]
-        } else {
-            segments
-        };
+        let segments = if segments == ["."] { vec![] } else { segments };
         Self { item, segments }
     }
 
     pub(super) fn is_root(&self) -> bool {
-        self.segments.len() <= 1
+        self.segments.is_empty()
     }
 
     pub(super) fn segments(&self) -> &[String] {
@@ -106,5 +102,30 @@ impl ExternalOntologyPath {
 
     pub(super) fn as_str(&self) -> &str {
         self.item.as_str()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn external_root_and_host_paths_are_distinct() {
+        let root = ExternalOntologyPath::from_input("");
+        assert!(root.is_root());
+        assert!(root.segments().is_empty());
+
+        let host = ExternalOntologyPath::from_input("example.com");
+        assert!(!host.is_root());
+        assert_eq!(host.segments(), &["example.com".to_string()]);
+    }
+
+    #[test]
+    fn external_path_keeps_each_url_segment_for_breadcrumbs() {
+        let path = ExternalOntologyPath::from_input("https://example.com/a/b");
+        assert_eq!(
+            path.segments(),
+            &["example.com".to_string(), "a".to_string(), "b".to_string()]
+        );
     }
 }

--- a/server/src/html/mod.rs
+++ b/server/src/html/mod.rs
@@ -20,27 +20,30 @@ mod search;
 pub mod ui_action;
 use breadcrumb_path::{ExternalOntologyPath, OntologyPath};
 
-pub use auth::{auth_complete_page, auth_signed_in_fragment, choose_username_error_fragment, choose_username_page};
+pub use auth::{
+    auth_complete_page, auth_signed_in_fragment, choose_username_error_fragment,
+    choose_username_page,
+};
 pub use editor::{editor_check, editor_page};
 pub use forum::{
     home, room_page, room_thread_post_view, room_thread_view, thread_feed_html,
     thread_feed_html_for_room, thread_feed_region_markup, thread_post_view, thread_view, ThreadNav,
 };
 
+pub use forum::user_profile_page;
 pub(crate) use forum::{
     fragment_new_thread_slot, login_to_post_hint_markup, room_members_section_markup,
     thread_ui_collapse_redacted_post, thread_ui_expand_post_full, thread_ui_expand_redacted_post,
     user_can_post_room, user_can_view_room,
 };
+pub(crate) use garden::{encode_pin_cookie_value, vote_compare_post_success_js, GARDEN_PIN_COOKIE};
 pub use garden::{
     external_garden_index, external_ontology_path, garden_index, ontology_path,
-    room_external_garden_index, room_external_ontology_path, room_garden_index,
-    room_ontology_path, room_vote_compare_page, vote_compare_page,
+    room_external_garden_index, room_external_ontology_path, room_garden_index, room_ontology_path,
+    room_vote_compare_page, vote_compare_page,
 };
-pub(crate) use garden::{encode_pin_cookie_value, vote_compare_post_success_js, GARDEN_PIN_COOKIE};
 pub use routing::RouteContext;
 pub use search::{search_page, search_results_fragment};
-pub use forum::user_profile_page;
 pub use ui_action::{parse_html_ui_from_form, HtmlUiAction, HtmlUiParseError, UI_RPC_FIELD};
 
 /// Public profile URL path for a stored username (no `@`).
@@ -107,8 +110,8 @@ pub struct ThemeForm {
 pub async fn post_theme(Form(form): Form<ThemeForm>) -> impl IntoResponse {
     let theme = normalize_theme(&form.theme);
     let next = sanitize_theme_next(form.next.as_deref());
-    let loc = HeaderValue::try_from(next.as_str())
-        .unwrap_or_else(|_| HeaderValue::from_static("/"));
+    let loc =
+        HeaderValue::try_from(next.as_str()).unwrap_or_else(|_| HeaderValue::from_static("/"));
     Response::builder()
         .status(StatusCode::SEE_OTHER)
         .header(header::LOCATION, loc)
@@ -179,7 +182,9 @@ pub(crate) struct JsQueryBuilder {
 
 impl JsBuilder {
     pub(crate) fn new() -> Self {
-        Self { snippets: Vec::new() }
+        Self {
+            snippets: Vec::new(),
+        }
     }
 
     pub(crate) fn morph_selector(self, selector: &str, markup: Markup) -> Self {
@@ -195,7 +200,12 @@ impl JsBuilder {
         self.qs(selector).morph_inner(markup)
     }
 
-    pub(crate) fn morph_expr(mut self, expr: &str, markup: Markup, morph_style: Option<&str>) -> Self {
+    pub(crate) fn morph_expr(
+        mut self,
+        expr: &str,
+        markup: Markup,
+        morph_style: Option<&str>,
+    ) -> Self {
         let html = js_string_literal(&markup.into_string());
         let opts = morph_style
             .map(|style| format!(", {{morphStyle: {}}}", js_string_literal(style)))
@@ -217,7 +227,11 @@ impl JsBuilder {
         self.qs(&format!("#{id}"))
     }
 
-    pub(crate) fn if_current_path_matches(mut self, path: &str, f: impl FnOnce(JsBuilder) -> JsBuilder) -> Self {
+    pub(crate) fn if_current_path_matches(
+        mut self,
+        path: &str,
+        f: impl FnOnce(JsBuilder) -> JsBuilder,
+    ) -> Self {
         let inner = f(JsBuilder::new()).build();
         self.snippets.push(format!(
             "var __slugHere = window.location.pathname + window.location.search; var __slugPath = {path}; if (__slugHere === __slugPath || __slugHere.indexOf(__slugPath + '?') === 0) {{ {inner} }}",
@@ -226,7 +240,11 @@ impl JsBuilder {
         self
     }
 
-    pub(crate) fn if_current_path_not_matches(mut self, path: &str, f: impl FnOnce(JsBuilder) -> JsBuilder) -> Self {
+    pub(crate) fn if_current_path_not_matches(
+        mut self,
+        path: &str,
+        f: impl FnOnce(JsBuilder) -> JsBuilder,
+    ) -> Self {
         let inner = f(JsBuilder::new()).build();
         self.snippets.push(format!(
             "var __slugHere = window.location.pathname + window.location.search; var __slugPath = {path}; if (!(__slugHere === __slugPath || __slugHere.indexOf(__slugPath + '?') === 0)) {{ {inner} }}",
@@ -301,7 +319,17 @@ pub(super) fn layout(
     garden_room_wire: Option<&str>,
     garden_path_prefix: Option<&str>,
 ) -> Markup {
-    layout_embed_controls(title, view, body, views, theme, theme_next, garden_room_wire, garden_path_prefix, true)
+    layout_embed_controls(
+        title,
+        view,
+        body,
+        views,
+        theme,
+        theme_next,
+        garden_room_wire,
+        garden_path_prefix,
+        true,
+    )
 }
 
 /// Minimal document shell: no bottom controls, no garden HUD data attributes (`data-garden-room` /
@@ -315,15 +343,7 @@ pub(super) fn layout_full_bleed_chromeless(
     theme_next: &str,
 ) -> Markup {
     layout_embed_controls(
-        title,
-        view,
-        body,
-        views,
-        theme,
-        theme_next,
-        None,
-        None,
-        false,
+        title, view, body, views, theme, theme_next, None, None, false,
     )
 }
 
@@ -545,7 +565,58 @@ fn item_body_title_snippet(body: &str) -> Option<String> {
     Some(format!("{truncated}{ellipsis}"))
 }
 
-/// Replace ~/path slugs in raw text with clickable links.
+fn garden_href_for_item_ref(
+    raw_ref: &str,
+    garden_prefix: &str,
+) -> Option<(crate::path_types::ItemId, String)> {
+    let key = slug_types::canonicalize_item(raw_ref);
+    let id = crate::path_types::ItemId::parse(&key)?;
+    let href = if let Some(tail) = id.tilde_tail() {
+        if tail.is_empty() {
+            garden_prefix.trim_end_matches('/').to_string()
+        } else {
+            format!("{}/{}", garden_prefix.trim_end_matches('/'), tail)
+        }
+    } else if id.as_str().starts_with("https://") || id.as_str().starts_with("http://") {
+        let display = id.display_path();
+        let rest = display.strip_prefix("-/").unwrap_or(display.as_str());
+        let ext_prefix = format!("{}-", garden_prefix.trim_end_matches('~'));
+        format!("{}/{}", ext_prefix, rest)
+    } else {
+        return None;
+    };
+    Some((id, href))
+}
+
+fn push_item_ref_anchor(
+    out: &mut String,
+    raw_ref: &str,
+    garden_prefix: &str,
+    item_bodies: Option<&HashMap<crate::path_types::ItemId, String>>,
+) -> bool {
+    let Some((id, href)) = garden_href_for_item_ref(raw_ref, garden_prefix) else {
+        return false;
+    };
+    out.push_str(r#"<a href=""#);
+    out.push_str(&escape_html(&href));
+    out.push('"');
+    out.push_str(r#" class="pre-link""#);
+    if let Some(bodies) = item_bodies {
+        if let Some(body) = bodies.get(&id) {
+            if let Some(snippet) = item_body_title_snippet(body) {
+                out.push_str(r#" title=""#);
+                out.push_str(&escape_html(&snippet));
+                out.push('"');
+            }
+        }
+    }
+    out.push('>');
+    out.push_str(&escape_html(raw_ref));
+    out.push_str("</a>");
+    true
+}
+
+/// Replace item refs in raw prose with clickable garden links.
 ///
 /// When `item_bodies` is set, matching ontology items get a `title` attribute with a truncated
 /// body preview for native browser tooltips (forum posts, item pages).
@@ -554,52 +625,15 @@ pub(super) fn linkify_slugs_with_prefix(
     garden_prefix: &str,
     item_bodies: Option<&HashMap<crate::path_types::ItemId, String>>,
 ) -> String {
-    let escaped = escape_html(raw);
-    let mut out = String::with_capacity(escaped.len() + 64);
-    let mut i = 0;
-    let s = escaped.as_str();
-    while i < s.len() {
-        let rest = &s[i..];
-        if let Some(after_tilde) = rest.strip_prefix("~/") {
-            let path_len = after_tilde
-                .chars()
-                .take_while(|c| c.is_ascii_alphanumeric() || *c == '_' || *c == '-' || *c == '/')
-                .map(|c| c.len_utf8())
-                .sum::<usize>();
-            if path_len > 0 {
-                let path = &after_tilde[..path_len];
-                out.push_str(r#"<a href=""#);
-                out.push_str(&escape_html(garden_prefix.trim_end_matches('/')));
-                out.push('/');
-                out.push_str(path);
-                out.push('"');
-                out.push_str(r#" class="pre-link""#);
-                if let Some(bodies) = item_bodies {
-                    let tilde_ref = format!("~/{}", path);
-                    let key = slug_types::canonicalize_item(&tilde_ref);
-                    if let Some(id) = crate::path_types::ItemId::parse(&key) {
-                        if let Some(body) = bodies.get(&id) {
-                            if let Some(snippet) = item_body_title_snippet(body) {
-                                out.push_str(r#" title=""#);
-                                out.push_str(&escape_html(&snippet));
-                                out.push('"');
-                            }
-                        }
-                    }
+    let mut out = String::with_capacity(raw.len() + 64);
+    for token in crate::dsl::tokenize_prose_item_refs(raw) {
+        match token {
+            crate::dsl::ProseToken::Text(text) => out.push_str(&escape_html(&text)),
+            crate::dsl::ProseToken::ItemRef(raw_ref) => {
+                if !push_item_ref_anchor(&mut out, &raw_ref, garden_prefix, item_bodies) {
+                    out.push_str(&escape_html(&raw_ref));
                 }
-                out.push('>');
-                out.push_str("~/");
-                out.push_str(path);
-                out.push_str("</a>");
-                i += 2 + path_len;
-                continue;
             }
-        }
-        if let Some((j, c)) = rest.char_indices().next() {
-            out.push(c);
-            i += j + c.len_utf8();
-        } else {
-            break;
         }
     }
     out
@@ -638,7 +672,13 @@ fn spotify_embed_src(url: &str) -> Option<EmbedFrame> {
     if !(host == "open.spotify.com" || host == "www.open.spotify.com") {
         return None;
     }
-    let path = tail.split('#').next().unwrap_or(tail).split('?').next().unwrap_or(tail);
+    let path = tail
+        .split('#')
+        .next()
+        .unwrap_or(tail)
+        .split('?')
+        .next()
+        .unwrap_or(tail);
     let mut segs: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
     if segs.first().is_some_and(|s| s.starts_with("intl-")) {
         segs.remove(0);
@@ -670,8 +710,16 @@ fn youtube_embed_src(url: &str) -> Option<EmbedFrame> {
     let host = host.to_lowercase();
 
     let video_id = if host == "youtu.be" || host == "www.youtu.be" {
-        clean_media_id(tail.split(['?', '#']).next().unwrap_or(tail).trim_matches('/'))
-    } else if matches!(host.as_str(), "youtube.com" | "www.youtube.com" | "m.youtube.com" | "music.youtube.com") {
+        clean_media_id(
+            tail.split(['?', '#'])
+                .next()
+                .unwrap_or(tail)
+                .trim_matches('/'),
+        )
+    } else if matches!(
+        host.as_str(),
+        "youtube.com" | "www.youtube.com" | "m.youtube.com" | "music.youtube.com"
+    ) {
         let path = format!("/{}", tail.split('#').next().unwrap_or(tail));
         if path.starts_with("/watch") {
             clean_media_id(&query_param(url, "v")?)
@@ -745,10 +793,7 @@ pub(super) fn render_linkified_with_embeds_in_scope(
 /// CLI strings are embedded in a single-quoted JS literal; they must never need escaping.
 fn assert_cli_panel_cmd_js_single_quote_safe(s: &str) {
     assert!(
-        !s.contains('\\')
-            && !s.contains('\'')
-            && !s.contains('\n')
-            && !s.contains('\r'),
+        !s.contains('\\') && !s.contains('\'') && !s.contains('\n') && !s.contains('\r'),
         "cli_panel cmd must not contain `\\`, `'`, or newlines (got {s:?})"
     );
 }
@@ -805,13 +850,38 @@ mod linkify_title_tests {
         let mut bodies = HashMap::new();
         let key = ItemId::parse(&slug_types::canonicalize_item("~/foo/bar")).unwrap();
         bodies.insert(key, "Hello  world\nline".to_string());
-        let html = linkify_slugs_with_prefix(
-            "see ~/foo/bar ok",
-            "/r/x/~",
-            Some(&bodies),
-        );
+        let html = linkify_slugs_with_prefix("see ~/foo/bar ok", "/r/x/~", Some(&bodies));
         assert!(html.contains("title=\"Hello world line\""));
         assert!(html.contains("href=\"/r/x/~/foo/bar\""));
+    }
+
+    #[test]
+    fn raw_url_links_to_public_external_garden_page() {
+        let html = linkify_slugs_with_prefix("see https://example.com/z.", "/~", None);
+        assert!(html
+            .contains(r#"<a href="/-/example.com/z" class="pre-link">https://example.com/z</a>."#));
+    }
+
+    #[test]
+    fn dash_ref_links_to_room_external_garden_page_with_title() {
+        let mut bodies = HashMap::new();
+        let key = ItemId::parse(&slug_types::canonicalize_item("-/example.com/z")).unwrap();
+        bodies.insert(key, "External body\npreview".to_string());
+        let html =
+            linkify_slugs_with_prefix("see -/example.com/z", "/r/9ab12cdroom/~", Some(&bodies));
+        assert!(html.contains(r#"href="/r/9ab12cdroom/-/example.com/z""#));
+        assert!(html.contains(r#"title="External body preview""#));
+    }
+
+    #[test]
+    fn code_fence_urls_are_not_linkified() {
+        let html = linkify_slugs_with_prefix(
+            "```json\n{\"url\":\"https://example.com/z\"}\n```\nthen https://example.com/a",
+            "/~",
+            None,
+        );
+        assert!(!html.contains(r#"href="/-/example.com/z""#));
+        assert!(html.contains(r#"href="/-/example.com/a""#));
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Make block masking deterministic and expose typed block tokens for the DSL parser.
- Add shared prose item-reference tokenization for `~/...`, `-/...`, and raw `http(s)://...` refs while keeping code fences opaque.
- Render forum/garden prose URL refs as internal garden links and fix external breadcrumb root detection.
- Stop raw prose URL tokens at line boundaries so adjacent DSL lines remain independently linked.
- Require item bodies and vote explanations to use brace blocks; code fences are preserved only inside those blocks.
- Emit resolver DSL as preferred raw URL item definitions with braced bodies, including braced fenced JSON.

### Walkthrough
[forum_url_to_garden_walkthrough.mp4](https://cursor.com/agents/bc-b76b16c4-1ed6-426b-a091-340757add3cf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fforum_url_to_garden_walkthrough.mp4)
[Forum URL link](https://cursor.com/agents/bc-b76b16c4-1ed6-426b-a091-340757add3cf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fforum_url_link_thread.webp)
[External garden breadcrumbs](https://cursor.com/agents/bc-b76b16c4-1ed6-426b-a091-340757add3cf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexternal_garden_breadcrumbs.webp)

### Testing
- `cargo test -p slugsocial-server dsl::tests`
- `cargo test -p slugsocial-server external_resolver::tests`
- `cargo test --workspace`
- Manual browser walkthrough verified forum URLs link to `/-/` garden pages and external breadcrumbs are segmented.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b76b16c4-1ed6-426b-a091-340757add3cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b76b16c4-1ed6-426b-a091-340757add3cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

