### PR TITLE
fix private-room privacy leak via unauthenticated /sse

### DIFF
--- a/server/src/api/stream.rs
+++ b/server/src/api/stream.rs
@@ -1,10 +1,17 @@
 use axum::{
     extract::{Query, State},
+    http::{HeaderMap, StatusCode},
     response::IntoResponse,
 };
+use axum_extra::extract::cookie::CookieJar;
 use serde::Deserialize;
+use slug_types::room_id_from_route_segment;
 
-use crate::state::AppState;
+use crate::{
+    api::optional_principal,
+    html::user_can_view_room,
+    state::{AppState, JsSnippetAudience},
+};
 
 // ============================================================================
 // SSE streams
@@ -15,30 +22,118 @@ pub struct SseQuery {
     pub path: Option<String>,
 }
 
-pub async fn get_html_stream(Query(q): Query<SseQuery>, State(state): State<AppState>) -> impl IntoResponse {
+/// Room wire id for the subscriber's page URL, if it is a private `/r/{seg}/…` route.
+fn sse_context_room_id(subscribed_path: &str) -> Option<String> {
+    let path = subscribed_path.split('?').next().unwrap_or(subscribed_path);
+    let segs: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+    if segs.len() >= 2 && segs[0] == "r" {
+        room_id_from_route_segment(segs[1])
+    } else {
+        None
+    }
+}
+
+fn sse_snippet_allowed_for_subscriber(
+    snippet: &crate::state::JsSnippet,
+    subscribed_path: &str,
+    username: Option<&str>,
+    reduced: &crate::reducer::ReducerState,
+) -> bool {
+    let path_matches = snippet.path_prefixes.is_empty()
+        || snippet.path_prefixes.iter().any(|prefix| {
+            subscribed_path == *prefix || subscribed_path.starts_with(&format!("{prefix}?"))
+        });
+    if !path_matches {
+        return false;
+    }
+
+    match &snippet.audience {
+        JsSnippetAudience::Public => true,
+        JsSnippetAudience::RoomViewers(room_id) => user_can_view_room(reduced, room_id, username),
+    }
+}
+
+/// Fixed response for unauthorized or invalid `/sse` subscription (no JS execution).
+fn sse_forbidden_or_gone() -> impl IntoResponse {
+    (
+        StatusCode::FORBIDDEN,
+        [(
+            axum::http::header::CONTENT_TYPE,
+            "text/event-stream; charset=utf-8",
+        )],
+        ": forbidden\n\n",
+    )
+}
+
+pub async fn get_html_stream(
+    Query(q): Query<SseQuery>,
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    jar: CookieJar,
+) -> impl IntoResponse {
     use axum::response::sse::{Event as SseEvent, KeepAlive, Sse};
     use tokio_stream::wrappers::BroadcastStream;
-    use tokio_stream::StreamExt as _;
 
-    let path = q.path.unwrap_or_default();
-    let js_rx = state.js_tx.subscribe();
-    let js_updates = BroadcastStream::new(js_rx).filter_map(move |msg| match msg {
-        Ok(snippet)
-            if snippet.path_prefixes.is_empty()
-                || snippet
-                    .path_prefixes
-                    .iter()
-                    .any(|prefix| path == *prefix || path.starts_with(&format!("{prefix}?"))) =>
-        {
-            Some(Ok::<_, std::convert::Infallible>(
-                SseEvent::default().data(snippet.code),
-            ))
+    let subscribed_path = q.path.unwrap_or_default();
+    let path_only = subscribed_path
+        .split('?')
+        .next()
+        .unwrap_or(&subscribed_path)
+        .to_string();
+
+    let reduced = state.reduced.read().await;
+    let user = optional_principal(&headers, &jar, &reduced);
+    let path_room_id = sse_context_room_id(&subscribed_path);
+
+    // Private room routes require a signed-in member (same as HTML).
+    if path_only.starts_with("/r/") && path_room_id.is_none() {
+        drop(reduced);
+        return sse_forbidden_or_gone().into_response();
+    }
+    if let Some(ref rid) = path_room_id {
+        if !user_can_view_room(&reduced, rid, user.as_deref()) {
+            drop(reduced);
+            return sse_forbidden_or_gone().into_response();
         }
-        Err(_) => None,
-        _ => None,
+    }
+    drop(reduced);
+
+    let user_for_filter = user;
+    let subscribed_path_owned = subscribed_path;
+    let state_clone = state.clone();
+    let js_rx = state.js_tx.subscribe();
+    use futures_util::StreamExt;
+    let js_updates = BroadcastStream::new(js_rx).filter_map(move |msg| {
+        let state = state_clone.clone();
+        let subscribed_path = subscribed_path_owned.clone();
+        let user_for_filter = user_for_filter.clone();
+        async move {
+            match msg {
+                Ok(snippet) => {
+                    let reduced = state.reduced.read().await;
+                    let allowed = sse_snippet_allowed_for_subscriber(
+                        &snippet,
+                        &subscribed_path,
+                        user_for_filter.as_deref(),
+                        &reduced,
+                    );
+                    drop(reduced);
+                    if allowed {
+                        Some(Ok::<_, std::convert::Infallible>(
+                            SseEvent::default().data(snippet.code),
+                        ))
+                    } else {
+                        None
+                    }
+                }
+                Err(_) => None,
+            }
+        }
     });
 
-    Sse::new(js_updates).keep_alive(KeepAlive::default())
+    Sse::new(js_updates)
+        .keep_alive(KeepAlive::default())
+        .into_response()
 }
 
 pub async fn get_stream(State(state): State<AppState>) -> impl IntoResponse {
@@ -47,16 +142,14 @@ pub async fn get_stream(State(state): State<AppState>) -> impl IntoResponse {
     use tokio_stream::StreamExt as _;
 
     let rx = state.stream_tx.subscribe();
-    let stream = BroadcastStream::new(rx).filter_map(|msg| {
-        match msg {
-            Ok(ev) => {
-                let data = serde_json::to_string(&ev).unwrap_or_default();
-                Some(Ok::<_, std::convert::Infallible>(
-                    SseEvent::default().event("ingest").data(data),
-                ))
-            }
-            Err(_) => None,
+    let stream = BroadcastStream::new(rx).filter_map(|msg| match msg {
+        Ok(ev) => {
+            let data = serde_json::to_string(&ev).unwrap_or_default();
+            Some(Ok::<_, std::convert::Infallible>(
+                SseEvent::default().event("ingest").data(data),
+            ))
         }
+        Err(_) => None,
     });
 
     Sse::new(stream).keep_alive(KeepAlive::default())

--- a/server/src/api/write_actor.rs
+++ b/server/src/api/write_actor.rs
@@ -76,23 +76,40 @@ async fn broadcast_web_refresh(state: &AppState, room_key: &str, thread_id: &str
     let thread_feed_markup =
         crate::html::thread_feed_region_markup(state, Some(room_key), thread_id, None).await;
 
-    let builder = JsBuilder::new().morph_selector(&format!("#{feed_id}"), feed_markup);
-    let builder = builder.qs("#new-thread-compose form").reset();
-    let builder = builder.if_current_path_matches(&thread_url, |builder| {
+    // Two SSE payloads: the bump-list morph must not ship private HTML to subscribers who only
+    // matched `/` (public) or lack room access — see [`crate::api::stream::get_html_stream`].
+    let feed_builder = JsBuilder::new().morph_selector(&format!("#{feed_id}"), feed_markup);
+    let feed_builder = feed_builder.qs("#new-thread-compose form").reset();
+    let feed_js = feed_builder.build();
+
+    let thread_builder = JsBuilder::new().if_current_path_matches(&thread_url, |builder| {
         builder.morph_selector("#thread-feed-region", thread_feed_markup)
     });
-    let js = builder.build();
-    let mut path_prefixes = vec![if room_key == "public" {
-        "/".to_string()
-    } else if let Some(seg) = room_route_segment(room_key) {
-        format!("/r/{seg}")
+    let thread_js = thread_builder.build();
+
+    let audience = if room_key == "public" {
+        crate::state::JsSnippetAudience::Public
     } else {
-        "/".to_string()
-    }];
-    path_prefixes.push(thread_url.clone());
+        crate::state::JsSnippetAudience::RoomViewers(room_key.to_string())
+    };
+
+    let feed_prefixes = if room_key == "public" {
+        vec!["/".to_string(), thread_url.clone()]
+    } else if let Some(seg) = room_route_segment(room_key) {
+        vec![format!("/r/{seg}"), thread_url.clone()]
+    } else {
+        vec!["/".to_string(), thread_url.clone()]
+    };
+
     let _ = state.js_tx.send(crate::state::JsSnippet {
-        code: js,
-        path_prefixes,
+        code: feed_js,
+        path_prefixes: feed_prefixes,
+        audience: audience.clone(),
+    });
+    let _ = state.js_tx.send(crate::state::JsSnippet {
+        code: thread_js,
+        path_prefixes: vec![thread_url.clone()],
+        audience,
     });
 }
 

--- a/server/src/html/forum/access.rs
+++ b/server/src/html/forum/access.rs
@@ -1,7 +1,7 @@
 use crate::events::ThreadCapability;
 use crate::reducer::ReducerState;
 
-pub(crate) fn user_can_view_room(reduced: &ReducerState, room_id: &str, username: Option<&str>) -> bool {
+pub fn user_can_view_room(reduced: &ReducerState, room_id: &str, username: Option<&str>) -> bool {
     if !reduced.rooms.contains(room_id) {
         return false;
     }

--- a/server/src/html/forum/mod.rs
+++ b/server/src/html/forum/mod.rs
@@ -21,7 +21,8 @@ pub use post_single::{room_thread_post_view, thread_post_view};
 pub use profile::user_profile_page;
 pub use views::{room_page, room_thread_view, thread_view};
 
-pub(crate) use access::{user_can_post_room, user_can_view_room};
+pub(crate) use access::user_can_post_room;
+pub use access::user_can_view_room;
 pub(crate) use copy::thread_ui_copy_thread;
 pub(crate) use new_thread::{fragment_new_thread_slot, login_to_post_hint_markup};
 pub(crate) use room_members::room_members_section_markup;

--- a/server/src/html/mod.rs
+++ b/server/src/html/mod.rs
@@ -31,10 +31,11 @@ pub use forum::{
 };
 
 pub use forum::user_profile_page;
+pub use forum::user_can_view_room;
 pub(crate) use forum::{
     fragment_new_thread_slot, login_to_post_hint_markup, room_members_section_markup,
     thread_ui_collapse_redacted_post, thread_ui_copy_thread, thread_ui_expand_post_full, thread_ui_expand_redacted_post,
-    user_can_post_room, user_can_view_room,
+    user_can_post_room,
 };
 pub(crate) use garden::{
     encode_pin_cookie_value, external_resolver_status_markup, garden_ui_copy_rank,

--- a/server/src/state.rs
+++ b/server/src/state.rs
@@ -42,6 +42,15 @@ pub struct StreamEvent {
     pub snippet: String,
 }
 
+/// Who may receive a [`JsSnippet`] over `/sse` (matches private-room HTML visibility).
+#[derive(Debug, Clone)]
+pub enum JsSnippetAudience {
+    /// Public forum + pages not tied to a specific room (home, `/t/…`, etc.).
+    Public,
+    /// Members with [`crate::events::ThreadCapability::View`] on this room (`short/slug` wire id).
+    RoomViewers(String),
+}
+
 /// JavaScript snippet broadcast to web SSE subscribers and `eval`'d client-side.
 #[derive(Debug, Clone)]
 pub struct JsSnippet {
@@ -49,6 +58,7 @@ pub struct JsSnippet {
     /// Only deliver to SSE streams whose subscribed path matches one of these prefixes.
     /// Empty means broadcast to all connected pages.
     pub path_prefixes: Vec<String>,
+    pub audience: JsSnippetAudience,
 }
 
 #[derive(Debug, Clone)]

--- a/server/tests/integration_ui.rs
+++ b/server/tests/integration_ui.rs
@@ -152,6 +152,7 @@ async fn test_sse_stream_emits_evalable_js_after_post() {
             "http://{addr}/sse?path={}",
             urlencoding::encode(&room_path)
         ))
+        .header("Authorization", format!("Bearer {bearer}"))
         .send()
         .await
         .unwrap();
@@ -184,6 +185,175 @@ async fn test_sse_stream_emits_evalable_js_after_post() {
     }
     assert!(body.contains("room-thread-feed"));
     assert!(body.contains("live-thread"));
+}
+
+#[tokio::test]
+async fn test_sse_private_room_requires_valid_room_path_or_auth() {
+    let (addr, _tmp, _log, _handle) = create_test_server().await;
+    let client = reqwest::Client::new();
+
+    // Segment too short to decode as `short/slug` → reject subscription (no JS execution).
+    let bad_seg = client
+        .get(format!(
+            "http://{addr}/sse?path={}",
+            urlencoding::encode("/r/abcdefg")
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(bad_seg.status(), reqwest::StatusCode::FORBIDDEN);
+
+    let room_ok = rpc_batch(
+        &client,
+        addr,
+        Some(&test_bearer()),
+        serde_json::json!([{ "RoomCreate": { "slug": "sse-auth-room" } }]),
+    )
+    .await;
+    let room_id = room_ok["results"][0]["result"]["RoomCreated"]["room_id"]
+        .as_str()
+        .unwrap();
+    let seg = room_route_segment(room_id).unwrap();
+    let room_path = format!("/r/{seg}");
+
+    let no_cookie = client
+        .get(format!(
+            "http://{addr}/sse?path={}",
+            urlencoding::encode(&room_path)
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(no_cookie.status(), reqwest::StatusCode::FORBIDDEN);
+
+    let with_auth = client
+        .get(format!(
+            "http://{addr}/sse?path={}",
+            urlencoding::encode(&room_path)
+        ))
+        .header("Authorization", format!("Bearer {}", test_bearer()))
+        .send()
+        .await
+        .unwrap();
+    assert!(with_auth.status().is_success());
+}
+
+#[tokio::test]
+async fn test_sse_private_feed_not_sent_to_home_without_membership() {
+    let (addr, _tmp, _log, _state, _handle) = create_test_server_with_state().await;
+
+    let client = reqwest::Client::new();
+    let owner = test_bearer();
+
+    let create = rpc_batch(
+        &client,
+        addr,
+        Some(&owner),
+        serde_json::json!([{ "RoomCreate": { "slug": "sse-acl-home" } }]),
+    )
+    .await;
+    let room_id = create["results"][0]["result"]["RoomCreated"]["room_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let sse_resp = client
+        .get(format!(
+            "http://{addr}/sse?path={}",
+            urlencoding::encode("/")
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert!(sse_resp.status().is_success());
+
+    let secret_phrase = "PRIVATE_SSE_HOME_LEAK_TEST_UNIQUE";
+    let rpc = ui_post_ingest_rpc(&room_id, "acl-thread", secret_phrase);
+    let _post = client
+        .post(format!("http://{addr}/ui"))
+        .header("Authorization", format!("Bearer {owner}"))
+        .form(&[("__rpc__", rpc.as_str())])
+        .send()
+        .await
+        .unwrap();
+
+    let mut body = String::new();
+    let mut sse_resp = sse_resp;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+    while std::time::Instant::now() < deadline {
+        match tokio::time::timeout(std::time::Duration::from_millis(400), sse_resp.chunk()).await {
+            Ok(Ok(Some(chunk))) => {
+                body.push_str(&String::from_utf8_lossy(&chunk));
+            }
+            Ok(Ok(None)) => break,
+            Ok(Err(err)) => panic!("sse read failed: {err}"),
+            Err(_) => {}
+        }
+    }
+    assert!(
+        !body.contains(secret_phrase),
+        "anonymous home SSE must not receive private room morph payload"
+    );
+}
+
+#[tokio::test]
+async fn test_sse_private_feed_masked_for_non_member_even_with_bearer() {
+    let (addr, _tmp, _log, state, _handle) = create_test_server_with_state().await;
+    let other = seed_test_identity(&state, "otheruser", "othertok", "othersecret").await;
+
+    let client = reqwest::Client::new();
+    let owner = test_bearer();
+
+    let create = rpc_batch(
+        &client,
+        addr,
+        Some(&owner),
+        serde_json::json!([{ "RoomCreate": { "slug": "sse-acl-other" } }]),
+    )
+    .await;
+    let room_id = create["results"][0]["result"]["RoomCreated"]["room_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let sse_resp = client
+        .get(format!(
+            "http://{addr}/sse?path={}",
+            urlencoding::encode("/")
+        ))
+        .header("Authorization", format!("Bearer {other}"))
+        .send()
+        .await
+        .unwrap();
+    assert!(sse_resp.status().is_success());
+
+    let secret_phrase = "PRIVATE_SSE_OTHER_USER_LEAK";
+    let rpc = ui_post_ingest_rpc(&room_id, "leak-thread", secret_phrase);
+    let _post = client
+        .post(format!("http://{addr}/ui"))
+        .header("Authorization", format!("Bearer {owner}"))
+        .form(&[("__rpc__", rpc.as_str())])
+        .send()
+        .await
+        .unwrap();
+
+    let mut body = String::new();
+    let mut sse_resp = sse_resp;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+    while std::time::Instant::now() < deadline {
+        match tokio::time::timeout(std::time::Duration::from_millis(400), sse_resp.chunk()).await {
+            Ok(Ok(Some(chunk))) => {
+                body.push_str(&String::from_utf8_lossy(&chunk));
+            }
+            Ok(Ok(None)) => break,
+            Ok(Err(err)) => panic!("sse read failed: {err}"),
+            Err(_) => {}
+        }
+    }
+    assert!(
+        !body.contains(secret_phrase),
+        "non-member must not receive private room SSE payloads even when subscribed from `/` with a bearer"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Private-room HTML and RPC already require explicit `View` (unauthorized → `"room not found"` / 404). The live HTML morph channel did not:

- `GET /sse?path=/r/{seg}…` accepted anonymous subscribers
- `broadcast_web_refresh` shipped private feed/thread markup to any matching path prefix

Anyone who knew a room URL could receive live private post bodies over SSE even though the HTML page 404'd.

This restores the approach from the unmerged PR #141 (commit `ccc9bd5`), rebased onto current main.

## Fix

1. **`JsSnippetAudience`**: `Public` vs `RoomViewers(room_id)`
2. **`get_html_stream`**: resolve principal (bearer/cookie); reject `/r/*` without `View`; filter each snippet by audience + path
3. **`broadcast_web_refresh`**: split feed vs thread payloads so private HTML is never bundled onto public path prefixes

## Tests

`cargo nextest run -p slugsocial-server --test integration_ui --test integration_rooms` — **29 passed**

- Unauthenticated / invalid `/r/` SSE → 403
- Member bearer still receives room morphs
- Anonymous home SSE does not receive private post text
- Non-member bearer on `/` does not receive private morphs
- Existing private-room RPC/HTML ACL tests still pass

## Out of scope (noted, not changed)

- Invite tokens remain RAM-only (documented)
- Caps still do not inherit (`Manage` ≠ `View`)
- No last-`Manage` revoke guard
- `RoomList` / home “your rooms” still lists any grant (not View-only)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-adead140-da91-443d-b960-c2c7651f7c14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-adead140-da91-443d-b960-c2c7651f7c14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

