### PR TITLE
Show reduced vote ratios on the compare screen

### DIFF
--- a/server/src/api/rpc.rs
+++ b/server/src/api/rpc.rs
@@ -1307,7 +1307,10 @@ pub async fn handle_rpc_batch(
                                     ts: v.ts,
                                     a: GardenItemUrl::from_stored(&v.a, &room),
                                     b: GardenItemUrl::from_stored(&v.b, &room),
-                                    ratio: format!("{}:{}", v.ratio_left, v.ratio_right),
+                                    ratio: {
+                                        let (l, r) = crate::dsl::reduce_ratio(v.ratio_left, v.ratio_right);
+                                        format!("{l}:{r}")
+                                    },
                                     actor: Some(v.principal.clone()),
                                     body: v.body.clone(),
                                     thread: Some(v.thread_tag.clone()),
@@ -1345,8 +1348,11 @@ pub async fn handle_rpc_batch(
                                             ts: e.ts,
                                             a: GardenItemUrl::from_storage_str(&a, &room),
                                             b: GardenItemUrl::from_storage_str(&b, &room),
-                                            ratio: format!("{ratio_left}:{ratio_right}"),
-                                            actor: reduced.ingests_by_id.get(&e.post_id).map(|ing| ing.principal.clone()),
+                                    ratio: {
+                                        let (l, r) = crate::dsl::reduce_ratio(ratio_left, ratio_right);
+                                        format!("{l}:{r}")
+                                    },
+                                    actor: reduced.ingests_by_id.get(&e.post_id).map(|ing| ing.principal.clone()),
                                             body: explanation,
                                             thread: Some(format!("#{}", e.thread)),
                                         })
@@ -1453,7 +1459,10 @@ pub async fn handle_rpc_batch(
                         ts: v.ts,
                         a: GardenItemUrl::from_stored(&v.a, &room),
                         b: GardenItemUrl::from_stored(&v.b, &room),
-                        ratio: format!("{}:{}", v.ratio_left, v.ratio_right),
+                        ratio: {
+                            let (l, r) = crate::dsl::reduce_ratio(v.ratio_left, v.ratio_right);
+                            format!("{l}:{r}")
+                        },
                         actor: Some(v.principal.clone()),
                         body: v.body.clone(),
                         thread: Some(v.thread_tag.clone()),

--- a/server/src/api/ui_html.rs
+++ b/server/src/api/ui_html.rs
@@ -261,6 +261,7 @@ async fn dispatch_ui_action(
                 )
                 .into_response();
             }
+            let (rl, rr) = crate::dsl::reduce_ratio(rl, rr);
 
             let text = format!(
                 "{{\n{}\n}}\n{} {}:{} {}\n",

--- a/server/src/dsl.rs
+++ b/server/src/dsl.rs
@@ -32,6 +32,30 @@ pub enum DslError {
     Parse(String),
 }
 
+/// Greatest common divisor (non-negative). `gcd(0, n) == n`, `gcd(0, 0) == 0`.
+pub fn gcd_i32(mut a: i32, mut b: i32) -> i32 {
+    a = a.abs();
+    b = b.abs();
+    while b != 0 {
+        let t = b;
+        b = a % b;
+        a = t;
+    }
+    a
+}
+
+/// Reduce a vote ratio by dividing both sides by their GCD.
+/// Non-positive inputs are clamped to 0; `(0, 0)` becomes `(1, 1)`.
+pub fn reduce_ratio(left: i32, right: i32) -> (i32, i32) {
+    let l = left.max(0);
+    let r = right.max(0);
+    if l == 0 && r == 0 {
+        return (1, 1);
+    }
+    let g = gcd_i32(l, r).max(1);
+    (l / g, r / g)
+}
+
 /// Helper to mask balanced blocks to protect them during filtering/parsing.
 ///
 /// Matches the legacy Python parser behavior:
@@ -555,6 +579,7 @@ fn parse_block_prefixed_statement(
             "vote ratio sides must be ≤ 100".to_string(),
         ));
     }
+    let (ratio_left, ratio_right) = reduce_ratio(ratio_left, ratio_right);
     i = skip_ws(s, k);
     let (item2, m) = parse_item_name_at(s, i)
         .ok_or_else(|| DslError::Parse("invalid rhs item name".to_string()))?;
