### PR TITLE
Thread copy button: position after newer, unified post-nav-btn styles

### DIFF
--- a/server/src/html/forum/copy.rs
+++ b/server/src/html/forum/copy.rs
@@ -89,7 +89,7 @@ pub(super) fn thread_copy_button_markup(nav: &ThreadNav, tag: &str, top: bool) -
     })
     .expect("CopyThread serializes");
     html! {
-        button type="button" id=(copy_btn_id) class="post-nav-btn thread-copy-btn" title="Copy full thread"
+        button type="button" id=(copy_btn_id) class="post-nav-btn" title="Copy full thread"
             onclick=(thread_ui_fetch_onclick(&rpc)) {
             "copy"
         }

--- a/server/src/html/forum/paginator.rs
+++ b/server/src/html/forum/paginator.rs
@@ -58,10 +58,10 @@ pub(super) fn render_thread_paginator(nav: &ThreadNav, tag: &str, offset: usize,
             } @else {
                 a href="#" class="post-nav-btn disabled" { "newer →" }
             }
-            (thread_copy_button_markup(nav, tag, top))
             @if !on_latest {
                 a href=(nav.thread_page_url(tag, latest_offset)) class="post-nav-btn" { "latest" }
             }
+            (thread_copy_button_markup(nav, tag, top))
         }
     }
 }

--- a/server/src/html/forum/paginator.rs
+++ b/server/src/html/forum/paginator.rs
@@ -53,12 +53,12 @@ pub(super) fn render_thread_paginator(nav: &ThreadNav, tag: &str, offset: usize,
             span class="post-nav-pos muted" {
                 (offset + 1) "–" (total.min(offset + PAGE_SIZE)) " / " (total)
             }
-            (thread_copy_button_markup(nav, tag, top))
             @if let Some(o) = newer_offset {
                 a href=(nav.thread_page_url(tag, o)) class="post-nav-btn" { "newer →" }
             } @else {
                 a href="#" class="post-nav-btn disabled" { "newer →" }
             }
+            (thread_copy_button_markup(nav, tag, top))
             @if !on_latest {
                 a href=(nav.thread_page_url(tag, latest_offset)) class="post-nav-btn" { "latest" }
             }

--- a/server/static/theme_default.css
+++ b/server/static/theme_default.css
@@ -507,22 +507,16 @@ div.thread-paginator { margin-top: 10px; }
   padding: 2px 10px;
   text-decoration: none;
 }
-a.post-nav-btn:hover { color: var(--signal); }
-a.post-nav-btn:active {
+.post-nav-btn:hover { color: var(--signal); }
+.post-nav-btn:active {
   border-color: var(--lo) var(--hi) var(--hi) var(--lo);
   transform: translate(1px, 1px);
 }
 .post-nav-btn.disabled { color: var(--meta); cursor: default; }
 .post-nav-pos { font-size: 12px; }
-button.post-nav-btn.thread-copy-btn {
+button.post-nav-btn {
   cursor: pointer;
   font: inherit;
-  font-size: 11px;
-  padding: 1px 7px;
-}
-button.post-nav-btn.thread-copy-btn:active {
-  border-color: var(--lo) var(--hi) var(--hi) var(--lo);
-  transform: translate(1px, 1px);
 }
 
 /* ----------------------------------------------------------------

--- a/server/static/theme_retro_craft.css
+++ b/server/static/theme_retro_craft.css
@@ -335,28 +335,20 @@ div.thread-paginator {
   font-family: var(--font-ui);
   font-size: 0.8rem;
 }
-a.post-nav-btn {
+.post-nav-btn {
   border: 1px solid var(--line);
   color: var(--ink-dim);
   padding: 0.2rem 0.55rem;
   text-decoration: none;
 }
-a.post-nav-btn:hover {
+.post-nav-btn:hover {
   border-color: var(--accent);
   color: var(--accent);
 }
-button.post-nav-btn.thread-copy-btn {
+button.post-nav-btn {
   background: transparent;
-  border: 1px solid var(--line);
-  color: var(--ink-dim);
   cursor: pointer;
   font: inherit;
-  font-size: 0.72rem;
-  padding: 0.15rem 0.45rem;
-}
-button.post-nav-btn.thread-copy-btn:hover {
-  border-color: var(--accent);
-  color: var(--accent);
 }
 
 div.cli-panel {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #154 (merged). Positions the thread **copy** control as the **rightmost** paginator button (after **latest** when that link is shown), and uses only `post-nav-btn` so it matches the other controls in default and retro craft themes.

## Changes

- `render_thread_paginator`: copy after **latest** (or after **newer** when already on latest page)
- `thread_copy_button_markup`: `class="post-nav-btn"` only
- `theme_retro_craft.css`: `.post-nav-btn` for links and buttons
- `theme_default.css`: shared `.post-nav-btn` hover/active; minimal `button.post-nav-btn` reset
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f78f6349-2aa3-4e1e-a910-0693b00b6705"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f78f6349-2aa3-4e1e-a910-0693b00b6705"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

