### PR TITLE
Show bumper username alongside timestamp in thread feed

### DIFF
--- a/server/src/api/rpc.rs
+++ b/server/src/api/rpc.rs
@@ -432,6 +432,7 @@ fn rpc_list_forum_threads(reduced: &ReducerState, room: &str) -> ThreadsResponse
         .map(|((_, tag), ts)| ThreadSummary {
             thread: format!("#{tag}"),
             last_activity_ts: ts.last_activity_ts,
+            last_actor: ts.last_actor.clone(),
             web: ForumThreadUrl::from_room_tag(room, tag),
         })
         .collect();

--- a/server/src/html/forum/feed.rs
+++ b/server/src/html/forum/feed.rs
@@ -27,6 +27,7 @@ pub(super) struct ThreadRow {
     pub(super) tag: String,
     pub(super) subtitle: Option<String>,
     pub(super) last_ts: i64,
+    pub(super) last_actor: String,
     pub(super) ingests: usize,
 }
 
@@ -46,6 +47,7 @@ pub(super) fn collect_thread_rows_for_scope(reduced: &ReducerState, scope: &Scop
                 tag: tag.clone(),
                 subtitle: None,
                 last_ts: thread.last_activity_ts,
+                last_actor: thread.last_actor.clone(),
                 ingests,
             }
         })
@@ -88,6 +90,9 @@ pub(super) fn render_thread_feed(nav: Option<&ThreadNav>, feed_id: &str, rows: &
                                 " "
                                 span class="muted" title=(hover) {
                                     (ago)
+                                    @if !r.last_actor.is_empty() {
+                                        " by @" (r.last_actor)
+                                    }
                                     " · "
                                     (format!("{}n", r.ingests))
                                 }

--- a/server/src/reducer.rs
+++ b/server/src/reducer.rs
@@ -197,12 +197,15 @@ pub struct RoomTimelineEntry {
 #[derive(Debug, Clone)]
 pub struct ForumThreadState {
     pub last_activity_ts: i64,
+    /// Username of the most recent person who bumped this thread.
+    pub last_actor: String,
 }
 
 impl Default for ForumThreadState {
     fn default() -> Self {
         Self {
             last_activity_ts: 0,
+            last_actor: String::new(),
         }
     }
 }
@@ -730,7 +733,10 @@ impl ReducerState {
 
                 let ft = self.forum_threads.entry(scope_thread_key.clone()).or_default();
                 let prev_ts = ft.last_activity_ts;
-                nav!(ft.last_activity_ts, selected(ing.ts > prev_ts, setval(ing.ts)));
+                if ing.ts > prev_ts {
+                    ft.last_activity_ts = ing.ts;
+                    ft.last_actor = ing.principal.clone();
+                }
 
                 nav!(self.ingests_by_scope_thread, keypath(scope_thread_key), push_front(ing.id.clone()));
 

--- a/server/tests/basic.rs
+++ b/server/tests/basic.rs
@@ -720,22 +720,32 @@ fn test_thread_timestamp_bump() {
     let key = (ScopeId::Public, "my-thread".to_string());
     let mut ev1 = match ingest_event(100, "~/t/a {a}\n") { Event::Ingest(i) => i, _ => unreachable!() };
     ev1.thread_tag = "my-thread".to_string();
+    ev1.principal = "alice".to_string();
     state.apply_event(Event::Ingest(ev1));
     assert_eq!(state.forum_threads.get(&key).unwrap().last_activity_ts, 100);
+    assert_eq!(state.forum_threads.get(&key).unwrap().last_actor, "alice");
 
     let mut ev2 = match ingest_event(200, "~/t/b {b}\n") { Event::Ingest(i) => i, _ => unreachable!() };
     ev2.thread_tag = "my-thread".to_string();
+    ev2.principal = "bob".to_string();
     state.apply_event(Event::Ingest(ev2));
     assert_eq!(state.forum_threads.get(&key).unwrap().last_activity_ts, 200);
+    assert_eq!(state.forum_threads.get(&key).unwrap().last_actor, "bob");
 
-    // Ingest with earlier timestamp should NOT regress
+    // Ingest with earlier timestamp should NOT regress ts or actor
     let mut ev3 = match ingest_event(150, "~/t/c {c}\n") { Event::Ingest(i) => i, _ => unreachable!() };
     ev3.thread_tag = "my-thread".to_string();
+    ev3.principal = "charlie".to_string();
     state.apply_event(Event::Ingest(ev3));
     assert_eq!(
         state.forum_threads.get(&key).unwrap().last_activity_ts,
         200,
         "thread timestamp should not regress to an earlier value"
+    );
+    assert_eq!(
+        state.forum_threads.get(&key).unwrap().last_actor,
+        "bob",
+        "last_actor should not change when timestamp does not advance"
     );
 }
 

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -131,6 +131,7 @@ pub struct ThreadsResponse {
 pub struct ThreadSummary {
     pub thread: String,
     pub last_activity_ts: i64,
+    pub last_actor: String,
     pub web: ForumThreadUrl,
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Threads in the bump-ordered feed now show **who** most recently posted alongside the relative timestamp.

Before: `3h ago · 5n`
After: `3h ago by @alice · 5n`

## Changes

- **`server/src/reducer.rs`** — Added `last_actor: String` to `ForumThreadState`. The reducer sets it to `ing.principal` whenever `last_activity_ts` advances (same strict-greater-than guard, so an older ingest cannot overwrite a newer actor).
- **`server/src/html/forum/feed.rs`** — Added `last_actor` to `ThreadRow`, populated from `ForumThreadState`. `render_thread_feed` renders `" by @<username>"` inside the existing muted span, only when `last_actor` is non-empty (safe for legacy/default state).
- **`types/src/lib.rs`** — Added `last_actor: String` to `ThreadSummary` so RPC consumers also receive the field.
- **`server/src/api/rpc.rs`** — Passes `ts.last_actor` when constructing `ThreadSummary` in `rpc_list_forum_threads`.
- **`server/tests/basic.rs`** — Extended `test_thread_timestamp_bump` to assert `last_actor` is captured on an advancing ingest and does not regress when an older ingest arrives.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb844596-25c3-4525-92af-480e0682cccc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb844596-25c3-4525-92af-480e0682cccc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

