### PR TITLE
Fix retro theme reply box width on mobile

### DIFF
--- a/server/static/theme_retro.css
+++ b/server/static/theme_retro.css
@@ -41,9 +41,18 @@ pre {
   word-break: break-word;
   white-space: pre-wrap;
 }
+/* cols=80 intrinsic width overflows mobile; constrain like default/craft */
 textarea {
   font-family: var(--font-prose);
   font-size: 1rem;
+  max-width: 100%;
+  min-width: 0;
+  width: 100%;
+}
+section.compose,
+section.compose form {
+  max-width: 100%;
+  min-width: 0;
 }
 code {
   font-family: var(--font-code);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
On the lean **retro** theme, the thread reply box (`cols="80"`) was wider than the viewport on mobile and caused horizontal scrolling.

## Fix
In `theme_retro.css`, constrain `textarea` and `section.compose` to `width/max-width: 100%` (same approach as default/craft).

## Verification
Headless Chrome fixture at ~mobile width:
- **Before:** textarea ~741px, document overflows
- **After:** textarea fits content column, no overflow

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b256455-f8b8-4439-8aee-1aa1b1f88cfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b256455-f8b8-4439-8aee-1aa1b1f88cfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

