### PR TITLE
Color timestamps by recency; sort private rooms by latest post

### DIFF
--- a/server/src/api/rpc.rs
+++ b/server/src/api/rpc.rs
@@ -1218,12 +1218,17 @@ pub async fn handle_rpc_batch(
                     Err((_, m)) => line_err(m, None),
                     Ok(principal) => {
                         let reduced = state.reduced.read().await;
-                        let rooms: Vec<String> = reduced
+                        let mut rooms: Vec<(i64, String)> = reduced
                             .grants
                             .iter()
-                            .filter(|(_, members)| members.contains_key(&principal))
-                            .map(|(room, _)| room.clone())
+                            .filter(|(room, members)| {
+                                reduced.rooms.contains(*room) && members.contains_key(&principal)
+                            })
+                            .map(|(room, _)| (reduced.room_last_activity_ts(room), room.clone()))
                             .collect();
+                        // Newest activity first; stable tie-break on room id.
+                        rooms.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
+                        let rooms: Vec<String> = rooms.into_iter().map(|(_, id)| id).collect();
                         line_ok(RpcResult::RoomList(RoomListResponse { rooms }))
                     }
                 }

--- a/server/src/html/forum/feed.rs
+++ b/server/src/html/forum/feed.rs
@@ -19,7 +19,8 @@ use super::new_thread::{fragment_new_thread_slot, login_to_post_hint_markup};
 use super::page::auth_strip;
 use super::paginator::{render_thread_paginator, PAGE_SIZE};
 use crate::html::{
-    bc_threads, cli_panel, layout, now_ms, recency_class, theme_from_jar, theme_next_from_uri,
+    bc_threads, cli_panel, layout, now_ms, recency_class, recency_color_style, theme_from_jar,
+    theme_next_from_uri,
 };
 
 #[derive(Clone)]
