### PR TITLE
Fix CLI garden paths, GitHub body display, single resolver thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1757,6 +1757,7 @@ name = "slug-types"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "serde_json",
  "url",
 ]
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -360,7 +360,7 @@ enum GardenCmd {
 
 fn print_item_response(resp: &ItemResponse) {
     if let Some(body) = &resp.body {
-        println!("{body}");
+        println!("{}", compact_item_body_for_display(body));
     } else {
         println!("(no body)");
     }
@@ -389,15 +389,28 @@ fn print_item_response(resp: &ItemResponse) {
     }
 }
 
+fn pair_body_preview(body: &str) -> String {
+    let compact = compact_item_body_for_display(body);
+    compact
+        .lines()
+        .take(8)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 fn print_pair_response(resp: &PairResponse) {
-    println!("{}  vs  {}", resp.left, resp.right);
+    println!(
+        "{}  vs  {}",
+        garden_display_path(resp.left.as_str()),
+        garden_display_path(resp.right.as_str())
+    );
     if let Some(b) = &resp.left_body {
-        println!("  left:  {}", b.lines().next().unwrap_or(b).trim());
+        println!("  left:\n{}", pair_body_preview(b));
     } else {
         println!("  left:  (no description)");
     }
     if let Some(b) = &resp.right_body {
-        println!("  right: {}", b.lines().next().unwrap_or(b).trim());
+        println!("  right:\n{}", pair_body_preview(b));
     } else {
         println!("  right: (no description)");
     }
@@ -479,18 +492,19 @@ fn print_global_rank_response(resp: &GlobalRankResponse) {
     );
     for (i, r) in resp.items.iter().enumerate() {
         let rank = resp.offset + i + 1;
+        let label = garden_display_path(r.item.as_str());
         if r.score == 0.0 && r.percent.is_none_or(|p| p == 0.0) && rank > resp.ranked_total {
-            println!("    - {:<40}   (unranked)", r.item);
+            println!("    - {:<40}   (unranked)", label);
         } else if show_percent {
             println!(
                 "{:>4}. {:<40} {:>6.1}%  ({:.6})",
                 rank,
-                r.item,
+                label,
                 r.percent.unwrap_or(0.0),
                 r.score,
             );
         } else {
-            println!("{:>4}. {:<40} {:.6}", rank, r.item, r.score);
+            println!("{:>4}. {:<40} {:.6}", rank, label, r.score);
         }
     }
 }
@@ -499,11 +513,16 @@ fn print_global_rank_response(resp: &GlobalRankResponse) {
 fn print_rank_response(resp: &RankResponse) {
     for comp in &resp.components {
         for (i, r) in comp.ranking.iter().enumerate() {
-            println!("{:>3}. {:<24} {:.6}", i + 1, r.item, r.score);
+            println!(
+                "{:>3}. {:<24} {:.6}",
+                i + 1,
+                garden_display_path(r.item.as_str()),
+                r.score
+            );
         }
     }
     for item in &resp.unranked_items {
-        println!("  - {item}  (unranked)");
+        println!("  - {}  (unranked)", garden_display_path(item.as_str()));
     }
 }
 
@@ -742,10 +761,13 @@ fn normalize_ontology_path_input(path: &str) -> Result<String, String> {
 fn ontology_path_for_api_query(normalized: &str) -> String {
     let p = normalized.trim();
     if p.starts_with("http://") || p.starts_with("https://") || p.starts_with("-/") {
-        p.to_string()
-    } else {
-        format!("~/{}", p.trim_start_matches('/'))
+        return p.to_string();
     }
+    if is_external_path_input(p) {
+        let rest = p.strip_prefix("~/").unwrap_or(p).trim_start_matches('/');
+        return format!("-/{rest}");
+    }
+    format!("~/{}", p.trim_start_matches('/'))
 }
 
 /// Thread name for API; strip leading # so shell users can omit it (# is comment).
@@ -823,7 +845,7 @@ async fn run_scoped(base: &str, room: &str, sub: ScopedCmd) -> Result<()> {
                             println!("{}", serde_json::to_string_pretty(&resp)?);
                         } else {
                             for p in &resp.paths {
-                                println!("~/{p}");
+                                println!("{}", garden_display_path(p.as_str()));
                             }
                         }
                     }

--- a/server/src/api/helpers.rs
+++ b/server/src/api/helpers.rs
@@ -31,6 +31,14 @@ pub fn now_ms() -> i64 {
     t.as_millis() as i64
 }
 
+/// Hint when a garden item id is missing (uses `-/` display paths).
+pub fn garden_item_not_found_hint(item_str: &str) -> String {
+    let display = ItemId::parse(item_str)
+        .map(|id| id.display_path())
+        .unwrap_or_else(|| item_str.to_string());
+    format!("{display} does not exist. For off-site items use `-/host/…` or `https://…`.")
+}
+
 /// Resolve DSL/user input to a stored [`ItemId`].
 pub fn resolve_item(item: &str) -> Result<ItemId, String> {
     let wire = canonicalize_item(item);
@@ -67,9 +75,20 @@ pub fn validate_garden_parent_scope_paths(
         !content.items.contains(&canon) && !content.item_children.contains_key(&canon)
     });
     if none_exist {
+        let displayed: Vec<String> = specs
+            .iter()
+            .map(|spec| {
+                ItemId::parse(spec)
+                    .map(|id| id.display_path())
+                    .unwrap_or_else(|| spec.clone())
+            })
+            .collect();
         return Err((
             "path not found".into(),
-            Some(format!("{} does not exist", specs.join(", "))),
+            Some(format!(
+                "{} does not exist. For off-site items use `-/host/…` or `https://…` (not `~/host/…`).",
+                displayed.join(", ")
+            )),
         ));
     }
     Ok(())

--- a/server/src/api/rpc.rs
+++ b/server/src/api/rpc.rs
@@ -28,7 +28,8 @@ use crate::{
 use super::auth::{parse_bearer, verify_bearer_principal};
 use super::helpers::{
     compute_connectivity_stats, is_pair_voted, now_ms, paginate_rankings, parse_parent_specs,
-    pick_random_distinct_item_pair, resolve_item, validate_garden_parent_scope_paths,
+    garden_item_not_found_hint, pick_random_distinct_item_pair, resolve_item,
+    validate_garden_parent_scope_paths,
     vote_touches_path,
 };
 use super::validate::validate_ingest_document;
@@ -862,10 +863,7 @@ pub async fn handle_rpc_batch(
                 let item_str = canonicalize_item(&item_path);
                 let item = ItemId::parse(&item_str).unwrap_or_else(|| ItemId::opaque(item_str.clone()));
                 if !content.items.contains(&item) {
-                    line_err(
-                        "item not found",
-                        Some(format!("{} does not exist", GardenItemUrl::from_storage_str(&item_str, &room))),
-                    )
+                    line_err("item not found", Some(garden_item_not_found_hint(&item_str)))
                 } else {
                     let want_full = full.unwrap_or(false);
                     let (body, truncated, body_len) = match content.item_bodies.get(&item) {
@@ -1261,10 +1259,7 @@ pub async fn handle_rpc_batch(
                 let item = ItemId::parse(&item_str).unwrap_or_else(|| ItemId::opaque(item_str.clone()));
                 let limit = limit.unwrap_or(50).clamp(1, 200);
                 if !content.items.contains(&item) {
-                    line_err(
-                        "item not found",
-                        Some(format!("{} does not exist", GardenItemUrl::from_storage_str(&item_str, &room))),
-                    )
+                    line_err("item not found", Some(garden_item_not_found_hint(&item_str)))
                 } else {
                     let votes: Vec<VoteRow> = content
                         .item_votes

--- a/server/src/resolvers/github.rs
+++ b/server/src/resolvers/github.rs
@@ -9,6 +9,8 @@ use crate::{path_types::ItemId, state::AppState, write_cmd::WriteCmd};
 pub const SLUG_GITHUB_SCHEMA: &str = "slug_github_import";
 
 const GITHUB_SYSTEM_PRINCIPAL: &str = "system:github-resolver";
+/// All GitHub resolver ingests land in this single forum thread (per room).
+pub const GITHUB_RESOLVER_THREAD_TAG: &str = "github-imports";
 const GITHUB_RESOLVER_COOLDOWN_MS: i64 = 15_000;
 const GITHUB_MAX_PAGES: usize = 3;
 
@@ -357,14 +359,6 @@ fn github_repo_sections(owner: &str, repo: &str) -> Vec<ResolvedChild> {
     .collect()
 }
 
-fn resolver_thread_tag(item: &ItemId) -> String {
-    let tail = item
-        .display_path()
-        .trim_start_matches("-/")
-        .replace(['/', '?'], ":");
-    format!("import:{tail}")
-}
-
 fn children_to_dsl(children: &[ResolvedChild]) -> String {
     let mut out = String::new();
     for child in children {
@@ -545,7 +539,7 @@ pub async fn resolve_github_children(
         return Ok(0);
     }
     let text = children_to_dsl(&children);
-    let thread_tag = resolver_thread_tag(item);
+    let thread_tag = GITHUB_RESOLVER_THREAD_TAG.to_string();
     let (tx, rx) = oneshot::channel();
     state
         .write_tx
@@ -689,6 +683,11 @@ mod tests {
         let urls: Vec<String> = sections.into_iter().map(|c| c.url).collect();
         assert!(urls.contains(&"https://github.com/sortersocial/slug/issues".to_string()));
         assert!(urls.contains(&"https://github.com/sortersocial/slug/pulls".to_string()));
+    }
+
+    #[test]
+    fn resolver_uses_single_github_imports_thread() {
+        assert_eq!(GITHUB_RESOLVER_THREAD_TAG, "github-imports");
     }
 
     #[test]

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -5,4 +5,5 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
 url = { version = "2.5", features = ["serde"] }

--- a/types/src/github_body.rs
+++ b/types/src/github_body.rs
@@ -1,0 +1,161 @@
+//! Compact text summaries for GitHub import bodies (CLI and other non-HTML surfaces).
+
+use serde::Deserialize;
+
+const SLUG_GITHUB_SCHEMA: &str = "slug_github_import";
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum GithubImportKind {
+    Repo,
+    RepoSection,
+    Issue,
+    Pull,
+    Commit,
+    Release,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct GithubImportCard {
+    v: u32,
+    #[serde(default)]
+    schema: String,
+    kind: GithubImportKind,
+    url: String,
+    headline: String,
+    #[serde(default)]
+    sublines: Vec<String>,
+    #[serde(default)]
+    excerpt: Option<String>,
+}
+
+fn extract_fence<'a>(body: &'a str, lang: &str) -> Option<&'a str> {
+    let b = body.trim();
+    let prefix = format!("```{lang}");
+    let rest = b.strip_prefix(prefix.as_str())?;
+    let rest = rest
+        .strip_prefix('\n')
+        .or_else(|| rest.strip_prefix('\r'))
+        .unwrap_or(rest);
+    let end = rest.find("\n```")?;
+    Some(rest[..end].trim())
+}
+
+fn parse_github_card(body: &str) -> Option<GithubImportCard> {
+    let trimmed = body.trim();
+    if let Some(json) = extract_fence(trimmed, "slug-github-card") {
+        let c: GithubImportCard = serde_json::from_str(json).ok()?;
+        return (c.v == 1 && (c.schema.is_empty() || c.schema == SLUG_GITHUB_SCHEMA)).then_some(c);
+    }
+    if let Some(json) = extract_fence(trimmed, "json") {
+        let c: GithubImportCard = serde_json::from_str(json).ok()?;
+        if c.v == 1
+            && (c.schema == SLUG_GITHUB_SCHEMA
+                || (c.schema.is_empty() && c.url.contains("github.com")))
+        {
+            return Some(c);
+        }
+    }
+    if trimmed.starts_with('{') {
+        let c: GithubImportCard = serde_json::from_str(trimmed).ok()?;
+        return (c.v == 1
+            && (c.schema == SLUG_GITHUB_SCHEMA
+                || (c.schema.is_empty() && c.url.contains("github.com"))))
+        .then_some(c);
+    }
+    None
+}
+
+fn format_github_card(card: &GithubImportCard) -> String {
+    let mut out = card.headline.clone();
+    if !card.sublines.is_empty() {
+        out.push('\n');
+        for line in &card.sublines {
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    if let Some(ex) = &card.excerpt {
+        if !ex.trim().is_empty() {
+            out.push('\n');
+            out.push_str(ex.trim());
+        }
+    }
+    out.trim().to_string()
+}
+
+fn summarize_raw_github_api_json(value: &serde_json::Value) -> Option<String> {
+    let title = value.get("title").and_then(|v| v.as_str()).filter(|s| !s.is_empty());
+    let state = value.get("state").and_then(|v| v.as_str());
+    let body = value.get("body").and_then(|v| v.as_str());
+    let number = value.get("number").and_then(|v| v.as_i64());
+    if title.is_none() && body.is_none() {
+        return None;
+    }
+    let headline = match (number, title) {
+        (Some(n), Some(t)) => format!("#{n} {t}"),
+        (_, Some(t)) => t.to_string(),
+        _ => return None,
+    };
+    let mut out = headline;
+    if let Some(st) = state {
+        out.push_str(&format!("\nState: {st}"));
+    }
+    if let Some(user) = value.get("user").and_then(|u| u.get("login")).and_then(|v| v.as_str()) {
+        out.push_str(&format!("\nAuthor: @{user}"));
+    }
+    if let Some(b) = body.filter(|s| !s.trim().is_empty()) {
+        out.push_str("\n\n");
+        out.push_str(b.trim());
+    }
+    Some(out)
+}
+
+/// If `raw` looks like a GitHub import card or API JSON blob, return a compact human-readable summary.
+pub fn compact_github_item_body(raw: &str) -> Option<String> {
+    if let Some(card) = parse_github_card(raw) {
+        return Some(format_github_card(&card));
+    }
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(raw.trim()) {
+        if let Some(summary) = summarize_raw_github_api_json(&value) {
+            return Some(summary);
+        }
+    }
+    if let Some(json) = extract_fence(raw.trim(), "json") {
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(json) {
+            return summarize_raw_github_api_json(&value);
+        }
+    }
+    None
+}
+
+/// Prefer a compact GitHub summary when the stored body is import/API JSON; otherwise return `raw`.
+pub fn compact_item_body_for_display(raw: &str) -> String {
+    compact_github_item_body(raw).unwrap_or_else(|| raw.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compact_slug_github_card_fence() {
+        let body = "```slug-github-card\n\
+{\"v\":1,\"schema\":\"slug_github_import\",\"kind\":\"issue\",\
+\"url\":\"https://github.com/o/r/issues/1\",\"headline\":\"#1 Title\",\
+\"sublines\":[\"State: open\"],\"excerpt\":\"Issue text.\"}\n\
+```";
+        let out = compact_github_item_body(body).expect("parses");
+        assert!(out.contains("#1 Title"));
+        assert!(out.contains("State: open"));
+        assert!(out.contains("Issue text."));
+    }
+
+    #[test]
+    fn compact_raw_github_api_issue_json() {
+        let body = r#"{"number":42,"title":"Ranking history","state":"open","body":"The real description.","user":{"login":"octo"}}"#;
+        let out = compact_github_item_body(body).expect("parses");
+        assert!(out.contains("#42 Ranking history"));
+        assert!(out.contains("The real description."));
+    }
+}

--- a/types/src/item_wire.rs
+++ b/types/src/item_wire.rs
@@ -116,12 +116,51 @@ pub fn canonicalize_item(input: &str) -> String {
         if tail.is_empty() {
             return SLUG_TILDE_ONTOLOGY_ROOT.to_string();
         }
+        // `~/github.com/…` is a common mistake for external `-/github.com/…`.
+        if tail
+            .split('/')
+            .next()
+            .is_some_and(|seg| seg.contains('.'))
+        {
+            return finalize_external_identity_url(format!("https://{tail}"));
+        }
         format!("https://slug.social/~/{tail}")
     } else if tail.is_empty() {
         "https://slug.social".to_string()
+    } else if tail
+        .split('/')
+        .next()
+        .is_some_and(|seg| seg.contains('.'))
+    {
+        finalize_external_identity_url(format!("https://{tail}"))
     } else {
         format!("https://slug.social/{tail}")
     }
+}
+
+/// True when user input refers to an off-site item (`-/…`, URL, or `host.tld/…`).
+pub fn is_external_path_input(input: &str) -> bool {
+    let s = input.trim();
+    if s.starts_with("-/")
+        || s.starts_with("http://")
+        || s.starts_with("https://")
+    {
+        return true;
+    }
+    let rest = s
+        .strip_prefix("~/")
+        .or_else(|| s.strip_prefix('/'))
+        .unwrap_or(s);
+    rest.split('/')
+        .next()
+        .is_some_and(|seg| !seg.is_empty() && seg.contains('.'))
+}
+
+/// CLI / browse display path (`~/…` native, `-/…` external) from a stored item id string.
+pub fn garden_display_path(stored: &str) -> String {
+    crate::ItemId::parse(stored)
+        .map(|id| id.display_path())
+        .unwrap_or_else(|| stored.to_string())
 }
 
 pub fn item_path_segments(input: &str) -> Vec<String> {

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -5,12 +5,14 @@ pub mod item_wire;
 pub mod item_id;
 pub mod paths;
 pub mod timeago;
+pub mod github_body;
 
 pub use item_id::ItemId;
 pub use item_wire::{
-    canonicalize_item, item_parent_path, item_path_segments, normalize_slug_ontology_storage_url,
-    SLUG_TILDE_ONTOLOGY_ROOT,
+    canonicalize_item, garden_display_path, is_external_path_input, item_parent_path,
+    item_path_segments, normalize_slug_ontology_storage_url, SLUG_TILDE_ONTOLOGY_ROOT,
 };
+pub use github_body::{compact_github_item_body, compact_item_body_for_display};
 pub use paths::{
     canonicalize_tag, ForumThreadUrl, GardenItemUrl, RelativePath,
     room_id_from_route_segment, room_route_segment, ROOM_SHORT_ID_LEN,

--- a/types/src/paths.rs
+++ b/types/src/paths.rs
@@ -476,6 +476,23 @@ mod tests {
     }
 
     #[test]
+    #[test]
+    fn bare_host_path_is_external_not_slug_ontology() {
+        assert_eq!(
+            canonicalize_item("github.com/org/repo/issues"),
+            "https://github.com/org/repo/issues"
+        );
+    }
+
+    #[test]
+    fn tilde_prefixed_host_path_is_external() {
+        assert_eq!(
+            canonicalize_item("~/github.com/org/repo"),
+            "https://github.com/org/repo"
+        );
+    }
+
+    #[test]
     fn canonicalize_item_dash_namespace_https() {
         assert_eq!(
             canonicalize_item("-/github.com/A/B"),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the browse/CLI friction from the garden exploration session: external items now show and resolve consistently, GitHub JSON bodies render compactly, and all GitHub resolver ingests go to one forum thread.

## Changes

### Path display and resolution
- **Browse output** (`rank`, `tree`, `children`, `pair`, global `rank`) now prints `-/github.com/…` for external items instead of bare `https://…` or mistaken `~/https://…`.
- **CLI input**: bare `github.com/org/repo` and mistaken `~/github.com/…` are treated as external (`-/…` or `https://…`), matching what `body` already accepted.
- **Server canonicalization**: `~/github.com/…` and bare host paths normalize to external `https://…` identities.
- **Errors**: "path not found" hints use `display_path()` and mention `-/host/…` and `https://…` instead of implying native `~/host/…`.

### GitHub JSON bodies (#4)
- `body` and `pair` CLI output detects `slug-github-card` fences and raw GitHub API JSON, showing title, state, author, and excerpt instead of dumping the blob.
- `pair` shows up to 8 lines of summary per side (not just the opening fence line).

### GitHub resolver thread
- All resolver ingests (any repo, any scope) post to **`#github-imports`** instead of per-scope `import:…` threads.

## Testing
- `cargo test -p slug-types -p slugsocial-server`
- New unit tests for external path canonicalization, GitHub body compaction, and resolver thread constant.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36e1c836-0a90-4e99-9241-7a89e6ec9560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36e1c836-0a90-4e99-9241-7a89e6ec9560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

