### PR TITLE
Add copy button on thread page pagination

### DIFF
--- a/server/src/api/ui_html.rs
+++ b/server/src/api/ui_html.rs
@@ -24,6 +24,7 @@ use crate::{
         external_resolver_status_markup, fragment_new_thread_slot, login_to_post_hint_markup,
         parse_html_ui_from_form, room_members_section_markup, thread_feed_html,
         thread_feed_html_for_room, thread_feed_region_markup, thread_ui_collapse_redacted_post,
+        thread_ui_copy_thread,
         thread_ui_expand_post_full, thread_ui_expand_redacted_post, ui_js_warn, user_can_post_room,
         user_can_view_room, HtmlUiAction, JsBuilder, ThreadNav,
     },
@@ -546,6 +547,14 @@ async fn dispatch_ui_action(
         } => {
             let viewer = session.map(|s| s.username.as_str());
             thread_ui_collapse_redacted_post(state, &room, &thread_tag, post_index, viewer).await
+        }
+        HtmlUiAction::CopyThread {
+            room,
+            thread_tag,
+            copy_btn_id,
+        } => {
+            let viewer = session.map(|s| s.username.as_str());
+            thread_ui_copy_thread(state, &room, &thread_tag, &copy_btn_id, viewer).await
         }
     }
 }

--- a/server/src/html/forum/copy.rs
+++ b/server/src/html/forum/copy.rs
@@ -1,0 +1,97 @@
+use crate::canonical_path::canonicalize_tag;
+use crate::form_template::template_json_compact;
+use crate::reducer::{scope_from_room_wire, ReducerState, ScopeId};
+use crate::state::AppState;
+use maud::{html, Markup};
+use slug_types::timeago::timeago_compact;
+
+use super::access::user_can_view_room;
+use super::ingest::thread_ui_fetch_onclick;
+use super::nav::ThreadNav;
+use crate::html::ui_action::HtmlUiAction;
+use crate::html::{JsBuilder, now_ms};
+
+/// CLI `forum show` text (`print_thread` in `cli/src/main.rs`).
+pub(crate) fn format_thread_cli_text(
+    reduced: &ReducerState,
+    scope: &ScopeId,
+    tag: &str,
+    now_ms: i64,
+) -> String {
+    let tag = canonicalize_tag(tag);
+    let key = (scope.clone(), tag);
+    let all_ids: Vec<String> = reduced
+        .ingests_by_scope_thread
+        .get(&key)
+        .map(|q| q.iter().rev().cloned().collect())
+        .unwrap_or_default();
+
+    let mut out = String::new();
+    for (i, id) in all_ids.iter().enumerate() {
+        let Some(ing) = reduced.ingests_by_id.get(id) else {
+            continue;
+        };
+        if i > 0 {
+            out.push_str("\n\n\n");
+        }
+        let index = i;
+        let timeago = timeago_compact(now_ms, ing.ts);
+        let redacted = reduced.redacted_posts.contains(&ing.id);
+        let body = if redacted {
+            String::new()
+        } else {
+            ing.raw.trim().to_string()
+        };
+        out.push_str(&format!("<post index=\"{index}\" timeago=\"{timeago}\">\n"));
+        out.push_str(&body);
+        out.push_str("\n</post>");
+    }
+    out
+}
+
+pub(crate) async fn thread_ui_copy_thread(
+    state: &AppState,
+    room: &str,
+    thread_tag: &str,
+    copy_btn_id: &str,
+    viewer: Option<&str>,
+) -> axum::response::Response {
+    let room = room.trim();
+    let tag = canonicalize_tag(thread_tag);
+    let scope = scope_from_room_wire(room);
+    if let ScopeId::Room(ref rid) = scope {
+        let reduced = state.reduced.read().await;
+        if !user_can_view_room(&reduced, rid, viewer) {
+            return crate::html::ui_js_warn("forbidden");
+        }
+    }
+
+    let now = now_ms();
+    let reduced = state.reduced.read().await;
+    let text = format_thread_cli_text(&reduced, &scope, &tag, now);
+    drop(reduced);
+
+    JsBuilder::new()
+        .clipboard_write_text_and_label_btn(&text, copy_btn_id, "copied")
+        .into_response()
+}
+
+pub(super) fn thread_copy_button_markup(nav: &ThreadNav, tag: &str, top: bool) -> Markup {
+    let copy_btn_id = if top {
+        "thread-copy-top"
+    } else {
+        "thread-copy-bottom"
+    };
+    let rpc = template_json_compact(&HtmlUiAction::CopyThread {
+        room: nav.room_wire.clone(),
+        thread_tag: tag.to_string(),
+        copy_btn_id: copy_btn_id.to_string(),
+    })
+    .expect("CopyThread serializes");
+    html! {
+        button type="button" id=(copy_btn_id) class="post-nav-btn thread-copy-btn" title="Copy full thread"
+            onclick=(thread_ui_fetch_onclick(&rpc)) {
+            "copy"
+        }
+    }
+}

