### PR TITLE
Hide pair-vote "vs" on mobile; add vote-on-item CTA

### DIFF
--- a/server/src/html/garden/pin.rs
+++ b/server/src/html/garden/pin.rs
@@ -39,6 +39,7 @@ pub(super) fn ont_pin_vote_controls(
     current_storage: &str,
     pinned_room_and_item: Option<&(String, ItemId)>,
     next_path: &str,
+    vote_on_item_href: Option<&str>,
 ) -> maud::Markup {
     let room_wire = nav.room_wire.clone();
     let current = ItemId::parse(current_storage)
@@ -70,6 +71,13 @@ pub(super) fn ont_pin_vote_controls(
 
     html! {
         div class="ont-item-pin-zone" data-garden-room=(room_wire.as_str()) {
+            @if let Some(href) = vote_on_item_href {
+                a class="ont-vote-item-btn" data-testid="vote-on-this-item"
+                   href=(href)
+                   title="Compare this item with its siblings" {
+                    "vote on this item"
+                }
+            }
             @if let Some(pi) = pinned_item {
                 @if pi == &current {
                     form method="POST" action="/ui" data-navigate="full" class="ont-pin-form" {

--- a/server/src/html/garden/render.rs
+++ b/server/src/html/garden/render.rs
@@ -17,6 +17,7 @@ use crate::{
         theme_next_from_uri,
     },
     middleware::canonical_view_url,
+    path_types::ItemId,
     reducer::ScopeId,
     state::AppState,
     timeago,
@@ -75,7 +76,18 @@ pub(super) async fn render_scope_view(
                     @if model.sibling_nav.is_none() && model.item_has_parent {
                         span class="muted ont-item-unranked-note" { "unranked among siblings" }
                     }
-                    (ont_pin_vote_controls(&nav, &model.item, pin_ref.as_ref(), &next_for_pin))
+                    @let vote_item_href = model.sibling_nav.as_ref().and_then(|_| {
+                        ItemId::parse(&model.item)
+                            .and_then(|i| i.parent())
+                            .map(|p| vote_pool_href(&nav, p.as_str()))
+                    });
+                    (ont_pin_vote_controls(
+                        &nav,
+                        &model.item,
+                        pin_ref.as_ref(),
+                        &next_for_pin,
+                        vote_item_href.as_deref(),
+                    ))
                 }
                 @if let Some(body) = &model.body {
                     div class="ont-item-content" {

--- a/server/src/html/garden/tests.rs
+++ b/server/src/html/garden/tests.rs
@@ -2,10 +2,11 @@ use super::{
     access::content_for_garden_view,
     external::{external_frame_allowed, external_resolver_status_markup, external_source_href},
     item_page::build_item_page_view_model,
+    pin::ont_pin_vote_controls,
     vote::{
         canonical_edge_items, edge_vote_count_for_pair, edge_vote_entries_for_pair,
         ratios_for_compare_page, sort_votes_for_compare_display, suggest_next_vote_pair,
-        vote_compare_item_card,
+        vote_compare_item_card, vote_pool_href,
     },
 };
 use crate::{
@@ -364,6 +365,50 @@ fn vote_compare_item_card_renders_github_import_markup() {
     assert!(html.contains("item-body-rich"));
     assert!(html.contains("vote-compare-left"));
     assert!(html.contains("#1 Compare card"));
+}
+
+#[test]
+fn item_page_sibling_nav_implies_vote_on_item_pool_href() {
+    let mut reduced = ReducerState::default();
+    apply_ingest(
+        &mut reduced,
+        1,
+        "@00000000-0000-0000-0000-000000000000:test:local/test\n\
+         ~/topic {root}\n\
+         ~/topic/a {alpha}\n\
+         ~/topic/b {beta}\n",
+    );
+    let model = build_item_page_view_model(&reduced, &ScopeId::Public, "~/topic/a", 1);
+    assert!(model.sibling_nav.is_some(), "expected sibling nav for ~/topic/a");
+    let parent = ItemId::parse(&model.item)
+        .and_then(|i| i.parent())
+        .expect("item with siblings has a parent");
+    let nav = ThreadNav::public();
+    let href = vote_pool_href(&nav, parent.as_str());
+    assert!(
+        href.contains("/vote?pool="),
+        "expected sibling pool vote href, got {href}"
+    );
+    assert!(
+        href.contains(&urlencoding::encode(&parent.display_path()).into_owned())
+            || href.contains("topic")
+            || href.contains("%7E"),
+        "pool should target parent path, got {href}"
+    );
+    let markup = ont_pin_vote_controls(&nav, &model.item, None, "/~/topic/a", Some(&href)).into_string();
+    assert!(
+        markup.contains("data-testid=\"vote-on-this-item\""),
+        "expected vote-on-this-item CTA, got {markup}"
+    );
+    assert!(
+        markup.contains("vote on this item"),
+        "expected button label, got {markup}"
+    );
+    let solo = ont_pin_vote_controls(&nav, &model.item, None, "/~/topic/a", None).into_string();
+    assert!(
+        !solo.contains("vote-on-this-item"),
+        "CTA must be omitted when no sibling pool href is passed"
+    );
 }
 
 #[test]

--- a/server/static/theme_default.css
+++ b/server/static/theme_default.css
@@ -858,7 +858,8 @@ body.view-ontology-light .ont-item-pin-zone {
   gap: 6px;
 }
 button.ont-pin-btn,
-a.ont-vote-compare-btn {
+a.ont-vote-compare-btn,
+a.ont-vote-item-btn {
   background: var(--g4);
   border: var(--bv) solid;
   border-color: var(--hi) var(--lo) var(--lo) var(--hi);
@@ -874,9 +875,11 @@ a.ont-vote-compare-btn {
   border-radius: 2px;
 }
 button.ont-pin-btn:hover,
-a.ont-vote-compare-btn:hover { color: var(--signal); }
+a.ont-vote-compare-btn:hover,
+a.ont-vote-item-btn:hover { color: var(--signal); }
 button.ont-pin-btn:focus-visible,
-a.ont-vote-compare-btn:focus-visible {
+a.ont-vote-compare-btn:focus-visible,
+a.ont-vote-item-btn:focus-visible {
   outline: 2px solid var(--link);
   outline-offset: 2px;
 }
@@ -1024,6 +1027,16 @@ body.view-vote-compare .vote-compare-shell > h2 {
   font-size: 11px;
   letter-spacing: 0.1em;
   text-transform: uppercase;
+}
+/* Mobile: drop the "vs" column — path labels need every pixel. */
+@media (max-width: 600px) {
+  .vote-compare-pair {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: 10px 8px;
+  }
+  .vote-compare-vs {
+    display: none;
+  }
 }
 .vote-compare-item-body {
   margin-top: 8px;

--- a/server/static/theme_retro.css
+++ b/server/static/theme_retro.css
@@ -280,6 +280,15 @@ body.view-ontology .vote-compare-pair {
   grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
   margin: 0 0 0.75rem;
 }
+@media (max-width: 600px) {
+  body.view-ontology .vote-compare-pair {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: 0.65rem 0.5rem;
+  }
+  body.view-ontology .vote-compare-vs {
+    display: none;
+  }
+}
 body.view-ontology .vote-compare-item {
   display: inline-block;
 }

--- a/server/static/theme_retro_craft.css
+++ b/server/static/theme_retro_craft.css
@@ -658,7 +658,8 @@ body.view-ontology .ont-item-pin-zone {
 }
 
 body.view-ontology button.ont-pin-btn,
-body.view-ontology a.ont-vote-compare-btn {
+body.view-ontology a.ont-vote-compare-btn,
+body.view-ontology a.ont-vote-item-btn {
   background: #ebe6dc;
   border: 1px solid #c8c4bc;
   border-radius: 2px;
@@ -674,7 +675,8 @@ body.view-ontology a.ont-vote-compare-btn {
   gap: 0.3rem;
 }
 body.view-ontology button.ont-pin-btn:hover,
-body.view-ontology a.ont-vote-compare-btn:hover {
+body.view-ontology a.ont-vote-compare-btn:hover,
+body.view-ontology a.ont-vote-item-btn:hover {
   border-color: #a68e6b;
   color: #1a1814;
 }
@@ -684,7 +686,8 @@ body.view-ontology button.ont-pin-btn-active {
   color: #0d2d5c;
 }
 body.view-ontology button.ont-pin-btn:focus-visible,
-body.view-ontology a.ont-vote-compare-btn:focus-visible {
+body.view-ontology a.ont-vote-compare-btn:focus-visible,
+body.view-ontology a.ont-vote-item-btn:focus-visible {
   outline: 2px solid #1a4a8c;
   outline-offset: 2px;
 }
@@ -889,6 +892,15 @@ body.view-ontology .vote-compare-vs {
   letter-spacing: 0.1em;
   text-transform: uppercase;
   padding-top: 0.18rem;
+}
+@media (max-width: 600px) {
+  body.view-ontology .vote-compare-pair {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: 0.65rem 0.5rem;
+  }
+  body.view-ontology .vote-compare-vs {
+    display: none;
+  }
 }
 body.view-ontology .vote-compare-item {
   display: inline-block;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- On the pair voting page, hide the middle **vs** label below 600px and collapse the compare grid to two columns so item paths keep horizontal space on mobile.
- On garden item pages that have siblings, show a **vote on this item** button in the item header actions. It opens the sibling pool vote flow (`/vote?pool=<parent>`), parallel to the existing **vote on children** control.

## Screenshots

Mobile compare (no **vs**):
[Mobile vote compare without vs](https://cursor.com/agents/bc-5c93b5fb-dfc5-4e6a-8350-6b46a8bc211f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fvote-compare-mobile-no-vs.png)

Desktop compare (keeps **vs**):
[Desktop vote compare with vs](https://cursor.com/agents/bc-5c93b5fb-dfc5-4e6a-8350-6b46a8bc211f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fvote-compare-desktop-with-vs.png)

Item page CTA:
[Garden item vote on this item button](https://cursor.com/agents/bc-5c93b5fb-dfc5-4e6a-8350-6b46a8bc211f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fgarden-item-vote-on-this-item.png)

CTA opens sibling pool:
[Vote page from item CTA](https://cursor.com/agents/bc-5c93b5fb-dfc5-4e6a-8350-6b46a8bc211f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fvote-from-item-cta.png)

## Test plan
- [x] Open `/vote?left=…&right=…` at a mobile width and confirm **vs** is gone and both paths still sit side-by-side.
- [x] Open the same page on desktop and confirm **vs** remains.
- [x] Open a garden item with siblings and confirm **vote on this item** appears in the header and links into the sibling compare pool.
- [x] Unit test covers CTA markup + sibling pool href wiring.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c93b5fb-dfc5-4e6a-8350-6b46a8bc211f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c93b5fb-dfc5-4e6a-8350-6b46a8bc211f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