@@ -29,6 +30,13 @@ pub(super) struct ThreadRow {
     pub(super) last_ts: i64,
     pub(super) last_actor: String,
     pub(super) ingests: usize,
+}
+
+#[derive(Clone)]
+pub(super) struct RoomRow {
+    pub(super) id: String,
+    /// Most recent forum post in the room, or room-created time if empty.
+    pub(super) last_ts: i64,
 }
 
 pub(super) fn collect_thread_rows_for_scope(reduced: &ReducerState, scope: &ScopeId, now: i64) -> Vec<ThreadRow> {
@@ -54,14 +62,18 @@ pub(super) fn collect_thread_rows_for_scope(reduced: &ReducerState, scope: &Scop
         .collect()
 }
 
-pub(super) fn rooms_for_user(reduced: &ReducerState, username: &str) -> Vec<String> {
-    let mut v: Vec<String> = reduced
+/// Rooms the user can access, newest activity first (tie-break: room id).
+pub(super) fn rooms_for_user(reduced: &ReducerState, username: &str) -> Vec<RoomRow> {
+    let mut v: Vec<RoomRow> = reduced
         .grants
         .iter()
         .filter(|(rid, m)| reduced.rooms.contains(*rid) && m.contains_key(username))
-        .map(|(rid, _)| rid.clone())
+        .map(|(rid, _)| RoomRow {
+            id: rid.clone(),
+            last_ts: reduced.room_last_activity_ts(rid),
+        })
         .collect();
-    v.sort();
+    v.sort_by(|a, b| b.last_ts.cmp(&a.last_ts).then_with(|| a.id.cmp(&b.id)));
     v
 }
 
@@ -81,6 +93,7 @@ pub(super) fn render_thread_feed(nav: Option<&ThreadNav>, feed_id: &str, rows: &
                         @let hover = timeago::rfc3339_utc(r.last_ts);
                         @let ago = timeago::timeago(now, r.last_ts);
                         @let age_cls = recency_class(now, r.last_ts);
+                        @let ts_style = recency_color_style(now, r.last_ts);
                         li class=(age_cls) {
                             a href=(thread_href) {
                                 "#" (r.tag)
@@ -88,13 +101,15 @@ pub(super) fn render_thread_feed(nav: Option<&ThreadNav>, feed_id: &str, rows: &
                                     ": " (subtitle)
                                 }
                                 " "
-                                span class="muted" title=(hover) {
-                                    (ago)
-                                    @if !r.last_actor.is_empty() {
-                                        " by @" (r.last_actor)
+                                span title=(hover) {
+                                    span class="ts-recency" style=(ts_style.as_str()) { (ago) }
+                                    span class="muted" {
+                                        @if !r.last_actor.is_empty() {
+                                            " by @" (r.last_actor)
+                                        }
+                                        " · "
+                                        (format!("{}n", r.ingests))
                                     }
-                                    " · "
-                                    (format!("{}n", r.ingests))
                                 }
                             }
                         }
@@ -239,13 +254,21 @@ pub async fn home(
             @if !room_ids.is_empty() {
                 h2 { "your rooms" }
                 ul class="thread-feed" {
-                    @for rid in &room_ids {
-                        @if let Some(nav_r) = ThreadNav::from_room_id(rid) {
-                            @let slug = if let Some((_, s)) = rid.split_once('/') { s } else { rid.as_str() };
-                            li {
+                    @for room in &room_ids {
+                        @if let Some(nav_r) = ThreadNav::from_room_id(&room.id) {
+                            @let slug = if let Some((_, s)) = room.id.split_once('/') { s } else { room.id.as_str() };
+                            @let hover = timeago::rfc3339_utc(room.last_ts);
+                            @let ago = timeago::timeago(now, room.last_ts);
+                            @let age_cls = recency_class(now, room.last_ts);
+                            @let ts_style = recency_color_style(now, room.last_ts);
+                            li class=(age_cls) {
                                 a href=(nav_r.room_url()) {
                                     (slug)
-                                    span class="muted" { " · " (rid) }
+                                    " "
+                                    span title=(hover) {
+                                        span class="ts-recency" style=(ts_style.as_str()) { (ago) }
+                                        span class="muted" { " · " (room.id) }
+                                    }
                                 }
                             }
                         }

--- a/server/src/html/forum/ingest.rs
+++ b/server/src/html/forum/ingest.rs
@@ -6,7 +6,9 @@ use slug_types::MAX_FORUM_POST_PREVIEW_CHARS;
 
 use crate::html::js_string_literal;
 use crate::html::ui_action::{HtmlUiAction, UI_RPC_FIELD};
-use crate::html::{authorship_attr, profile_href, render_linkified_with_embeds_in_scope};
+use crate::html::{
+    authorship_attr, profile_href, recency_color_style, render_linkified_with_embeds_in_scope,
+};
 use crate::timeago;
 
 use super::nav::ThreadNav;
@@ -47,6 +49,7 @@ fn post_header_meta(
     let profile = profile_href(principal);
     let ts_hover = timeago::rfc3339_utc(ts);
     let ago = timeago::timeago(now, ts);
+    let ts_style = recency_color_style(now, ts);
     let attr = authorship_attr(principal, delegate);
     let author_style = format!("color:{}", attr.color);
     html! {
@@ -60,7 +63,7 @@ fn post_header_meta(
                     a href=(profile) class="post-author" style=(author_style.as_str()) { (attr.label.as_str()) }
                 }
                 " · "
-                span title=(ts_hover) { (ago) }
+                span class="ts-recency" style=(ts_style.as_str()) title=(ts_hover) { (ago) }
             }
             @if let Some(pid) = delete_post_id {
                 form class="post-delete-form" method="POST" action="/ui" {

--- a/server/src/html/forum/profile.rs
+++ b/server/src/html/forum/profile.rs
@@ -16,7 +16,8 @@ use super::ingest::{thread_nav_for_ingest, thread_post_index_in_scope};
 use super::page::auth_strip;
 use crate::timeago;
 use crate::html::{
-    bc_segment, cli_panel, layout, now_ms, profile_href, theme_from_jar, theme_next_from_uri,
+    bc_segment, cli_panel, layout, now_ms, profile_href, recency_color_style, theme_from_jar,
+    theme_next_from_uri,
 };
 
 struct ProfilePostRow {
@@ -96,13 +97,15 @@ pub async fn user_profile_page(
                     @for r in &rows {
                         @let hover = timeago::rfc3339_utc(r.ts);
                         @let ago = timeago::timeago(now, r.ts);
+                        @let ts_style = recency_color_style(now, r.ts);
                         li {
                             a href=(r.post_href.as_str()) {
                                 "#" (r.thread_tag)
                                 " / #"
                                 (r.post_idx)
                             }
-                            span class="muted" title=(hover) { " · " (ago) }
+                            span class="muted" { " · " }
+                            span class="ts-recency" style=(ts_style.as_str()) title=(hover) { (ago) }
                             @if !r.snippet.is_empty() {
                                 p class="profile-post-snippet muted" { (r.snippet) }
                             }

--- a/server/src/html/garden/render.rs
+++ b/server/src/html/garden/render.rs
@@ -12,6 +12,7 @@ use crate::{
         layout,
         now_ms,
         format_ratio, ratio_pct,
+        recency_color_style,
         render_item_body_in_scope,
         theme_from_jar,
         theme_next_from_uri,
@@ -147,13 +148,15 @@ pub(super) async fn render_scope_view(
                         };
                         @let hover = timeago::rfc3339_utc(e.ts);
                         @let ago = timeago::timeago(now, e.ts);
+                        @let ts_style = recency_color_style(now, e.ts);
                         div class="rank-history-entry" {
                             div class="rank-history-meta" title=(hover) {
                                 span class="rank-history-pos" {
                                     (format!("#{} of {}{}", e.scope_rank, e.scope_total, delta_str))
                                 }
                                 " · "
-                                span class="muted" { (ago) (label) }
+                                span class="ts-recency" style=(ts_style.as_str()) { (ago) }
+                                span class="muted" { (label) }
                                 " · "
                                 a href=(thread_href(&e.thread)) { "#" (e.thread) }
                                 " "

--- a/server/src/html/mod.rs
+++ b/server/src/html/mod.rs
@@ -932,9 +932,44 @@ pub(super) fn recency_class(now_ms: i64, ts_ms: i64) -> &'static str {
     }
 }
 
+/// Freshness in 0..=100 for proportional timestamp color (100 = just now, 0 = ≥1 week).
+/// Linear fade over 7 days so color tracks age continuously.
+pub(super) fn recency_freshness_pct(now_ms: i64, ts_ms: i64) -> u8 {
+    const WEEK_SECS: i64 = 7 * 24 * 3600;
+    let age_secs = now_ms.saturating_sub(ts_ms).saturating_div(1000).max(0);
+    if age_secs >= WEEK_SECS {
+        return 0;
+    }
+    let remaining = WEEK_SECS - age_secs;
+    ((remaining * 100) / WEEK_SECS) as u8
+}
+
+/// Inline `color-mix` style for timestamps: fresher → `--age-fresh`, older → `--age-old`.
+pub(super) fn recency_color_style(now_ms: i64, ts_ms: i64) -> String {
+    let pct = recency_freshness_pct(now_ms, ts_ms);
+    format!("color:color-mix(in srgb,var(--age-fresh) {pct}%,var(--age-old))")
+}
+
 #[cfg(test)]
 mod authorship_tests {
     use super::*;
+
+    #[test]
+    fn recency_freshness_is_proportional() {
+        let now = 7 * 24 * 3600 * 1000;
+        assert_eq!(recency_freshness_pct(now, now), 100);
+        assert_eq!(recency_freshness_pct(now, now - 1000), 99); // ~1s old
+        // Mid-week ≈ 50%
+        assert_eq!(
+            recency_freshness_pct(now, now - 3 * 24 * 3600 * 1000 - 12 * 3600 * 1000),
+            50
+        );
+        assert_eq!(recency_freshness_pct(now, now - 7 * 24 * 3600 * 1000), 0);
+        assert_eq!(recency_freshness_pct(now, now - 14 * 24 * 3600 * 1000), 0);
+        let style = recency_color_style(now, now);
+        assert!(style.contains("100%"), "{style}");
+        assert!(style.contains("--age-fresh"), "{style}");
+    }
 
     #[test]
     fn human_or_missing_delegate_shows_username() {

--- a/server/src/html/search.rs
+++ b/server/src/html/search.rs
@@ -16,7 +16,10 @@ use crate::{
     timeago,
 };
 
-use super::{authorship_address, bc_segment, cli_panel, layout, now_ms, theme_from_jar, theme_next_from_uri};
+use super::{
+    authorship_address, bc_segment, cli_panel, layout, now_ms, recency_color_style, theme_from_jar,
+    theme_next_from_uri,
+};
 
 /// Escape HTML special chars for safe injection.
 fn escape_html(s: &str) -> String {
@@ -332,6 +335,7 @@ fn render_search_results(results: &SearchResults, query: &str) -> Markup {
                     h3 { "threads " span class="muted" { "(" (results.threads.len()) ")" } }
                     ul class="search-threads" {
                         @for r in &results.threads {
+                            @let ts_style = recency_color_style(now, r.last_activity);
                             li {
                                 a href=(format!("/t/{}", r.tag)) {
                                     "#" (PreEscaped(highlight_snippet(&r.tag, &words, r.tag.len() + 10)))
@@ -340,8 +344,9 @@ fn render_search_results(results: &SearchResults, query: &str) -> Markup {
                                     ": " (subtitle)
                                 }
                                 " "
-                                span class="muted" {
-                                    (r.post_count) "n · " (timeago::timeago(now, r.last_activity))
+                                span class="muted" { (r.post_count) "n · " }
+                                span class="ts-recency" style=(ts_style.as_str()) {
+                                    (timeago::timeago(now, r.last_activity))
                                 }
                             }
                         }
@@ -362,11 +367,15 @@ fn render_search_results(results: &SearchResults, query: &str) -> Markup {
                             } else {
                                 ("/".to_string(), r.thread.clone())
                             };
+                            @let ts_style = recency_color_style(now, r.ts);
                             li {
                                 div class="search-post-meta muted" {
                                     a href=(post_href) { (post_label) }
                                     " · " (r.actor_display)
-                                    " · " (timeago::timeago(now, r.ts))
+                                    " · "
+                                    span class="ts-recency" style=(ts_style.as_str()) {
+                                        (timeago::timeago(now, r.ts))
+                                    }
                                 }
                                 div class="search-snippet" {
                                     (PreEscaped(highlight_snippet(&r.text, &words, 160)))

--- a/server/src/reducer.rs
+++ b/server/src/reducer.rs
@@ -263,6 +263,24 @@ impl ReducerState {
         self.content.get(scope)
     }
 
+    /// Most recent forum post bump in `room_id`, or room-created time if the room has no posts.
+    pub fn room_last_activity_ts(&self, room_id: &str) -> i64 {
+        let scope = ScopeId::Room(room_id.to_string());
+        let mut max_ts = 0i64;
+        for ((s, _), thread) in &self.forum_threads {
+            if s == &scope {
+                max_ts = max_ts.max(thread.last_activity_ts);
+            }
+        }
+        if max_ts > 0 {
+            return max_ts;
+        }
+        self.room_timeline
+            .get(room_id)
+            .and_then(|entries| entries.first().map(|e| e.ts))
+            .unwrap_or(0)
+    }
+
     /// 0-based chronological index of `post_id` in `(scope, thread_tag)` (forum routes `/t/tag/N`).
     pub fn try_thread_post_index_chronological(
         &self,

--- a/server/static/theme_default.css
+++ b/server/static/theme_default.css
@@ -32,6 +32,10 @@
   --meta:   #4a4a4a;
   --link:   #8899ee;
 
+  /* Timestamp recency (color-mix endpoints) */
+  --age-fresh: #7acc7a;
+  --age-old:   var(--meta);
+
   /* Code tint */
   --code-fg: #c8dda0;
 
@@ -1263,6 +1267,8 @@ li.vote-edge-history-row {
 .age-recent a { color: #7ab0cc; }
 .age-week   a { color: var(--link); }
 .age-old    a { color: var(--meta); }
+/* Proportional timestamp tint (inline color-mix via --age-fresh / --age-old) */
+span.ts-recency { font-family: inherit; }
 
 /* Sibling quick-nav: second breadcrumb row (same link styling as nav.breadcrumb) */
 nav.breadcrumb.ont-sibling-nav {
@@ -1665,6 +1671,10 @@ body.view-ontology .age-fresh  a { color: #005500; }
 body.view-ontology .age-recent a { color: #003080; }
 body.view-ontology .age-week   a { color: var(--link); }
 body.view-ontology .age-old    a { color: var(--meta); }
+body.view-ontology {
+  --age-fresh: #005500;
+  --age-old: var(--meta);
+}
 
 /* Rank history */
 body.view-ontology-dark details.ont-rank-history {

--- a/server/static/theme_retro.css
+++ b/server/static/theme_retro.css
@@ -10,6 +10,10 @@
   --font-prose: "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", Georgia, serif;
   --font-ui:    system-ui, -apple-system, sans-serif;
   --font-code:  ui-monospace, "Cascadia Code", "SF Mono", Menlo, monospace;
+
+  /* Timestamp recency (color-mix endpoints) */
+  --age-fresh: #0a0;
+  --age-old:   #666;
 }
 
 *, *::before, *::after { box-sizing: border-box; }

--- a/server/static/theme_retro_craft.css
+++ b/server/static/theme_retro_craft.css
@@ -11,6 +11,10 @@
   --line: #2c2824;
   --code-bg: #1c1814;
 
+  /* Timestamp recency (color-mix endpoints) */
+  --age-fresh: #7d9;
+  --age-old:   var(--ink-dim);
+
   /* Semantic font stacks */
   --font-prose: "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", Georgia, serif;
   --font-ui:    system-ui, -apple-system, sans-serif;

--- a/server/tests/basic.rs
+++ b/server/tests/basic.rs
@@ -889,6 +889,36 @@ fn posts_by_actor_indexes_and_profile_visibility() {
     assert_eq!(bob.len(), 2);
 }
 
+#[test]
+fn room_last_activity_ts_tracks_newest_post() {
+    let mut state = ReducerState::default();
+    state.apply_event(Event::RoomCreated(RoomCreated {
+        ts: 1000,
+        room_id: "aa11bb/older".to_string(),
+        slug: "older".to_string(),
+        owner: "alice".to_string(),
+    }));
+    state.apply_event(Event::RoomCreated(RoomCreated {
+        ts: 2000,
+        room_id: "cc22dd/newer".to_string(),
+        slug: "newer".to_string(),
+        owner: "alice".to_string(),
+    }));
+    // Empty rooms fall back to created time.
+    assert_eq!(state.room_last_activity_ts("aa11bb/older"), 1000);
+    assert_eq!(state.room_last_activity_ts("cc22dd/newer"), 2000);
+
+    let mut ev = match ingest_event(5000, "hi\n") {
+        Event::Ingest(i) => i,
+        _ => unreachable!(),
+    };
+    ev.room_id = "aa11bb/older".to_string();
+    ev.thread_tag = "chat".to_string();
+    state.apply_event(Event::Ingest(ev));
+    assert_eq!(state.room_last_activity_ts("aa11bb/older"), 5000);
+    assert_eq!(state.room_last_activity_ts("cc22dd/newer"), 2000);
+}
+
 // ============================================================================
 // Feed redacted-post filtering regression tests
 // ============================================================================


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Timestamps (thread feed, posts, rooms, profile, search, rank history) are tinted with a continuous `color-mix` between `--age-fresh` and `--age-old`, fading linearly over 7 days.
- Private rooms on the home page and in `RoomList` RPC are ordered by most recent forum activity (fallback: room created time), and the home list shows a colored timeago.

## Notes
- Existing discrete `.age-*` classes still color thread titles in the feed; only the timeago text uses the proportional mix.
- Theme CSS vars: `--age-fresh` / `--age-old` in default, retro, and craft.

## Demo
Home feed with proportional timestamp colors (fresh green → aged gray):

[Timestamp recency colors on home feed](https://cursor.com/agents/bc-83eb8191-fda0-4a9a-a53d-9604d4b25aef/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftimestamp-recency-home.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83eb8191-fda0-4a9a-a53d-9604d4b25aef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83eb8191-fda0-4a9a-a53d-9604d4b25aef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

