### PR TITLE
Add localStorage draft autosave for post editors

### DIFF
--- a/server/src/html/editor.rs
+++ b/server/src/html/editor.rs
@@ -36,9 +36,9 @@ pub async fn editor_page(State(state): State<AppState>, jar: CookieJar, uri: Uri
         html! {
             nav class="breadcrumb" { (bc_try()) }
             h2 { "try" }
-            p class="muted" { "write DSL, see what happens. nothing is saved." }
+            p class="muted" { "write DSL, see what happens. drafts autosave in your browser." }
             div class="editor-container" {
-                textarea id="editor-input" rows="12" cols="80"
+                textarea id="editor-input" rows="12" cols="80" data-draft-key="try"
                     placeholder="your-uuid:rig:provider/model\n#your-thread\n\n{ description }\n~/path/item-a\n{ description }\n~/path/item-b\n\n{ reasoning }\n~/path/item-a 3:1 ~/path/item-b"
                     autocomplete="off" autofocus {}
                 div id="editor-status" class="muted" { "type to check…" }

--- a/server/src/html/forum/new_thread.rs
+++ b/server/src/html/forum/new_thread.rs
@@ -15,7 +15,7 @@ const TAG_INPUT_ID: &str = "new-thread-tag";
 fn new_thread_compose_section(room_wire: &str) -> Markup {
     html! {
         section class="compose" id=(COMPOSE_SECTION_ID) {
-            form id=(FORM_ID) method="POST" action="/ui" data-check-action="/ui" data-check-rpc=(template_json_compact(&json!({
+            form id=(FORM_ID) method="POST" action="/ui" data-check-action="/ui" data-draft-key=(format!("new-thread:{}", room_wire)) data-check-rpc=(template_json_compact(&json!({
                 "action": "check_ingest",
                 "room": room_wire,
                 "thread_tag": {"$form": "thread_tag"},

--- a/server/src/html/forum/views.rs
+++ b/server/src/html/forum/views.rs
@@ -37,7 +37,7 @@ fn compose_form(nav: &ThreadNav, thread_tag: &str, show: bool) -> Markup {
     }
     html! {
         section class="compose" id="thread-compose" {
-            form id="thread-compose-form" method="POST" action="/ui" data-check-action="/ui" data-check-rpc=(template_json_compact(&json!({
+            form id="thread-compose-form" method="POST" action="/ui" data-check-action="/ui" data-draft-key=(format!("reply:{}/{}", nav.room_wire, thread_tag)) data-check-rpc=(template_json_compact(&json!({
                 "action": "check_ingest",
                 "room": nav.room_wire,
                 "thread_tag": thread_tag,

--- a/server/src/html/garden/vote.rs
+++ b/server/src/html/garden/vote.rs
@@ -224,6 +224,8 @@ pub(crate) async fn vote_compare_post_success_js(
     JsBuilder::new()
         .morph_inner_selector("#vote-edge-history-region", edge_history)
         .morph_selector(".vote-compare-nav", nav_markup)
+        .qs("#vote-compare-form")
+        .reset()
         .build()
 }
 
@@ -528,7 +530,7 @@ async fn vote_compare_inner(
             (edge_history)
         }
         @if can_post {
-            form id="vote-compare-form" method="POST" action="/ui" {
+            form id="vote-compare-form" method="POST" action="/ui" data-draft-key=(format!("vote:{}/{}/{}", nav.room_wire, left.as_str(), right.as_str())) {
                 input type="hidden" name=(UI_RPC_FIELD) value=(rpc_json);
                 div class="vote-thread-picker" {
                     label class="vote-thread-picker-label" { "thread" }

--- a/server/static/slug_ui.js
+++ b/server/static/slug_ui.js
@@ -2,11 +2,167 @@
  * Slug web UI: only plumbing — fetch/eval/SSE. No product UI logic here.
  */
 (function () {
+  var DRAFT_PREFIX = 'slug-draft:';
+  var draftSaveTimers = new WeakMap();
+  var draftBound = new WeakSet();
+
   function evalJs(js) {
     if (js && String(js).trim()) {
       eval(js);
     }
+    initDrafts();
   }
+
+  function draftStorageId(key) {
+    return DRAFT_PREFIX + key;
+  }
+
+  function draftIsEmpty(data) {
+    return Object.keys(data).every(function (k) {
+      return !String(data[k] || '').trim();
+    });
+  }
+
+  function collectDraft(container) {
+    var data = {};
+    if (container.tagName === 'FORM') {
+      container.querySelectorAll('input[name], textarea[name], select[name]').forEach(function (el) {
+        if (el.type === 'radio' && !el.checked) return;
+        if (el.type === 'checkbox' && !el.checked) return;
+        data[el.name] = el.value;
+      });
+      var slider = container.querySelector('#vote-preference-slider');
+      if (slider) data.__slider = slider.value;
+      return data;
+    }
+    if (container.tagName === 'TEXTAREA' || container.tagName === 'INPUT') {
+      data.__self = container.value;
+    }
+    return data;
+  }
+
+  function clearDraftByKey(key) {
+    if (!key) return;
+    try {
+      localStorage.removeItem(draftStorageId(key));
+    } catch (e) {}
+  }
+
+  function saveDraft(container) {
+    var key = container.getAttribute('data-draft-key');
+    if (!key) return;
+    var data = collectDraft(container);
+    try {
+      if (draftIsEmpty(data)) {
+        clearDraftByKey(key);
+      } else {
+        localStorage.setItem(draftStorageId(key), JSON.stringify(data));
+      }
+    } catch (e) {}
+  }
+
+  function scheduleDraftSave(container) {
+    var prev = draftSaveTimers.get(container);
+    if (prev) clearTimeout(prev);
+    var handle = setTimeout(function () {
+      saveDraft(container);
+    }, 500);
+    draftSaveTimers.set(container, handle);
+  }
+
+  function syncVoteSliderFromDraft(form, data) {
+    var slider = form.querySelector('#vote-preference-slider');
+    if (!slider) return;
+    if (data.__slider != null && String(data.__slider).trim() !== '') {
+      slider.value = data.__slider;
+      slider.dispatchEvent(new Event('input', { bubbles: true }));
+      return;
+    }
+    var left = parseInt(data.ratio_left, 10);
+    var right = parseInt(data.ratio_right, 10);
+    if (!isNaN(left) && !isNaN(right) && left + right > 0) {
+      slider.value = String(Math.round((right * 100) / (left + right)));
+      slider.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+  }
+
+  function restoreDraft(container) {
+    var key = container.getAttribute('data-draft-key');
+    if (!key) return;
+    var raw;
+    try {
+      raw = localStorage.getItem(draftStorageId(key));
+    } catch (e) {
+      return;
+    }
+    if (!raw) return;
+    var data;
+    try {
+      data = JSON.parse(raw);
+    } catch (e) {
+      return;
+    }
+    if (!data || typeof data !== 'object') return;
+
+    if (container.tagName === 'FORM') {
+      container.querySelectorAll('input[name], textarea[name], select[name]').forEach(function (el) {
+        if (!(el.name in data)) return;
+        if (el.type === 'radio') {
+          el.checked = el.value === data[el.name];
+          return;
+        }
+        if (el.type === 'checkbox') {
+          el.checked = !!data[el.name];
+          return;
+        }
+        el.value = data[el.name];
+      });
+      syncVoteSliderFromDraft(container, data);
+      return;
+    }
+
+    if (data.__self != null && (container.tagName === 'TEXTAREA' || container.tagName === 'INPUT')) {
+      container.value = data.__self;
+    }
+  }
+
+  function bindDraftAutosave(container) {
+    if (!container || !container.getAttribute('data-draft-key') || draftBound.has(container)) {
+      return;
+    }
+    draftBound.add(container);
+    restoreDraft(container);
+
+    if (container.tagName === 'FORM') {
+      container.addEventListener('input', function (e) {
+        var target = e.target;
+        if (!target || !(target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.tagName === 'SELECT')) {
+          return;
+        }
+        scheduleDraftSave(container);
+      });
+      container.addEventListener('change', function (e) {
+        var target = e.target;
+        if (!target || target.tagName !== 'SELECT') return;
+        scheduleDraftSave(container);
+      });
+      return;
+    }
+
+    container.addEventListener('input', function () {
+      scheduleDraftSave(container);
+    });
+  }
+
+  function initDrafts() {
+    document.querySelectorAll('form[data-draft-key], [data-draft-key]#editor-input').forEach(bindDraftAutosave);
+  }
+
+  var nativeFormReset = HTMLFormElement.prototype.reset;
+  HTMLFormElement.prototype.reset = function () {
+    nativeFormReset.call(this);
+    clearDraftByKey(this.getAttribute('data-draft-key'));
+  };
 
   // Theme cookie sync (runs before paint; full reload if localStorage disagrees with cookie)
   try {
@@ -246,6 +402,7 @@
       };
     }
     connectSSE();
+    initDrafts();
   }
 
   if (document.readyState === 'loading') {

--- a/test/browser_draft_autosave.clj
+++ b/test/browser_draft_autosave.clj
@@ -1,0 +1,147 @@
+(ns test.browser-draft-autosave
+  "Playwright checks for compose draft autosave in localStorage."
+  (:require [babashka.fs :as fs]
+            [cheshire.core :as json]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is]]
+            [com.blockether.spel.core :as core]
+            [com.blockether.spel.locator :as locator]
+            [com.blockether.spel.page :as page]
+            [test.common :as common]
+            [test.oauth :as oauth]))
+
+(defn- wait-for-text [pg selector expected timeout-ms]
+  (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+    (loop []
+      (let [text (locator/text-content (page/locator pg selector))]
+        (if (and (string? text) (str/includes? text expected))
+          true
+          (if (< (System/currentTimeMillis) deadline)
+            (do (Thread/sleep 200) (recur))
+            false))))))
+
+(defn- draft-ls-key [draft-key]
+  (str "slug-draft:" draft-key))
+
+(defn- wait-for-local-storage [pg ls-key pred timeout-ms]
+  (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+    (loop []
+      (let [raw (page/evaluate pg (str "localStorage.getItem(" (pr-str ls-key) ")"))]
+        (if (pred raw)
+          raw
+          (if (< (System/currentTimeMillis) deadline)
+            (do (Thread/sleep 200) (recur))
+            nil))))))
+
+(defn- textarea-value [pg selector]
+  (page/evaluate pg (str "(document.querySelector(" (pr-str selector) ") || {}).value")))
+
+(defn draft-autosave-flow! []
+  (println "\n━━━ browser compose draft autosave (localStorage) ━━━\n")
+
+  (common/letlocals
+   (bind build (common/run-cargo-build-release! ["slugsocial-server"]))
+   (is (zero? (:exit build)) "cargo build succeeds")
+   (bind server-bin "target/release/slugsocial-server")
+
+   (bind tmp-dir (str (fs/create-temp-dir {:prefix "slug-browser-draft-"})))
+   (bind slug-port (common/pick-port))
+   (bind google-port (common/pick-port))
+   (bind base-url (str "http://127.0.0.1:" slug-port))
+   (bind google-url (str "http://127.0.0.1:" google-port))
+
+   (bind !server (atom nil))
+   (bind !google (atom nil))
+   (bind server-env (common/slug-server-env tmp-dir base-url google-url slug-port))
+   (try
+     (reset! !google (oauth/start-mock-google google-port
+                                              :google-users ["google-user-alice"]))
+     (reset! !server (common/start-server server-bin server-env))
+     (is (common/wait-for-server base-url 10000) "server responds to /healthz")
+
+     (let [alice-token (oauth/fetch-bearer-token! base-url :username "alice")
+           thread-tag "browser-draft-autosave"
+           draft-text "PLAYWRIGHT_DRAFT_AUTOSAVE_MARKER"
+           draft-key (str "reply:public/" thread-tag)
+           ls-key (draft-ls-key draft-key)
+           seed-resp (oauth/http-post-json
+                      (str base-url "/api/v0/rpc")
+                      [{"Post" {"room" "public"
+                                "thread_tag" thread-tag
+                                "text" (str "# " thread-tag "\n\nseed post for draft test")
+                                "return_rank_diff" false}}]
+                      :headers {"Authorization" (str "Bearer " alice-token)})
+           seed-json (json/parse-string (:body seed-resp) false)
+           _ (is (true? (get-in seed-json ["results" 0 "ok"])) "seed thread via rpc")]
+       (core/with-playwright [pw]
+         (core/with-browser [browser (core/launch-chromium pw {:headless true :channel "chrome"})]
+           (core/with-context [ctx (core/new-context browser)]
+             (core/with-page [pg (core/new-page-from-context ctx)]
+               (page/navigate pg (str base-url "/login"))
+               (is (wait-for-text pg "body" "@alice" 15000) "alice session after login")
+
+               ;; Thread reply compose: autosave + restore on reload
+               (page/navigate pg (str base-url "/t/" thread-tag))
+               (is (wait-for-text pg "#thread-compose" "post" 15000) "thread compose visible")
+               (locator/fill (page/locator pg "#thread-compose textarea") draft-text)
+               (let [stored (wait-for-local-storage
+                             pg ls-key
+                             (fn [raw]
+                               (when raw
+                                 (try
+                                   (= draft-text (get (json/parse-string raw false) "text"))
+                                   (catch Exception _ false))))
+                             5000)]
+                 (is (string? stored) "draft saved to localStorage after typing"))
+               (page/reload pg)
+               (is (wait-for-text pg "#thread-compose" "post" 15000) "compose after reload")
+               (is (= draft-text (textarea-value pg "#thread-compose textarea"))
+                   "draft restored into textarea after reload")
+
+               ;; Successful post clears draft
+               (locator/click (page/locator pg "#thread-compose-form button[type=submit]"))
+               (is (wait-for-text pg "#thread-feed-region" draft-text 20000)
+                   "posted draft text appears in feed")
+               (let [cleared (wait-for-local-storage
+                              pg ls-key
+                              (fn [raw] (nil? raw))
+                              5000)]
+                 (is (nil? cleared) "draft removed from localStorage after successful post"))
+
+               ;; New thread compose: tag + body persist across reload when expanded
+               (page/navigate pg base-url)
+               (is (wait-for-text pg "#new-thread-ui-slot" "+" 15000) "new thread slot on home")
+               (locator/click (page/locator pg "#new-thread-ui-slot button.form-toggle"))
+               (is (wait-for-text pg "#new-thread-compose" "create thread" 15000) "new thread compose expanded")
+               (locator/fill (page/locator pg "#new-thread-tag") "draft-tag-slug")
+               (locator/fill (page/locator pg "#new-thread-compose textarea") "draft new thread body")
+               (let [new-ls-key (draft-ls-key "new-thread:public")
+                     stored (wait-for-local-storage
+                             pg new-ls-key
+                             (fn [raw]
+                               (when raw
+                                 (let [d (json/parse-string raw false)]
+                                   (and (= "draft-tag-slug" (get d "thread_tag"))
+                                        (= "draft new thread body" (get d "text"))))))
+                             5000)]
+                 (is (string? stored) "new-thread draft saved to localStorage"))
+               (page/reload pg)
+               (locator/click (page/locator pg "#new-thread-ui-slot button.form-toggle"))
+               (is (wait-for-text pg "#new-thread-compose" "create thread" 15000) "new thread compose re-expanded")
+               (is (= "draft-tag-slug" (textarea-value pg "#new-thread-tag"))
+                   "new-thread tag restored after reload")
+               (is (= "draft new thread body" (textarea-value pg "#new-thread-compose textarea"))
+                   "new-thread body restored after reload"))))))
+
+     (finally
+       (when-some [s @!server] (common/kill-server s))
+       (when-some [g @!google] ((:stop-fn g)))
+       (fs/delete-tree tmp-dir)))
+
+   nil))
+
+(defn draft-autosave-browser-test [& _args]
+  (draft-autosave-flow!))
+
+(deftest browser-compose-draft-autosave
+  (draft-autosave-flow!))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds client-side draft autosave for all compose surfaces. Drafts persist in `localStorage` (not server events or session storage), matching how other UI preferences like spread are stored.

## Approach

**localStorage over session or event-based drafts:**
- **localStorage** — survives browser restarts, matches existing `slug-spread` / `slug-theme` patterns
- **sessionStorage** — would lose drafts when the tab closes; not used elsewhere in the app
- **Event-based drafts** — would require a new event type, reducer changes, and published draft records; too heavy for v1

## Behavior

- **Autosave**: every input/textarea/select in a compose form debounces to 500ms and saves to `localStorage`
- **Restore**: on page load and after server-driven Idiomorph morphs (e.g. expanding new-thread compose)
- **Clear**: drafts are removed when a form is reset (after successful post) or when all fields are empty
- **Scoped keys** per context:
  - `reply:{room}/{thread}` — thread reply
  - `new-thread:{room}` — new thread compose
  - `vote:{room}/{left}/{right}` — vote compare
  - `try` — `/try` playground

## Surfaces covered

| Surface | Fields saved |
|---------|-------------|
| Thread reply | `text` |
| New thread | `thread_tag`, `text` |
| Vote compare | `thread_tag`, slider, ratios, `explanation` |
| `/try` editor | textarea body |

Vote compare form now resets after a successful post (explanation cleared, slider back to 50/50).

## Testing

- `cargo test -p slugsocial-server` — passes
- `clojure -M:kaocha --focus test.browser-draft-autosave` — Playwright test (16 assertions) covering:
  - thread reply draft save + restore on reload
  - draft cleared after successful post
  - new-thread tag + body restore after reload + re-expand
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3508d565-2f93-4584-af90-049d63b0b5cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3508d565-2f93-4584-af90-049d63b0b5cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

