### PR TITLE
Fix garden tree paths and concise CLI errors

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -837,7 +837,10 @@ async fn run_scoped(base: &str, room: &str, sub: ScopedCmd) -> Result<()> {
                             println!("{}", serde_json::to_string_pretty(&resp)?);
                         } else {
                             for p in &resp.paths {
-                                println!("~/{p}");
+                                let display = ItemId::parse(p.as_str())
+                                    .map(|item| item.display_path())
+                                    .unwrap_or_else(|| p.to_string());
+                                println!("{display}");
                             }
                         }
                     }
@@ -1355,7 +1358,17 @@ async fn run_scoped(base: &str, room: &str, sub: ScopedCmd) -> Result<()> {
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> std::process::ExitCode {
+    match run().await {
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("Error: {error}");
+            std::process::ExitCode::FAILURE
+        }
+    }
+}
+
+async fn run() -> Result<()> {
     let Cli { cmd, server } = Cli::parse();
 
     // If no command provided, print the guide

--- a/test/integration.clj
+++ b/test/integration.clj
@@ -230,6 +230,22 @@
       (is (str/ends-with? (last ranked) "languages/go")
                (str "go is #3 (got " (last ranked) ")"))
 
+      (println "\nchecking agent-facing missing path error…")
+      (bind missing-path-result
+            (common/run-cli cli-bin base-url
+                            ["public" "garden" "children" "--" "does-not-exist"]
+                            :extra-env {"RUST_BACKTRACE" "1"}))
+      (is (not (zero? (:exit missing-path-result)))
+          "missing garden path exits nonzero")
+      (bind missing-path-output
+            (str (:out missing-path-result) (:err missing-path-result)))
+      (is (str/includes? missing-path-output "path not found")
+          "missing garden path reports the concise error")
+      (is (str/includes? missing-path-output "~/does-not-exist does not exist")
+          "missing garden path preserves the actionable hint")
+      (is (not (str/includes? missing-path-output "Stack backtrace:"))
+          "missing garden path does not expose an anyhow backtrace")
+
         ;; 5. verify JSONL written (user_registered + token_issued + room_created + grant_added
         ;;    + private ingest + agent_bound + public ingest)
       (is (fs/exists? event-log) "events.jsonl exists")
@@ -251,6 +267,18 @@
       (is (= 2 (count ext-ranked)) (str "2 external issues ranked (got " (count ext-ranked) ")"))
       (is (str/ends-with? (first ext-ranked) "github.com/iss/1")
                (str "iss/1 is #1 (got " (first ext-ranked) ")"))
+
+      (println "\nquerying complete garden tree via CLI…")
+      (bind tree-result (common/run-cli cli-bin base-url ["public" "garden" "tree"]))
+      (is (zero? (:exit tree-result))
+          (str "cli garden tree exits 0 (err: " (:err tree-result) ")"))
+      (bind tree-paths (->> (:out tree-result) str/split-lines (remove str/blank?) set))
+      (is (contains? tree-paths "~/languages/rust")
+          "tree renders slug.social leaves as clean ~/ paths")
+      (is (contains? tree-paths "-/https://github.com/iss/1")
+          "tree renders external leaves with the -/ URL form")
+      (is (not-any? #(str/starts-with? % "~/http") tree-paths)
+          "tree never adds ~/ in front of absolute URLs")
 
       (bind event-lines-after-ext (->> (slurp event-log) str/split-lines (remove str/blank?)))
       (is (= 8 (count event-lines-after-ext))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- render garden leaves through canonical item display paths instead of prefixing absolute URLs
- print CLI failures with `Display` so `RUST_BACKTRACE=1` never leaks internal stack frames to agents
- cover clean public and external tree paths plus concise missing-path failures end to end

## Verification
- `clojure -M:kaocha --focus test.integration/slug-integration-check` (78 assertions)
- `cargo nextest run --workspace` (227 tests)
- `cargo clippy --workspace --all-targets` (passes with existing warnings)
- production-backed CLI read checks for canonical tree output and concise errors

## Cross-repository finding
The council regression is not implemented in this repository: `sortersocial/constitution` still calls removed `GET /api/v0/rank` and `/api/v0/item` endpoints, suppresses every exception, and production has no durable ingest under `~/slug/token/commit-ranking/model`. That repository must migrate to `POST /api/v0/rpc`, fail closed when its configured council is unavailable, and publish model declarations/votes through a real community ingest. This agent's token does not have write access to that repository.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05f50d0c-62d3-4810-8e13-87399fdb5594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05f50d0c-62d3-4810-8e13-87399fdb5594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