@@ -975,6 +1000,38 @@ mod tests {
         assert!(matches!(
             doc.statements.last(),
             Some(Stmt::Vote { ratio_left: 100, ratio_right: 1, .. })
+        ));
+    }
+
+    #[test]
+    fn reduce_ratio_divides_by_gcd() {
+        assert_eq!(reduce_ratio(50, 50), (1, 1));
+        assert_eq!(reduce_ratio(25, 75), (1, 3));
+        assert_eq!(reduce_ratio(75, 25), (3, 1));
+        assert_eq!(reduce_ratio(2, 1), (2, 1));
+        assert_eq!(reduce_ratio(100, 1), (100, 1));
+        assert_eq!(reduce_ratio(0, 0), (1, 1));
+    }
+
+    #[test]
+    fn parse_vote_reduces_ratio_by_gcd() {
+        let doc = parse_full("{tie}\n~/a 50:50 ~/b").unwrap();
+        assert!(matches!(
+            doc.statements.last(),
+            Some(Stmt::Vote {
+                ratio_left: 1,
+                ratio_right: 1,
+                ..
+            })
+        ));
+        let doc = parse_full("{prefer b}\n~/a 25:75 ~/b").unwrap();
+        assert!(matches!(
+            doc.statements.last(),
+            Some(Stmt::Vote {
+                ratio_left: 1,
+                ratio_right: 3,
+                ..
+            })
         ));
     }
 