--- a/server/src/html/forum/mod.rs
+++ b/server/src/html/forum/mod.rs
@@ -1,6 +1,7 @@
 //! Forum / thread HTML: public home, room index, thread views, profile, and UI morph helpers.
 
 mod access;
+mod copy;
 mod feed;
 mod ingest;
 mod nav;
@@ -20,6 +21,7 @@ pub use profile::user_profile_page;
 pub use views::{room_page, room_thread_view, thread_view};
 
 pub(crate) use access::{user_can_post_room, user_can_view_room};
+pub(crate) use copy::thread_ui_copy_thread;
 pub(crate) use new_thread::{fragment_new_thread_slot, login_to_post_hint_markup};
 pub(crate) use room_members::room_members_section_markup;
 pub(crate) use thread_morph::{

--- a/server/src/html/forum/paginator.rs
+++ b/server/src/html/forum/paginator.rs
@@ -1,5 +1,6 @@
 use maud::{html, Markup};
 
+use super::copy::thread_copy_button_markup;
 use super::nav::ThreadNav;
 
 pub(super) const PAGE_SIZE: usize = 10;
@@ -52,6 +53,7 @@ pub(super) fn render_thread_paginator(nav: &ThreadNav, tag: &str, offset: usize,
             span class="post-nav-pos muted" {
                 (offset + 1) "–" (total.min(offset + PAGE_SIZE)) " / " (total)
             }
+            (thread_copy_button_markup(nav, tag, top))
             @if let Some(o) = newer_offset {
                 a href=(nav.thread_page_url(tag, o)) class="post-nav-btn" { "newer →" }
             } @else {

--- a/server/src/html/mod.rs
+++ b/server/src/html/mod.rs
@@ -33,7 +33,7 @@ pub use forum::{
 pub use forum::user_profile_page;
 pub(crate) use forum::{
     fragment_new_thread_slot, login_to_post_hint_markup, room_members_section_markup,
-    thread_ui_collapse_redacted_post, thread_ui_expand_post_full, thread_ui_expand_redacted_post,
+    thread_ui_collapse_redacted_post, thread_ui_copy_thread, thread_ui_expand_post_full, thread_ui_expand_redacted_post,
     user_can_post_room, user_can_view_room,
 };
 pub(crate) use garden::{
@@ -259,6 +259,21 @@ impl JsBuilder {
     pub(crate) fn redirect(mut self, to: &str) -> Self {
         self.snippets
             .push(format!("window.location = {};", js_string_literal(to)));
+        self
+    }
+
+    pub(crate) fn clipboard_write_text_and_label_btn(
+        mut self,
+        text: &str,
+        btn_id: &str,
+        copied_label: &str,
+    ) -> Self {
+        self.snippets.push(format!(
+            "navigator.clipboard.writeText({text}).then(function(){{ var __slugCopyBtn = document.getElementById({btn_id}); if (__slugCopyBtn) {{ __slugCopyBtn.textContent = {label}; }} }}).catch(function(__slugErr){{ console.warn(__slugErr); }});",
+            text = js_string_literal(text),
+            btn_id = js_string_literal(btn_id),
+            label = js_string_literal(copied_label),
+        ));
         self
     }
 

--- a/server/src/html/ui_action.rs
+++ b/server/src/html/ui_action.rs
@@ -109,6 +109,12 @@ pub enum HtmlUiAction {
         thread_tag: String,
         post_index: usize,
     },
+    /// Copy full thread text (CLI `forum show` format) to the clipboard.
+    CopyThread {
+        room: String,
+        thread_tag: String,
+        copy_btn_id: String,
+    },
 }
 
 #[derive(Debug, Error)]
@@ -214,6 +220,29 @@ mod tests {
     }
 
     #[test]
+    fn copy_thread_round_trip() {
+        let template = serde_json::json!({
+            "action": "copy_thread",
+            "room": "public",
+            "thread_tag": "demo",
+            "copy_btn_id": "thread-copy-top",
+        });
+        let mut form = HashMap::new();
+        form.insert(
+            UI_RPC_FIELD.to_string(),
+            serde_json::to_string(&template).unwrap(),
+        );
+        let a = parse_html_ui_from_form(&form).unwrap();
+        assert_eq!(
+            a,
+            HtmlUiAction::CopyThread {
+                room: "public".into(),
+                thread_tag: "demo".into(),
+                copy_btn_id: "thread-copy-top".into(),
+            }
+        );
+    }
+
     fn set_new_thread_compose_expanded_true() {
         let template = serde_json::json!({
             "action": "set_new_thread_compose_expanded",

--- a/server/static/theme_default.css
+++ b/server/static/theme_default.css
@@ -514,6 +514,16 @@ a.post-nav-btn:active {
 }
 .post-nav-btn.disabled { color: var(--meta); cursor: default; }
 .post-nav-pos { font-size: 12px; }
+button.post-nav-btn.thread-copy-btn {
+  cursor: pointer;
+  font: inherit;
+  font-size: 11px;
+  padding: 1px 7px;
+}
+button.post-nav-btn.thread-copy-btn:active {
+  border-color: var(--lo) var(--hi) var(--hi) var(--lo);
+  transform: translate(1px, 1px);
+}
 
 /* ----------------------------------------------------------------
    INGEST ENTRIES (thread view)

--- a/server/static/theme_retro_craft.css
+++ b/server/static/theme_retro_craft.css
@@ -345,6 +345,19 @@ a.post-nav-btn:hover {
   border-color: var(--accent);
   color: var(--accent);
 }
+button.post-nav-btn.thread-copy-btn {
+  background: transparent;
+  border: 1px solid var(--line);
+  color: var(--ink-dim);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.72rem;
+  padding: 0.15rem 0.45rem;
+}
+button.post-nav-btn.thread-copy-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
 
 div.cli-panel {
   align-items: flex-start;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a small **copy** button next to the thread paginator (top and bottom). Clicking it fetches the full thread text in the same format as `npx slugsocial … forum show` (all posts, full bodies, CLI-style `<post>` blocks) and copies it to the clipboard.

## Implementation

- New `HtmlUiAction::CopyThread` — `POST /ui` returns `text/javascript` that runs `navigator.clipboard.writeText(...)` and sets the button label to `copied`.
- `format_thread_cli_text` builds the export from reducer state (not the visible page slice), so pagination does not limit what gets copied.
- Copy buttons live in `render_thread_paginator` via `thread_copy_button_markup`, using the existing fetch+eval onclick pattern.

## Notes

- Redacted posts export with empty bodies (matches RPC/CLI behavior).
- Private rooms respect the same view permission check as other thread UI actions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f78f6349-2aa3-4e1e-a910-0693b00b6705"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f78f6349-2aa3-4e1e-a910-0693b00b6705"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

