### PR TITLE
Set up dev environment; fix stale AGENTS.md test notes

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -106,7 +106,7 @@ cargo run -p sorterc -- scan path/to/events.jsonl [--pretty]
 
 ### Testing
 
-- **Rust tests:** `cargo nextest run --workspace` (163 tests; requires `cargo-nextest`)
+- **Rust tests:** `cargo nextest run --workspace` (226 tests; requires `cargo-nextest`)
 - **Clojure integration + browser tests:** `clojure -M:kaocha` (runs both `:http-integration` and `:browser` suites; the test harness builds release binaries, starts its own server instances with mock OAuth, and runs Playwright browser tests)
 - **Lint:** `cargo clippy --workspace` (warnings are expected; zero errors required)
 
@@ -116,3 +116,4 @@ cargo run -p sorterc -- scan path/to/events.jsonl [--pretty]
 - `bb dev` (Babashka) is a convenience wrapper around `cargo run` for local dev. It requires `bb` (Babashka) to be installed.
 - Bearer tokens use format `slug_<id>_<secret>` and are verified against the reducer state's `tokens_by_id` map. Raw API-key strings like "dev" won't work; you must complete the OAuth registration flow to get a valid token.
 - Node.js 24 + Playwright chromium are required for browser tests (`npx playwright install chromium`).
+- The browser suite drives Playwright through the **JVM** driver bundled by `spel` (`com.microsoft.playwright`), not Node's `@playwright/test`. On first run it auto-downloads Chromium into `~/.cache/ms-playwright`, so `clojure -M:kaocha` passes even without a separate `npx playwright install` step (the CI-only Node 24 setup above is not a hard local requirement).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Set up and verified the full development environment for the `slugsocial` Rust server (+ Clojure/Kaocha test harness). No product code changed. This PR only corrects two stale/non-obvious notes in the maintainer-facing `agents.md`:

- Rust test count `163` → `226` (actual `cargo nextest run --workspace` result).
- Clarify that the browser suite drives Playwright via the **JVM** driver bundled by `spel` (auto-downloads Chromium to `~/.cache/ms-playwright`), so `clojure -M:kaocha` passes without a separate Node `npx playwright install` step.

## Environment setup performed (not in this diff)

- Rust toolchain `1.88.0` (edition 2024 deps), `cargo-nextest`, `babashka`, and system `pkg-config` + `libssl-dev`.
- Update script (dependency refresh only): `cargo fetch` + `clojure -P -M:kaocha`.

## Verification

- `cargo build --workspace` — builds.
- `cargo clippy --workspace` — 0 errors (warnings expected).
- `cargo nextest run --workspace` — 226 passed.
- `clojure -M:kaocha` — 20 tests / 547 assertions passed (integration + browser).
- Ran dev server (`SLUG_DATA_DIR=dev-data SLUG_KEYS=dev:dev PORT=8080 cargo run -p slugsocial-server`) and exercised the core `.sorter` ranking engine through the `/try` editor.

[slugsocial_try_editor_ranking_demo.mp4](https://cursor.com/agents/bc-f3ceab99-9b09-4f9a-918c-7a0cb030b185/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fslugsocial_try_editor_ranking_demo.mp4)

Core ranking engine ranking fruit items (mango > apple > lemon) live in the `/try` editor.

[Try editor ranking result](https://cursor.com/agents/bc-f3ceab99-9b09-4f9a-918c-7a0cb030b185/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fslug_try_editor_ranking.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3ceab99-9b09-4f9a-918c-7a0cb030b185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3ceab99-9b09-4f9a-918c-7a0cb030b185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