--- a/server/src/html/garden/render.rs
+++ b/server/src/html/garden/render.rs
@@ -11,7 +11,7 @@ use crate::{
         forum::ThreadNav,
         layout,
         now_ms,
-        ratio_pct,
+        format_ratio, ratio_pct,
         render_item_body_in_scope,
         theme_from_jar,
         theme_next_from_uri,
@@ -158,7 +158,7 @@ pub(super) async fn render_scope_view(
                                     div class="rank-history-vote" {
                                         div class="ont-vote-header" {
                                             a class="item-link" href=(item_href(v.a.as_str(), &nav)) { code { (item_code_label(v.a.as_str())) } }
-                                            span class="vote-ratio" { (format!("{}:{}", v.ratio_left, v.ratio_right)) }
+                                            span class="vote-ratio" { (format_ratio(v.ratio_left, v.ratio_right)) }
                                             a class="item-link" href=(item_href(v.b.as_str(), &nav)) { code { (item_code_label(v.b.as_str())) } }
                                         }
                                         div class="ratio-bar" {

--- a/server/src/html/garden/tests.rs
+++ b/server/src/html/garden/tests.rs
@@ -58,10 +58,11 @@ fn vote_edge_compare_sorts_rows_by_strength_for_page_left() {
     let raw = edge_vote_entries_for_pair(content, &page_left, &page_right);
     assert_eq!(raw.len(), 2);
     let sorted = sort_votes_for_compare_display(raw, &page_left, &page_right);
-    let (r0, _) = ratios_for_compare_page(&sorted[0], &page_left, &page_right);
-    assert_eq!(r0, 8, "stronger left weight should sort first");
-    let (r1, _) = ratios_for_compare_page(&sorted[1], &page_left, &page_right);
-    assert_eq!(r1, 1);
+    // 8:2 is stored reduced as 4:1; still a stronger left share than 1:9.
+    let (r0_l, r0_r) = ratios_for_compare_page(&sorted[0], &page_left, &page_right);
+    assert_eq!((r0_l, r0_r), (4, 1), "stronger left weight should sort first");
+    let (r1_l, r1_r) = ratios_for_compare_page(&sorted[1], &page_left, &page_right);
+    assert_eq!((r1_l, r1_r), (1, 9));
 }
 
 #[test]

--- a/server/src/html/garden/vote.rs
+++ b/server/src/html/garden/vote.rs
@@ -16,7 +16,7 @@ use crate::{
     html::{
         forum::ThreadNav,
         layout_full_bleed_chromeless,
-        ratio_pct, render_item_body_in_scope,
+        format_ratio, ratio_pct, render_item_body_in_scope,
         theme_from_jar, theme_next_from_uri,
         user_can_post_room,
         ui_action::UI_RPC_FIELD,
@@ -173,11 +173,11 @@ fn vote_edge_history_markup(content: &ContentState, left: &ItemId, right: &ItemI
             ul class="vote-edge-history" {
                 @for v in &votes {
                     @let (r_left, r_right) = ratios_for_compare_page(v, left, right);
+                    @let ratio_label = format_ratio(r_left, r_right);
                     @let pct = ratio_pct(r_left, r_right);
                     @let row_tip = format!(
-                        "{}:{} counts toward {} (left of bar) vs {} (right of bar); #{} · @{}",
-                        r_left,
-                        r_right,
+                        "{} counts toward {} (left of bar) vs {} (right of bar); #{} · @{}",
+                        ratio_label,
                         legend_left,
                         legend_right,
                         v.thread_tag,
@@ -185,7 +185,7 @@ fn vote_edge_history_markup(content: &ContentState, left: &ItemId, right: &ItemI
                     );
                     li class="vote-edge-history-row" title=(row_tip) {
                         div class="vote-edge-meta" {
-                            span class="vote-edge-ratio" { (format!("{}:{}", r_left, r_right)) }
+                            span class="vote-edge-ratio" { (ratio_label) }
                             span class="muted" { " · #" (v.thread_tag) " · @" (v.principal) }
                         }
                         div class="ratio-bar vote-edge-bar" aria-hidden="true" {
@@ -547,12 +547,17 @@ async fn vote_compare_inner(
                         }
                     }
                 }
-                input type="hidden" name="ratio_left" id="vote-ratio-left" value="50";
-                input type="hidden" name="ratio_right" id="vote-ratio-right" value="50";
+                input type="hidden" name="ratio_left" id="vote-ratio-left" value="1";
+                input type="hidden" name="ratio_right" id="vote-ratio-right" value="1";
+                p class="vote-ratio-readout-wrap" {
+                    span class="vote-ratio-readout-label muted" { "ratio" }
+                    " "
+                    span id="vote-ratio-readout" class="vote-ratio-readout" aria-live="polite" { "1:1" }
+                }
                 label class="vote-compare-slider-label" {
                     span id="vote-slider-left-label" { (item_display_path(left.as_str())) }
                     input type="range" id="vote-preference-slider" min="0" max="100" value="50"
-                        aria-valuemin="0" aria-valuemax="100";
+                        aria-valuemin="0" aria-valuemax="100" aria-valuetext="1:1";
                     span id="vote-slider-right-label" { (item_display_path(right.as_str())) }
                 }
                 label class="vote-explain-label" { "reason (required)" }

--- a/server/src/html/mod.rs
+++ b/server/src/html/mod.rs
@@ -448,6 +448,12 @@ pub(super) fn ratio_pct(left: i32, right: i32) -> f64 {
     (l / denom) * 100.0
 }
 
+/// Display form of a vote ratio, reduced by GCD (e.g. `50:50` → `1:1`).
+pub(super) fn format_ratio(left: i32, right: i32) -> String {
+    let (l, r) = crate::dsl::reduce_ratio(left, right);
+    format!("{l}:{r}")
+}
+
 /// Render a single breadcrumb segment with `/` separator.
 pub(super) fn bc_segment(label: &str, href: &str, is_current: bool) -> Markup {
     html! {

--- a/server/static/slug_ui.js
+++ b/server/static/slug_ui.js
@@ -368,22 +368,41 @@
     }
     refreshPinHud();
 
-    // Vote compare: map slider 0–100 to integer ratio weights
+    // Vote compare: map slider 0–100 to reduced integer ratio weights
     var voteSlider = document.getElementById('vote-preference-slider');
     if (voteSlider) {
       var rl = document.getElementById('vote-ratio-left');
       var rr = document.getElementById('vote-ratio-right');
+      var readout = document.getElementById('vote-ratio-readout');
+      function gcd(a, b) {
+        a = Math.abs(a | 0);
+        b = Math.abs(b | 0);
+        while (b) {
+          var t = b;
+          b = a % b;
+          a = t;
+        }
+        return a || 1;
+      }
+      function reduceRatio(left, right) {
+        var L = Math.max(1, left | 0);
+        var R = Math.max(1, right | 0);
+        var g = gcd(L, R);
+        return [L / g, R / g];
+      }
       function syncVoteRatio() {
         var p = parseInt(voteSlider.value, 10);
         if (isNaN(p)) p = 50;
-        var L = 100 - p;
-        var R = p;
-        if (L === 0 && R === 0) {
-          L = 1;
-          R = 1;
-        }
+        var rawL = 100 - p;
+        var rawR = p;
+        var reduced = reduceRatio(rawL, rawR);
+        var L = reduced[0];
+        var R = reduced[1];
+        var label = L + ':' + R;
         if (rl) rl.value = String(L);
         if (rr) rr.value = String(R);
+        if (readout) readout.textContent = label;
+        voteSlider.setAttribute('aria-valuetext', label);
       }
       voteSlider.addEventListener('input', syncVoteRatio);
       syncVoteRatio();

--- a/server/static/theme_default.css
+++ b/server/static/theme_default.css
@@ -1068,6 +1068,23 @@ body.view-vote-compare .vote-compare-shell > h2 {
   cursor: default;
   opacity: 0.65;
 }
+.vote-ratio-readout-wrap {
+  margin: 14px 0 4px;
+  text-align: center;
+  font-size: 13px;
+}
+.vote-ratio-readout-label {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.vote-ratio-readout {
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  font-size: 18px;
+  letter-spacing: 0.04em;
+  color: var(--ui);
+}
 .vote-compare-slider-label {
   display: flex;
   flex-wrap: wrap;

--- a/server/static/theme_retro.css
+++ b/server/static/theme_retro.css
@@ -136,6 +136,24 @@ body.view-ontology nav.breadcrumb a.bc-current { color: #111; font-weight: 600; 
 body.view-ontology nav.breadcrumb .bc-sep { color: #888; padding: 0 2px; }
 
 body.view-ontology .resolver-actions,
+body.view-ontology .vote-ratio-readout-wrap {
+  margin: 0.85rem 0 0.25rem;
+  text-align: center;
+  font-size: 0.85rem;
+}
+body.view-ontology .vote-ratio-readout-label {
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #666;
+}
+body.view-ontology .vote-ratio-readout {
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  font-size: 1.15rem;
+  letter-spacing: 0.04em;
+  color: #111;
+}
 body.view-ontology .vote-compare-nav {
   display: flex;
   flex-wrap: wrap;

--- a/server/static/theme_retro_craft.css
+++ b/server/static/theme_retro_craft.css
@@ -996,6 +996,25 @@ body.view-ontology .vote-compare-slider-label {
   font-size: 0.72rem;
   color: #5c574e;
 }
+body.view-ontology .vote-ratio-readout-wrap {
+  margin: 0.85rem 0 0.25rem;
+  text-align: center;
+  font-family: var(--font-ui);
+  font-size: 0.78rem;
+}
+body.view-ontology .vote-ratio-readout-label {
+  font-size: 0.68rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #5c574e;
+}
+body.view-ontology .vote-ratio-readout {
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  font-size: 1.15rem;
+  letter-spacing: 0.04em;
+  color: #1a1814;
+}
 body.view-ontology #vote-preference-slider {
   flex: 1 1 11rem;
   min-width: 8rem;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a live ratio readout on the voting/compare screen and reduces ratios by GCD everywhere they matter.

### Changes
- Vote slider now shows a live **ratio** (e.g. `1:1`, `3:1`) as you drag
- Client maps the slider to GCD-reduced integer weights before submit (`50:50` → `1:1`, `25:75` → `1:3`)
- DSL parse + UI vote post also reduce ratios on ingest
- Edge history / rank history / API vote rows display reduced ratios for older unreduced data

### Example
| Slider | Before | After |
|--------|--------|-------|
| center | `50:50` | `1:1` |
| 25% right | `75:25` | `3:1` |
| 75% right | `25:75` | `1:3` |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-651b1928-1d44-4eaf-ae74-834af08b5400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-651b1928-1d44-4eaf-ae74-834af08b5400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

