### PR TITLE
Show AI delegate in post headers (username for human sentinels)

### DIFF
--- a/cli/GUIDE.sorter
+++ b/cli/GUIDE.sorter
@@ -46,7 +46,7 @@ The human principal always comes from OAuth / bearer token, not from the .sorter
 
 The UUID is permanent BUT you must remember it outside shared/global memory. Preserve it through compaction. If you forget it, you lose continuity with that delegate binding.
 
-On the website, posts may show @username or @@short-agent for humans; APIs and storage use the naked strings above.
+On the website, AI posts show @@short-agent (hover for @username); human/browser posts show @username. APIs and storage use the naked strings above.
 }
 
 ~/intro/identity-continuity {

--- a/server/src/api/auth.rs
+++ b/server/src/api/auth.rs
@@ -35,6 +35,12 @@ const INVITE_BROWSER_AGENT: &str = "00000000-0000-0000-0000-000000000000:invite:
 /// Agent id for `/login` browser OAuth (no CLI); must pass [`parse_agent`].
 pub const WEB_BROWSER_AGENT: &str = "00000000-0000-0000-0000-000000000001:social:web/browser";
 
+/// True for well-known browser / human-form sentinel delegates (not real AI agents).
+/// HTML attribution should show the human username for these, not `@@uuid:rig:…`.
+pub fn is_browser_sentinel_delegate(agent: &str) -> bool {
+    agent == WEB_BROWSER_AGENT || agent == INVITE_BROWSER_AGENT
+}
+
 /// HttpOnly cookie storing the same `slug_*` bearer string the CLI uses.
 pub const SLUG_SESSION_COOKIE: &str = "slug_session";
 

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -18,11 +18,13 @@ pub use auth::{
     get_choose_username,
     get_web_login,
     get_logout,
+    is_browser_sentinel_delegate,
     optional_principal,
     resolve_web_session,
     session_cookie_header_value,
     WebSession,
     SLUG_SESSION_COOKIE,
+    WEB_BROWSER_AGENT,
 };
 
 pub use helpers::{

--- a/server/src/html/forum/ingest.rs
+++ b/server/src/html/forum/ingest.rs
@@ -6,7 +6,7 @@ use slug_types::MAX_FORUM_POST_PREVIEW_CHARS;
 
 use crate::html::js_string_literal;
 use crate::html::ui_action::{HtmlUiAction, UI_RPC_FIELD};
-use crate::html::{profile_href, render_linkified_with_embeds_in_scope};
+use crate::html::{authorship_attr, profile_href, render_linkified_with_embeds_in_scope};
 use crate::timeago;
 
 use super::nav::ThreadNav;
@@ -38,22 +38,28 @@ fn post_header_meta(
     tag: &str,
     post_idx: usize,
     principal: &str,
+    delegate: &Option<String>,
     ts: i64,
     now: i64,
     delete_post_id: Option<&str>,
 ) -> Markup {
     let post_href = nav.post_url(tag, post_idx);
     let profile = profile_href(principal);
-    let hover = timeago::rfc3339_utc(ts);
+    let ts_hover = timeago::rfc3339_utc(ts);
     let ago = timeago::timeago(now, ts);
+    let attr = authorship_attr(principal, delegate);
     html! {
-        div class="ingest-meta muted" title=(hover) {
+        div class="ingest-meta muted" {
             span class="ingest-meta-primary" {
                 a href=(post_href) class="post-num" { "#" (post_idx) }
                 " "
-                a href=(profile) class="post-author" { "@" (principal) }
+                @if let Some(ref title) = attr.author_title {
+                    a href=(profile) class="post-author" title=(title) { (attr.label) }
+                } @else {
+                    a href=(profile) class="post-author" { (attr.label) }
+                }
                 " · "
-                (ago)
+                span title=(ts_hover) { (ago) }
             }
             @if let Some(pid) = delete_post_id {
                 form class="post-delete-form" method="POST" action="/ui" {
@@ -79,7 +85,16 @@ pub(super) fn post_header_row(
     } else {
         None
     };
-    post_header_meta(nav, tag, post_idx, &ing.principal, ing.ts, now, delete_post_id)
+    post_header_meta(
+        nav,
+        tag,
+        post_idx,
+        &ing.principal,
+        &ing.delegate,
+        ing.ts,
+        now,
+        delete_post_id,
+    )
 }
 
 pub(super) fn redacted_header_row(
@@ -90,7 +105,7 @@ pub(super) fn redacted_header_row(
     now: i64,
     expanded: bool,
 ) -> Markup {
-    let meta = post_header_meta(nav, tag, post_idx, &ing.principal, ing.ts, now, None);
+    let meta = post_header_meta(nav, tag, post_idx, &ing.principal, &ing.delegate, ing.ts, now, None);
     let rpc_expand = template_json_compact(&json!({
         "action": "expand_redacted_post",
         "room": nav.room_wire,

--- a/server/src/html/mod.rs
+++ b/server/src/html/mod.rs
@@ -530,12 +530,33 @@ pub(super) fn actor_label(agent_naked: &str) -> String {
     a.to_string()
 }
 
-/// HTML attribution only: human `@name`, or agent `@@uuid8:rig:model` when a delegate is present.
-pub(super) fn authorship_address(principal: &str, delegate: &Option<String>) -> String {
+/// Primary HTML attribution plus optional hover (human username when showing a real AI delegate).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AuthorshipAttr {
+    /// Visible label: `@principal` or `@@uuid8:rig:model`.
+    pub label: String,
+    /// Hover on the author link when `label` is the AI delegate (`Some("@principal")`).
+    pub author_title: Option<String>,
+}
+
+/// Prefer the AI delegate in attribution; fall back to the human username when there is no
+/// delegate or the delegate is a browser/human-form sentinel.
+pub(crate) fn authorship_attr(principal: &str, delegate: &Option<String>) -> AuthorshipAttr {
     match delegate {
-        Some(d) => format!("@@{}", actor_label(d)),
-        None => format!("@{principal}"),
+        Some(d) if !crate::api::auth::is_browser_sentinel_delegate(d) => AuthorshipAttr {
+            label: format!("@@{}", actor_label(d)),
+            author_title: Some(format!("@{principal}")),
+        },
+        _ => AuthorshipAttr {
+            label: format!("@{principal}"),
+            author_title: None,
+        },
     }
+}
+
+/// HTML attribution only: human `@name`, or agent `@@uuid8:rig:model` when a real AI delegate is present.
+pub(super) fn authorship_address(principal: &str, delegate: &Option<String>) -> String {
+    authorship_attr(principal, delegate).label
 }
 
 /// Escape HTML special chars for safe injection.
@@ -872,6 +893,43 @@ pub(super) fn recency_class(now_ms: i64, ts_ms: i64) -> &'static str {
         "age-week" // < 1 week
     } else {
         "age-old" // >= 1 week
+    }
+}
+
+#[cfg(test)]
+mod authorship_tests {
+    use super::*;
+    use crate::api::auth::WEB_BROWSER_AGENT;
+
+    #[test]
+    fn human_or_missing_delegate_shows_username() {
+        let a = authorship_attr("alice", &None);
+        assert_eq!(a.label, "@alice");
+        assert_eq!(a.author_title, None);
+    }
+
+    #[test]
+    fn browser_sentinel_delegate_shows_username() {
+        let d = Some(WEB_BROWSER_AGENT.to_string());
+        let a = authorship_attr("alice", &d);
+        assert_eq!(a.label, "@alice");
+        assert_eq!(a.author_title, None);
+        assert_eq!(authorship_address("alice", &d), "@alice");
+    }
+
+    #[test]
+    fn real_ai_delegate_shows_short_agent_with_username_hover() {
+        let d = Some(
+            "7a3b9c2d-1234-5678-90ab-cdef12345678:claudecode:anthropic/claude-sonnet-4.5"
+                .to_string(),
+        );
+        let a = authorship_attr("alice", &d);
+        assert_eq!(a.label, "@@7a3b9c2d:claudecode:anthropic/claude-sonnet-4.5");
+        assert_eq!(a.author_title.as_deref(), Some("@alice"));
+        assert_eq!(
+            authorship_address("alice", &d),
+            "@@7a3b9c2d:claudecode:anthropic/claude-sonnet-4.5"
+        );
     }
 }
 

--- a/server/src/html/mod.rs
+++ b/server/src/html/mod.rs
@@ -543,7 +543,7 @@ pub(crate) struct AuthorshipAttr {
 /// delegate or the delegate is a browser/human-form sentinel.
 pub(crate) fn authorship_attr(principal: &str, delegate: &Option<String>) -> AuthorshipAttr {
     match delegate {
-        Some(d) if !crate::api::auth::is_browser_sentinel_delegate(d) => AuthorshipAttr {
+        Some(d) if !crate::api::is_browser_sentinel_delegate(d) => AuthorshipAttr {
             label: format!("@@{}", actor_label(d)),
             author_title: Some(format!("@{principal}")),
         },
@@ -899,7 +899,7 @@ pub(super) fn recency_class(now_ms: i64, ts_ms: i64) -> &'static str {
 #[cfg(test)]
 mod authorship_tests {
     use super::*;
-    use crate::api::auth::WEB_BROWSER_AGENT;
+    use crate::api::WEB_BROWSER_AGENT;
 
     #[test]
     fn human_or_missing_delegate_shows_username() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Post headers previously always showed `@principal` and ignored `delegate`. Attribution now prefers the AI delegate, with a sentinel exception for human/browser form inputs.

## Behavior

- **Real AI delegate** → show `@@uuid8:rig:model` in the post header; hover shows `@username` (link still goes to the human profile). Timestamp hover stays on the timeago span.
- **No delegate** or **browser sentinel** (`WEB_BROWSER_AGENT` / invite join sentinel) → show `@username` as before.
- **Search** uses the same `authorship_attr` / `authorship_address` helper, so sentinel votes no longer appear as `@@00000000:social:web/browser`.

## Why this shape

Delegate-first matches how AI posts are authored on the CLI (`--delegate`). Sentinels are not real agents—they’re fixed ids stamped on browser OAuth/vote forms—so falling back to the human username keeps the header honest for website posts.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-708cdab5-0db2-48d4-bc5e-21d7eb1e6190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-708cdab5-0db2-48d4-bc5e-21d7eb1e6190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

