### PR TITLE
External garden URLs use /-/https://… full prefix

### DIFF
--- a/server/src/html/breadcrumb_path.rs
+++ b/server/src/html/breadcrumb_path.rs
@@ -1,4 +1,5 @@
 use crate::path_types::{tilde_http_path_to_item_id, ItemId};
+use slug_types::SLUG_TILDE_ONTOLOGY_ROOT;
 
 /// Semantic view of an ontology path for rendering and routing decisions.
 pub(super) struct OntologyPath {
@@ -54,11 +55,36 @@ impl OntologyPath {
     }
 }
 
-/// External `https://host/…` items addressed as `/-/host/…` in the URL bar.
+/// External `https://…` items use `/-/https://host/…` in the URL bar (full URL after the prefix).
 pub(super) struct ExternalOntologyPath {
     item: ItemId,
-    /// e.g. `["github.com", "org", "repo", "issues"]`
-    segments: Vec<String>,
+    /// Outermost external identity first (e.g. `https://host`), ending with `item`.
+    chain: Vec<ItemId>,
+}
+
+fn external_ancestor_chain(item: &ItemId) -> Vec<ItemId> {
+    let s = item.as_str();
+    // Sentinel used for the bare `/-/` index route.
+    if s == "https://." {
+        return vec![];
+    }
+    let mut rev = vec![item.clone()];
+    loop {
+        let cur = rev.last().expect("non-empty");
+        let Some(p) = cur.parent() else {
+            break;
+        };
+        let ps = p.as_str();
+        if ps == SLUG_TILDE_ONTOLOGY_ROOT || ps.starts_with("https://slug.social/~/") {
+            break;
+        }
+        if !(ps.starts_with("http://") || ps.starts_with("https://")) {
+            break;
+        }
+        rev.push(p);
+    }
+    rev.reverse();
+    rev
 }
 
 impl ExternalOntologyPath {
@@ -78,26 +104,17 @@ impl ExternalOntologyPath {
     }
 
     pub(super) fn from_item(item: ItemId) -> Self {
-        let s = item.as_str();
-        let rest = s
-            .strip_prefix("https://")
-            .or_else(|| s.strip_prefix("http://"))
-            .unwrap_or("");
-        let segments: Vec<String> = rest
-            .split('/')
-            .filter(|x| !x.is_empty())
-            .map(|x| x.to_string())
-            .collect();
-        let segments = if segments == ["."] { vec![] } else { segments };
-        Self { item, segments }
+        let chain = external_ancestor_chain(&item);
+        Self { item, chain }
     }
 
     pub(super) fn is_root(&self) -> bool {
-        self.segments.is_empty()
+        self.chain.is_empty()
     }
 
-    pub(super) fn segments(&self) -> &[String] {
-        &self.segments
+    /// Ancestor [`ItemId`]s from host root to current (inclusive), for external breadcrumbs.
+    pub(super) fn breadcrumb_chain(&self) -> &[ItemId] {
+        &self.chain
     }
 
     pub(super) fn as_str(&self) -> &str {
@@ -113,19 +130,32 @@ mod tests {
     fn external_root_and_host_paths_are_distinct() {
         let root = ExternalOntologyPath::from_input("");
         assert!(root.is_root());
-        assert!(root.segments().is_empty());
+        assert!(root.breadcrumb_chain().is_empty());
 
         let host = ExternalOntologyPath::from_input("example.com");
         assert!(!host.is_root());
-        assert_eq!(host.segments(), &["example.com".to_string()]);
+        assert_eq!(host.breadcrumb_chain().len(), 1);
+        assert_eq!(
+            host.breadcrumb_chain()[0].as_str(),
+            "https://example.com"
+        );
     }
 
     #[test]
     fn external_path_keeps_each_url_segment_for_breadcrumbs() {
         let path = ExternalOntologyPath::from_input("https://example.com/a/b");
+        assert_eq!(path.breadcrumb_chain().len(), 3);
         assert_eq!(
-            path.segments(),
-            &["example.com".to_string(), "a".to_string(), "b".to_string()]
+            path.breadcrumb_chain()[0].as_str(),
+            "https://example.com"
+        );
+        assert_eq!(
+            path.breadcrumb_chain()[1].as_str(),
+            "https://example.com/a"
+        );
+        assert_eq!(
+            path.breadcrumb_chain()[2].as_str(),
+            "https://example.com/a/b"
         );
     }
 }

--- a/server/src/html/garden/browse.rs
+++ b/server/src/html/garden/browse.rs
@@ -23,10 +23,12 @@ pub(super) fn scoped_bc_path_external(path: &ExternalOntologyPath, nav: &ThreadN
                 a href="/" { "slug.social" }
                 (bc_segment(&format!("room:{slug}"), nav.room_url(), false))
                 (bc_segment("-", &ext_root, path.is_root()))
-                @for (i, seg) in path.segments().iter().enumerate() {
-                    @let href = format!("{}/{}", ext_root, path.segments()[..=i].join("/"));
-                    @let is_last = i == path.segments().len() - 1;
-                    (bc_segment(seg, &href, is_last))
+                @for (i, id) in path.breadcrumb_chain().iter().enumerate() {
+                    @let disp = id.display_path();
+                    @let tail = disp.strip_prefix("-/").unwrap_or(disp.as_str());
+                    @let href = format!("{}/{}", ext_root, tail);
+                    @let is_last = i + 1 == path.breadcrumb_chain().len();
+                    (bc_segment(id.last_segment(), &href, is_last))
                 }
             }
         }

--- a/server/src/html/garden/routes.rs
+++ b/server/src/html/garden/routes.rs
@@ -138,7 +138,7 @@ pub async fn external_garden_index(
         html! {
             nav class="breadcrumb" { (bc_path_external(&ext_path)) }
             h2 { "external paths" }
-            p class="muted" { "Items outside slug.social use the " code { "-/" } " prefix (same role as " code { "~/" } ")." }
+            p class="muted" { "Items outside slug.social use the " code { "-/" } " prefix followed by the full " code { "https://…" } " URL (legacy " code { "-/host/path" } " still works)." }
             @if child_rankings.component_rankings.is_empty() && child_rankings.unranked_items.is_empty() {
                 p class="muted" { "no external items indexed yet" }
             } @else {

--- a/server/src/html/garden/tests.rs
+++ b/server/src/html/garden/tests.rs
@@ -118,9 +118,10 @@ fn suggest_next_vote_pair_prefers_unvoted_sibling_pair() {
 
 #[test]
 fn external_resolver_status_markup_reports_success_and_refresh() {
-    let html = external_resolver_status_markup(Ok(2), "/-/github.com/o/r").into_string();
+    let html =
+        external_resolver_status_markup(Ok(2), "/-/https://github.com/o/r").into_string();
     assert!(html.contains("Imported 2 GitHub items."));
-    assert!(html.contains("href=\"/-/github.com/o/r\""));
+    assert!(html.contains("href=\"/-/https://github.com/o/r\""));
 }
 
 #[test]

--- a/server/src/html/mod.rs
+++ b/server/src/html/mod.rs
@@ -460,15 +460,17 @@ pub(super) fn bc_segment(label: &str, href: &str, is_current: bool) -> Markup {
     }
 }
 
-/// Breadcrumb for external ontology `/-/host/...`
+/// Breadcrumb for external ontology `/-/https://…`
 fn bc_path_external(path: &ExternalOntologyPath) -> Markup {
     html! {
         a href="/" { "slug.social" }
         (bc_segment("-", "/-", path.is_root()))
-        @for (i, seg) in path.segments().iter().enumerate() {
-            @let href = format!("/-/{}", path.segments()[..=i].join("/"));
-            @let is_last = i == path.segments().len() - 1;
-            (bc_segment(seg, &href, is_last))
+        @for (i, id) in path.breadcrumb_chain().iter().enumerate() {
+            @let disp = id.display_path();
+            @let tail = disp.strip_prefix("-/").unwrap_or(disp.as_str());
+            @let href = format!("/-/{}", tail);
+            @let is_last = i + 1 == path.breadcrumb_chain().len();
+            (bc_segment(id.last_segment(), &href, is_last))
         }
     }
 }
@@ -892,8 +894,9 @@ mod linkify_title_tests {
     #[test]
     fn raw_url_links_to_public_external_garden_page() {
         let html = linkify_slugs_with_prefix("see https://example.com/z.", "/~", None);
-        assert!(html
-            .contains(r#"<a href="/-/example.com/z" class="pre-link">https://example.com/z</a>."#));
+        assert!(html.contains(
+            r#"<a href="/-/https://example.com/z" class="pre-link">https://example.com/z</a>."#
+        ));
     }
 
     #[test]
@@ -903,7 +906,7 @@ mod linkify_title_tests {
         bodies.insert(key, "External body\npreview".to_string());
         let html =
             linkify_slugs_with_prefix("see -/example.com/z", "/r/9ab12cdroom/~", Some(&bodies));
-        assert!(html.contains(r#"href="/r/9ab12cdroom/-/example.com/z""#));
+        assert!(html.contains(r#"href="/r/9ab12cdroom/-/https://example.com/z""#));
         assert!(html.contains(r#"title="External body preview""#));
     }
 
@@ -914,8 +917,8 @@ mod linkify_title_tests {
             "/~",
             None,
         );
-        assert!(!html.contains(r#"href="/-/example.com/z""#));
-        assert!(html.contains(r#"href="/-/example.com/a""#));
+        assert!(!html.contains(r#"href="/-/https://example.com/z""#));
+        assert!(html.contains(r#"href="/-/https://example.com/a""#));
     }
 
     #[test]

--- a/test/browser_github_resolver.clj
+++ b/test/browser_github_resolver.clj
@@ -113,31 +113,31 @@
                (page/navigate pg (str base-url "/login"))
                (is (wait-for-text pg "body" "@alice" 15000) "alice session after login")
 
-               (page/navigate pg (str base-url "/-/github.com/octo"))
+               (page/navigate pg (str base-url "/-/https://github.com/octo"))
                (is (wait-for-text pg "#external-resolver-panel" "GitHub resolver" 15000)
                    "user page shows resolver panel")
                (locator/click (page/locator pg "[data-testid=\"github-resolve-children\"]"))
-               (is (wait-for-text pg "body" "-/github.com/octo/other" 15000)
+               (is (wait-for-text pg "body" "-/https://github.com/octo/other" 15000)
                    "user resolver imports repos")
 
-               (page/navigate pg (str base-url "/-/github.com/octo/hello"))
+               (page/navigate pg (str base-url "/-/https://github.com/octo/hello"))
                (locator/click (page/locator pg "[data-testid=\"github-resolve-children\"]"))
-               (is (wait-for-text pg "body" "-/github.com/octo/hello/pulls" 15000)
+               (is (wait-for-text pg "body" "-/https://github.com/octo/hello/pulls" 15000)
                    "repo resolver imports structural children")
-               (is (wait-for-text pg "body" "-/github.com/octo/hello/commits" 15000)
+               (is (wait-for-text pg "body" "-/https://github.com/octo/hello/commits" 15000)
                    "repo resolver imports commits section")
-               (is (wait-for-text pg "body" "-/github.com/octo/hello/releases" 15000)
+               (is (wait-for-text pg "body" "-/https://github.com/octo/hello/releases" 15000)
                    "repo resolver imports releases section")
 
-               (page/navigate pg (str base-url "/-/github.com/octo/hello/issues/42"))
+               (page/navigate pg (str base-url "/-/https://github.com/octo/hello/issues/42"))
                (locator/click (page/locator pg "[data-testid=\"github-resolve-siblings\"]"))
-               (is (wait-for-http-text (str base-url "/-/github.com/octo/hello/issues")
-                                       "-/github.com/octo/hello/issues/43"
+               (is (wait-for-http-text (str base-url "/-/https://github.com/octo/hello/issues")
+                                       "-/https://github.com/octo/hello/issues/43"
                                        15000)
                    "issue sibling resolver persisted issue siblings")
                (core/with-page [pg2 (core/new-page-from-context ctx)]
-                 (page/navigate pg2 (str base-url "/-/github.com/octo/hello/issues"))
-                 (is (wait-for-text pg2 "body" "-/github.com/octo/hello/issues/43" 15000)
+                 (page/navigate pg2 (str base-url "/-/https://github.com/octo/hello/issues"))
+                 (is (wait-for-text pg2 "body" "-/https://github.com/octo/hello/issues/43" 15000)
                      "issue sibling resolver imports issue siblings"))))))
 
        (is (some #{"/users/octo/repos"} @(:paths @!github))

--- a/test/browser_ui_morph.clj
+++ b/test/browser_ui_morph.clj
@@ -66,7 +66,7 @@
              (core/with-page [pg (core/new-page-from-context ctx)]
                (page/navigate pg (str base-url "/login"))
                (is (wait-for-text pg "body" "@alice" 15000) "alice session after login")
-               (page/navigate pg (str base-url "/-/github.com/test/repo"))
+               (page/navigate pg (str base-url "/-/https://github.com/test/repo"))
                (is (wait-for-text pg "nav.breadcrumb" "slug.social" 15000) "external garden breadcrumb has site root")
                (is (wait-for-text pg "nav.breadcrumb" "github.com" 5000) "breadcrumb includes host segment")
                (is (wait-for-text pg "nav.breadcrumb" "test" 5000) "breadcrumb includes path segment test")

--- a/types/src/item_id.rs
+++ b/types/src/item_id.rs
@@ -6,8 +6,7 @@ use std::fmt;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::item_wire::{
-    canonicalize_item, external_display_dash_prefix, normalize_slug_ontology_storage_url,
-    SLUG_TILDE_ONTOLOGY_ROOT,
+    canonicalize_item, normalize_slug_ontology_storage_url, SLUG_TILDE_ONTOLOGY_ROOT,
 };
 
 /// Structural key for items in [`slug_types`] and the server reducer.
@@ -155,13 +154,13 @@ impl ItemId {
             if tail.starts_with("slug.social") {
                 return s.to_string();
             }
-            return external_display_dash_prefix(tail);
+            return format!("-/{}", s);
         }
         if let Some(tail) = s.strip_prefix("http://") {
             if tail.starts_with("slug.social") {
                 return s.to_string();
             }
-            return external_display_dash_prefix(tail);
+            return format!("-/{}", s);
         }
         s.to_string()
     }

--- a/types/src/item_wire.rs
+++ b/types/src/item_wire.rs
@@ -46,6 +46,12 @@ pub fn canonicalize_item(input: &str) -> String {
     }
 
     if let Some(rest) = s.strip_prefix("-/") {
+        let rest = rest.trim().trim_start_matches('/');
+        // New wire form: `/-/https://host/path` (full URL after the dash prefix).
+        if rest.starts_with("http://") || rest.starts_with("https://") {
+            return finalize_external_identity_url(rest.to_string());
+        }
+        // Legacy wire form: `/-/host/path` (host-first segments).
         let (host, tail) = rest
             .split_once('/')
             .map_or((rest, ""), |(h, t)| (h, t));
@@ -156,29 +162,4 @@ pub fn item_parent_path(input: &str) -> Option<String> {
         return None;
     }
     Some(segs[..segs.len() - 1].join("/"))
-}
-
-pub(crate) fn external_display_dash_prefix(host_and_path: &str) -> String {
-    let (host, path) = host_and_path
-        .split_once('/')
-        .map_or((host_and_path, ""), |(h, p)| (h, p));
-    let host = host.trim().to_lowercase();
-    let path = path
-        .trim_end_matches('/')
-        .split('/')
-        .filter_map(|seg| {
-            let t = seg.trim();
-            if t.is_empty() {
-                None
-            } else {
-                Some(t.to_lowercase())
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("/");
-    if path.is_empty() {
-        format!("-/{host}")
-    } else {
-        format!("-/{host}/{path}")
-    }
 }

--- a/types/src/paths.rs
+++ b/types/src/paths.rs
@@ -6,7 +6,7 @@
 //! - **[`canonicalize_item`] / [`crate::ItemId`]** — graph storage key and DSL form; tilde
 //!   ontology root is always [`SLUG_TILDE_ONTOLOGY_ROOT`] (no `…/~/` trailing slash only).
 //! - **[`TildeHttpPathTail`]** — capture from `GET /~/*path` or `…/r/{short}{slug}/~/…` (the `*path` segment).
-//! - **`-/…` wire form** — external items; see [`canonicalize_item`] dash branch.
+//! - **`-/…` wire form** — external items: legacy `/-/host/path` or `/-/https://host/path`; see [`canonicalize_item`] dash branch.
 //! - **[`GardenItemUrl`], [`ForumThreadUrl`]** — JSON / browser href surfaces.
 //! - **[`ROOM_SHORT_ID_LEN`] / [`room_route_segment`]** — `/r/{short}{slug}` vs wire `short/slug`.
 
@@ -447,7 +447,7 @@ mod tests {
         let u = "https://example.com/z";
         assert_eq!(
             GardenItemUrl::from_storage_str(u, "9ab12cd/my-room").as_str(),
-            "https://slug.social/r/9ab12cdmy-room/-/example.com/z"
+            "https://slug.social/r/9ab12cdmy-room/-/https://example.com/z"
         );
     }
 
@@ -485,6 +485,14 @@ mod tests {
         assert_eq!(
             canonicalize_item("-/example.com/foo/bar/"),
             "https://example.com/foo/bar"
+        );
+    }
+
+    #[test]
+    fn canonicalize_item_dash_prefix_with_full_https_url() {
+        assert_eq!(
+            canonicalize_item("-/https://BackPack.tf/item/123456"),
+            "https://backpack.tf/item/123456"
         );
     }
 
@@ -529,7 +537,7 @@ mod tests {
     #[test]
     fn display_path_roundtrips_dash_and_tilde() {
         let ext = ItemId::parse("https://GitHub.com/org/Issue").unwrap();
-        assert_eq!(ext.display_path(), "-/github.com/org/issue");
+        assert_eq!(ext.display_path(), "-/https://github.com/org/issue");
         let tilde = ItemId::parse("~/Rust/Doc").unwrap();
         assert_eq!(tilde.display_path(), "~/rust/doc");
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

External ontology items are stored as normalized absolute URLs (for example `https://backpack.tf/item/123456`). The site previously exposed them in the garden as `/-/host/path` (scheme stripped after the dash prefix). They now use the full URL after `/-/`, for example `/-/https://backpack.tf/item/123456`, matching the requested shape.

## How it worked (and still works)

- **Identity / graph**: `slug_types::canonicalize_item` and `ItemId::parse` turn user-facing references into a single canonical storage string (`https://…`). Ingest (DSL, RPC, CLI) uses that pipeline; the reducer keys items by that string.
- **HTTP routing**: Axum matches `GET /-/*path`; the captured tail is passed to `ExternalOntologyPath::from_input`, which prefixes `-/` when the tail does not already start with `http(s)://`, then parses via `ItemId::parse`.
- **Links / JSON hrefs**: `ItemId::display_path()` feeds `ThreadNav::garden_item_href`, `GardenItemUrl`, and prose linkification. Those paths are what browsers and room-scoped routes use.

## What changed

- **`canonicalize_item`**: If the remainder after `-/` begins with `http://` or `https://`, it is normalized as a full URL. The previous host-first branch remains for legacy `-/host/path` input.
- **`ItemId::display_path()`**: For external items, returns `-/` plus the full stored URL (for example `-/https://backpack.tf/item/123456`).
- **`ExternalOntologyPath`**: Breadcrumbs no longer join fake path segments; they walk `ItemId::parent()` so each crumb links to the correct cumulative `/-/https://…` URL.
- **Tests**: Rust unit tests, Playwright Clojure tests, and copy on the public external garden index were updated accordingly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20a1a7bf-b653-4680-814e-b19a9a30724d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20a1a7bf-b653-4680-814e-b19a9a30724d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

