### PR TITLE
Add x-listener: ingest #slugsocial tweets into the graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,6 +506,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-io"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,8 +541,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1439,6 +1448,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -1464,12 +1474,14 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -2452,6 +2464,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2776,6 +2801,21 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "x-listener"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "clap",
+ "futures-util",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "slug-types",
+ "tempfile",
+ "tokio",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["server", "cli", "sorterc"]
+members = ["server", "cli", "sorterc", "x-listener"]
 resolver = "2"
 
 

--- a/agents.md
+++ b/agents.md
@@ -108,6 +108,13 @@ cargo run -p sorterc -- scan path/to/events.jsonl [--pretty]
 
 `compile` validates DSL, simulates ingest against empty (or `--base`) reducer state, and prints JSON rankings. `scan` reports corrupt JSONL lines and ingests that fail DSL replay.
 
+**`x-listener`** — out-of-process bot (workspace crate `x-listener`). Listens to X API v2 filtered stream (default rule `#slugsocial`) and posts mapped `.sorter` text into slug via `POST /api/v0/rpc` (`RpcCommand::Post` + bearer + delegate). Uses raw `reqwest` (no Twitter SDK). Requires paid X filtered-stream access (`X_BEARER_TOKEN`) plus a slug agent identity (`SLUG_BEARER_TOKEN`, `SLUG_DELEGATE`). Dry-run / fixture mode:
+
+```
+cargo run -p x-listener -- ingest-file x-listener/fixtures/sample-stream.jsonl --dry-run
+cargo run -p x-listener -- stream --dry-run   # needs X_BEARER_TOKEN; prints mapped text only
+```
+
 ### Testing
 
 - **Rust tests:** `cargo nextest run --workspace` (163 tests; requires `cargo-nextest`)

--- a/x-listener/Cargo.toml
+++ b/x-listener/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "x-listener"
+version = "0.0.1"
+edition = "2021"
+license = "MIT"
+publish = false
+description = "Listen to #slugsocial on X and ingest matching posts into slug.social"
+
+[[bin]]
+name = "x-listener"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1"
+clap = { version = "4", features = ["derive", "env"] }
+futures-util = "0.3"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "rustls-tls-native-roots", "stream"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+slug-types = { path = "../types" }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs", "io-util", "signal", "time"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/x-listener/fixtures/sample-stream.jsonl
+++ b/x-listener/fixtures/sample-stream.jsonl
@@ -1,0 +1,2 @@
+{"data":{"id":"1001","text":"hello #slugsocial — first signal","author_id":"42"},"includes":{"users":[{"id":"42","username":"alice"}]}}
+{"data":{"id":"1002","text":"check https://t.co/xyz #slugsocial","author_id":"99","entities":{"urls":[{"url":"https://t.co/xyz","expanded_url":"https://example.com/cool","display_url":"example.com/cool"}]}},"includes":{"users":[{"id":"99","username":"bob"}]}}

--- a/x-listener/src/main.rs
+++ b/x-listener/src/main.rs
@@ -1,0 +1,232 @@
+//! x-listener — stream `#slugsocial` from X into slug.social.
+//!
+//! Uses raw reqwest against X API v2 filtered stream (no abandoned Twitter SDK).
+//! Ingests via slug RPC `Post` with a bearer + agent delegate.
+
+mod map;
+mod seen;
+mod slug_rpc;
+mod x_api;
+
+use anyhow::{bail, Context, Result};
+use clap::{Parser, Subcommand};
+use std::path::PathBuf;
+
+use map::tweet_to_sorter;
+use seen::SeenStore;
+use slug_rpc::SlugClient;
+use x_api::{parse_stream_line, XClient};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "x-listener",
+    about = "Listen to #slugsocial on X and ingest posts into slug.social"
+)]
+struct Args {
+    #[command(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(Subcommand, Debug)]
+enum Cmd {
+    /// Connect to X filtered stream and ingest matching posts.
+    Stream {
+        /// X API app bearer token.
+        #[arg(long, env = "X_BEARER_TOKEN")]
+        x_bearer: String,
+        /// Filtered-stream rule value (X query syntax).
+        #[arg(long, default_value = "#slugsocial")]
+        rule: String,
+        /// Tag stored on the X stream rule (for cleanup).
+        #[arg(long, default_value = "slugsocial-listener")]
+        rule_tag: String,
+        #[command(flatten)]
+        slug: SlugArgs,
+        /// File of ingested tweet ids (dedupe across restarts).
+        #[arg(long, env = "X_LISTENER_SEEN", default_value = "x-listener-seen.txt")]
+        seen: PathBuf,
+        /// Print mapped sorter text and skip slug RPC.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Ingest from a JSONL fixture of X stream payloads (no X network).
+    IngestFile {
+        /// Path to JSONL (one stream payload object per line).
+        path: PathBuf,
+        #[command(flatten)]
+        slug: SlugArgs,
+        #[arg(long, env = "X_LISTENER_SEEN", default_value = "x-listener-seen.txt")]
+        seen: PathBuf,
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Map a single stream JSON payload to sorter text (stdout).
+    Map {
+        /// Raw stream JSON object, or `-` for stdin.
+        json: String,
+    },
+}
+
+#[derive(clap::Args, Debug, Clone)]
+struct SlugArgs {
+    #[arg(long, env = "SLUG_SERVER", default_value = "https://slug.social")]
+    slug_server: String,
+    #[arg(long, env = "SLUG_BEARER_TOKEN")]
+    slug_bearer: Option<String>,
+    #[arg(long, env = "SLUG_DELEGATE")]
+    slug_delegate: Option<String>,
+    #[arg(long, default_value = "public")]
+    room: String,
+    /// Forum thread that receives ingested tweets.
+    #[arg(long, default_value = "slugsocial")]
+    thread: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+    match args.cmd {
+        Cmd::Stream {
+            x_bearer,
+            rule,
+            rule_tag,
+            slug,
+            seen,
+            dry_run,
+        } => run_stream(x_bearer, rule, rule_tag, slug, seen, dry_run).await,
+        Cmd::IngestFile {
+            path,
+            slug,
+            seen,
+            dry_run,
+        } => run_file(path, slug, seen, dry_run).await,
+        Cmd::Map { json } => {
+            let raw = if json == "-" {
+                use std::io::Read;
+                let mut s = String::new();
+                std::io::stdin().read_to_string(&mut s)?;
+                s
+            } else {
+                json
+            };
+            let (tweet, username) = parse_stream_line(raw.trim())?;
+            let mapped = tweet_to_sorter(&tweet, &username);
+            print!("{}", mapped.text);
+            Ok(())
+        }
+    }
+}
+
+async fn run_stream(
+    x_bearer: String,
+    rule: String,
+    rule_tag: String,
+    slug: SlugArgs,
+    seen_path: PathBuf,
+    dry_run: bool,
+) -> Result<()> {
+    let x = XClient::new(x_bearer);
+    x.ensure_rule(&rule, &rule_tag).await?;
+    let mut seen = SeenStore::open(&seen_path).await?;
+    let poster = if dry_run {
+        None
+    } else {
+        Some(slug_client_from_args(&slug)?)
+    };
+    eprintln!(
+        "x-listener: streaming rule={rule:?} → {} /#{} (seen={} dry_run={dry_run})",
+        slug.room,
+        slug.thread,
+        seen.path().display()
+    );
+    let mut rx = x.spawn_filtered_stream();
+    while let Some(ev) = rx.recv().await {
+        handle_tweet(ev.tweet, &ev.username, &mut seen, poster.as_ref(), dry_run).await?;
+    }
+    Ok(())
+}
+
+async fn run_file(
+    path: PathBuf,
+    slug: SlugArgs,
+    seen_path: PathBuf,
+    dry_run: bool,
+) -> Result<()> {
+    let raw = tokio::fs::read_to_string(&path)
+        .await
+        .with_context(|| format!("read {}", path.display()))?;
+    let mut seen = SeenStore::open(&seen_path).await?;
+    let poster = if dry_run {
+        None
+    } else {
+        Some(slug_client_from_args(&slug)?)
+    };
+    for (i, line) in raw.lines().enumerate() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let (tweet, username) =
+            parse_stream_line(line).with_context(|| format!("line {}", i + 1))?;
+        handle_tweet(tweet, &username, &mut seen, poster.as_ref(), dry_run).await?;
+    }
+    Ok(())
+}
+
+fn slug_client_from_args(slug: &SlugArgs) -> Result<SlugClient> {
+    let bearer = slug
+        .slug_bearer
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("SLUG_BEARER_TOKEN / --slug-bearer required (or pass --dry-run)"))?;
+    let delegate = slug
+        .slug_delegate
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("SLUG_DELEGATE / --slug-delegate required (or pass --dry-run)"))?;
+    if !delegate.contains(':') {
+        bail!("delegate must look like uuid:rig:provider/model (got {delegate})");
+    }
+    Ok(SlugClient::new(
+        &slug.slug_server,
+        bearer,
+        delegate,
+        &slug.room,
+        &slug.thread,
+    ))
+}
+
+async fn handle_tweet(
+    tweet: map::Tweet,
+    username: &str,
+    seen: &mut SeenStore,
+    poster: Option<&SlugClient>,
+    dry_run: bool,
+) -> Result<()> {
+    if seen.contains(&tweet.id) {
+        eprintln!("x-listener: skip already-seen {}", tweet.id);
+        return Ok(());
+    }
+    let mapped = tweet_to_sorter(&tweet, username);
+    eprintln!(
+        "x-listener: {} (@{}) → {}",
+        mapped.tweet_id, mapped.author, mapped.status_url
+    );
+    if dry_run || poster.is_none() {
+        println!("----- {} -----\n{}\n", mapped.tweet_id, mapped.text);
+        seen.insert(&mapped.tweet_id).await?;
+        return Ok(());
+    }
+    let poster = poster.expect("poster");
+    match poster.post_text(&mapped.text).await {
+        Ok(msg) => {
+            eprintln!("x-listener: {msg}");
+            seen.insert(&mapped.tweet_id).await?;
+        }
+        Err(e) => {
+            // Don't mark seen — retry on restart.
+            eprintln!("x-listener: post failed for {}: {e:#}", mapped.tweet_id);
+        }
+    }
+    Ok(())
+}

--- a/x-listener/src/map.rs
+++ b/x-listener/src/map.rs
@@ -1,0 +1,174 @@
+//! Map an X post into a `.sorter` ingest body.
+//!
+//! Everything sticks: tweet URL becomes a garden item; other URLs in the text
+//! become items too. Prose carries attribution + the raw tweet.
+
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Tweet {
+    pub id: String,
+    pub text: String,
+    #[serde(default)]
+    pub author_id: Option<String>,
+    #[serde(default)]
+    pub entities: Option<TweetEntities>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct TweetEntities {
+    #[serde(default)]
+    pub urls: Vec<UrlEntity>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct UrlEntity {
+    pub url: String,
+    #[serde(default)]
+    pub expanded_url: Option<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub display_url: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MappedIngest {
+    pub tweet_id: String,
+    pub author: String,
+    pub status_url: String,
+    pub text: String,
+}
+
+/// Build a status URL. Prefer real username; fall back to `i` when unknown.
+pub fn status_url(username: &str, tweet_id: &str) -> String {
+    let user = if username.is_empty() { "i" } else { username };
+    format!("https://x.com/{user}/status/{tweet_id}")
+}
+
+/// Expand t.co links in tweet text using entity metadata when present.
+pub fn expand_urls(text: &str, entities: Option<&TweetEntities>) -> String {
+    let Some(ents) = entities else {
+        return text.to_string();
+    };
+    let mut out = text.to_string();
+    for u in &ents.urls {
+        let expanded = u
+            .expanded_url
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .unwrap_or(u.url.as_str());
+        if expanded != u.url {
+            out = out.replace(&u.url, expanded);
+        }
+    }
+    out
+}
+
+/// Collect expanded http(s) URLs from entities, excluding the tweet's own status URL.
+fn external_urls(entities: Option<&TweetEntities>, status: &str) -> Vec<String> {
+    let Some(ents) = entities else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for u in &ents.urls {
+        let expanded = u
+            .expanded_url
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .unwrap_or(u.url.as_str());
+        if !expanded.starts_with("http://") && !expanded.starts_with("https://") {
+            continue;
+        }
+        // Skip x.com/twitter.com status self-links and media wrappers that aren't useful items.
+        if expanded == status {
+            continue;
+        }
+        if out.iter().any(|x: &String| x == expanded) {
+            continue;
+        }
+        out.push(expanded.to_string());
+    }
+    out
+}
+
+fn escape_item_body(s: &str) -> String {
+    // Item bodies are `{ … }`; keep braces literal — DSL parser tolerates nested text in practice
+    // when not starting a new path. Prefer stripping unmatched control that breaks fences later.
+    s.replace('\r', "")
+}
+
+/// Map a tweet (+ resolved username) into sorter text for `RpcCommand::Post`.
+pub fn tweet_to_sorter(tweet: &Tweet, username: &str) -> MappedIngest {
+    let author = if username.is_empty() {
+        tweet
+            .author_id
+            .clone()
+            .unwrap_or_else(|| "unknown".to_string())
+    } else {
+        username.trim_start_matches('@').to_string()
+    };
+    let status = status_url(&author, &tweet.id);
+    let body = expand_urls(&tweet.text, tweet.entities.as_ref());
+    let body = escape_item_body(&body);
+    let extras = external_urls(tweet.entities.as_ref(), &status);
+
+    let mut text = String::new();
+    text.push_str(&format!("@{author} on x:\n\n"));
+    text.push_str(&body);
+    text.push('\n');
+    text.push_str(&format!("\n{status} {{\n{body}\n}}\n"));
+    for url in extras {
+        text.push_str(&format!("\n{url} {{\nfrom @{author} via {status}\n}}\n"));
+    }
+
+    MappedIngest {
+        tweet_id: tweet.id.clone(),
+        author,
+        status_url: status,
+        text,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_plain_tweet() {
+        let t = Tweet {
+            id: "123".into(),
+            text: "hello #slugsocial".into(),
+            author_id: Some("99".into()),
+            entities: None,
+        };
+        let m = tweet_to_sorter(&t, "alice");
+        assert_eq!(m.status_url, "https://x.com/alice/status/123");
+        assert!(m.text.contains("@alice on x:"));
+        assert!(m.text.contains("hello #slugsocial"));
+        assert!(m.text.contains("https://x.com/alice/status/123 {\nhello #slugsocial\n}"));
+    }
+
+    #[test]
+    fn expands_tco_and_adds_external_item() {
+        let t = Tweet {
+            id: "456".into(),
+            text: "see https://t.co/abc #slugsocial".into(),
+            author_id: None,
+            entities: Some(TweetEntities {
+                urls: vec![UrlEntity {
+                    url: "https://t.co/abc".into(),
+                    expanded_url: Some("https://example.com/page".into()),
+                    display_url: Some("example.com/page".into()),
+                }],
+            }),
+        };
+        let m = tweet_to_sorter(&t, "bob");
+        assert!(m.text.contains("see https://example.com/page #slugsocial"));
+        assert!(m.text.contains("https://example.com/page {\nfrom @bob via https://x.com/bob/status/456\n}"));
+    }
+
+    #[test]
+    fn status_url_falls_back_without_username() {
+        assert_eq!(status_url("", "1"), "https://x.com/i/status/1");
+    }
+}

--- a/x-listener/src/seen.rs
+++ b/x-listener/src/seen.rs
@@ -1,0 +1,84 @@
+//! Persistent set of ingested tweet ids (one id per line).
+
+use anyhow::{Context, Result};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use tokio::io::AsyncWriteExt;
+
+pub struct SeenStore {
+    path: PathBuf,
+    ids: HashSet<String>,
+}
+
+impl SeenStore {
+    pub async fn open(path: impl Into<PathBuf>) -> Result<Self> {
+        let path = path.into();
+        let mut ids = HashSet::new();
+        if path.exists() {
+            let raw = tokio::fs::read_to_string(&path)
+                .await
+                .with_context(|| format!("read seen file {}", path.display()))?;
+            for line in raw.lines() {
+                let id = line.trim();
+                if !id.is_empty() {
+                    ids.insert(id.to_string());
+                }
+            }
+        } else if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .with_context(|| format!("create {}", parent.display()))?;
+        }
+        Ok(Self { path, ids })
+    }
+
+    pub fn contains(&self, id: &str) -> bool {
+        self.ids.contains(id)
+    }
+
+    pub async fn insert(&mut self, id: &str) -> Result<()> {
+        if !self.ids.insert(id.to_string()) {
+            return Ok(());
+        }
+        let mut f = tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+            .await
+            .with_context(|| format!("append {}", self.path.display()))?;
+        f.write_all(id.as_bytes()).await?;
+        f.write_all(b"\n").await?;
+        f.flush().await?;
+        Ok(())
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    #[allow(dead_code)]
+    pub fn len(&self) -> usize {
+        self.ids.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn persists_across_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("seen.txt");
+        {
+            let mut s = SeenStore::open(&path).await.unwrap();
+            s.insert("111").await.unwrap();
+            s.insert("222").await.unwrap();
+            assert!(s.contains("111"));
+        }
+        let s = SeenStore::open(&path).await.unwrap();
+        assert!(s.contains("111"));
+        assert!(s.contains("222"));
+        assert_eq!(s.len(), 2);
+    }
+}

--- a/x-listener/src/slug_rpc.rs
+++ b/x-listener/src/slug_rpc.rs
@@ -1,0 +1,84 @@
+//! Post mapped tweets into slug via `POST /api/v0/rpc`.
+
+use anyhow::{anyhow, Result};
+use slug_types::{RpcBatch, RpcBatchResponse, RpcCommand, RpcLine, RpcResult};
+
+pub struct SlugClient {
+    http: reqwest::Client,
+    base: String,
+    bearer: String,
+    delegate: String,
+    room: String,
+    thread_tag: String,
+}
+
+impl SlugClient {
+    pub fn new(
+        base: impl Into<String>,
+        bearer: impl Into<String>,
+        delegate: impl Into<String>,
+        room: impl Into<String>,
+        thread_tag: impl Into<String>,
+    ) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            base: base.into(),
+            bearer: bearer.into(),
+            delegate: delegate.into(),
+            room: room.into(),
+            thread_tag: thread_tag.into(),
+        }
+    }
+
+    pub async fn post_text(&self, text: &str) -> Result<String> {
+        let url = format!("{}/api/v0/rpc", self.base.trim_end_matches('/'));
+        let batch = RpcBatch(vec![RpcCommand::Post {
+            room: self.room.clone(),
+            thread_tag: self.thread_tag.clone(),
+            delegate: Some(self.delegate.clone()),
+            text: text.to_string(),
+            return_rank_diff: false,
+        }]);
+        let resp = self
+            .http
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.bearer))
+            .json(&batch)
+            .send()
+            .await?;
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            return Err(anyhow!("slug rpc HTTP {status}: {}", body.trim()));
+        }
+        let parsed: RpcBatchResponse = serde_json::from_str(&body)
+            .map_err(|e| anyhow!("slug rpc decode: {e}; body={}", body.trim()))?;
+        let line = parsed
+            .results
+            .first()
+            .ok_or_else(|| anyhow!("slug rpc empty results"))?;
+        let result = rpc_line_ok(line)?;
+        match result {
+            RpcResult::PostOk { post_id, post_index, .. } => Ok(format!(
+                "posted thread={} post_id={} index={}",
+                self.thread_tag,
+                post_id.as_deref().unwrap_or("?"),
+                post_index.map(|i| i.to_string()).unwrap_or_else(|| "?".into())
+            )),
+            other => Err(anyhow!("unexpected rpc result: {other:?}")),
+        }
+    }
+}
+
+fn rpc_line_ok(line: &RpcLine) -> Result<&RpcResult> {
+    if !line.ok {
+        let mut m = line.error.clone().unwrap_or_else(|| "rpc error".into());
+        if let Some(h) = &line.hint {
+            m.push_str(&format!("\nhint: {h}"));
+        }
+        return Err(anyhow!(m));
+    }
+    line.result
+        .as_ref()
+        .ok_or_else(|| anyhow!("rpc missing result"))
+}

--- a/x-listener/src/x_api.rs
+++ b/x-listener/src/x_api.rs
@@ -1,0 +1,232 @@
+//! Minimal X API v2 filtered-stream client (raw reqwest — no abandoned Twitter SDK).
+
+use anyhow::{anyhow, Context, Result};
+use futures_util::StreamExt;
+use serde::Deserialize;
+use serde_json::json;
+use std::collections::HashMap;
+use std::time::Duration;
+use tokio::sync::mpsc;
+
+use crate::map::Tweet;
+
+const API: &str = "https://api.x.com/2";
+
+#[derive(Debug, Deserialize)]
+struct RulesGet {
+    #[serde(default)]
+    data: Vec<Rule>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Rule {
+    id: String,
+    value: String,
+    #[serde(default)]
+    tag: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StreamPayload {
+    data: Tweet,
+    #[serde(default)]
+    includes: Option<Includes>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct Includes {
+    #[serde(default)]
+    users: Vec<User>,
+}
+
+#[derive(Debug, Deserialize)]
+struct User {
+    id: String,
+    username: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct StreamTweet {
+    pub tweet: Tweet,
+    pub username: String,
+}
+
+pub struct XClient {
+    bearer: String,
+}
+
+impl XClient {
+    pub fn new(bearer: impl Into<String>) -> Self {
+        Self {
+            bearer: bearer.into(),
+        }
+    }
+
+    fn http_short(&self) -> Result<reqwest::Client> {
+        reqwest::Client::builder()
+            .user_agent("slugsocial-x-listener/0.0.1")
+            .timeout(Duration::from_secs(30))
+            .connect_timeout(Duration::from_secs(20))
+            .build()
+            .context("reqwest client")
+    }
+
+    /// Ensure a filtered-stream rule exists for `value` (e.g. `#slugsocial`).
+    pub async fn ensure_rule(&self, value: &str, tag: &str) -> Result<()> {
+        let http = self.http_short()?;
+        let url = format!("{API}/tweets/search/stream/rules");
+        let resp = http
+            .get(&url)
+            .header("Authorization", format!("Bearer {}", self.bearer))
+            .send()
+            .await
+            .context("list stream rules")?;
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            return Err(anyhow!("list rules HTTP {status}: {}", body.trim()));
+        }
+        let parsed: RulesGet = serde_json::from_str(&body).unwrap_or(RulesGet { data: vec![] });
+        if parsed.data.iter().any(|r| r.value == value) {
+            eprintln!("x-listener: stream rule already present: {value}");
+            return Ok(());
+        }
+        let stale: Vec<String> = parsed
+            .data
+            .iter()
+            .filter(|r| r.tag.as_deref() == Some(tag))
+            .map(|r| r.id.clone())
+            .collect();
+        if !stale.is_empty() {
+            let del = json!({ "delete": { "ids": stale } });
+            let resp = http
+                .post(&url)
+                .header("Authorization", format!("Bearer {}", self.bearer))
+                .json(&del)
+                .send()
+                .await
+                .context("delete stale rules")?;
+            if !resp.status().is_success() {
+                let t = resp.text().await.unwrap_or_default();
+                return Err(anyhow!("delete rules failed: {}", t.trim()));
+            }
+        }
+        let add = json!({
+            "add": [{ "value": value, "tag": tag }]
+        });
+        let resp = http
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.bearer))
+            .json(&add)
+            .send()
+            .await
+            .context("add stream rule")?;
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            return Err(anyhow!("add rule HTTP {status}: {}", body.trim()));
+        }
+        eprintln!("x-listener: added stream rule {value:?} tag={tag}");
+        Ok(())
+    }
+
+    /// Spawn a reconnecting filtered-stream reader; returns a channel of tweets.
+    pub fn spawn_filtered_stream(&self) -> mpsc::Receiver<StreamTweet> {
+        let (tx, rx) = mpsc::channel(32);
+        let bearer = self.bearer.clone();
+        tokio::spawn(async move {
+            let mut backoff = Duration::from_secs(1);
+            loop {
+                match stream_once(&bearer, &tx).await {
+                    Ok(()) => {
+                        eprintln!("x-listener: stream ended cleanly; reconnecting");
+                        backoff = Duration::from_secs(1);
+                    }
+                    Err(e) => {
+                        eprintln!("x-listener: stream error: {e:#}; retry in {backoff:?}");
+                    }
+                }
+                if tx.is_closed() {
+                    break;
+                }
+                tokio::time::sleep(backoff).await;
+                backoff = (backoff * 2).min(Duration::from_secs(60));
+            }
+        });
+        rx
+    }
+}
+
+async fn stream_once(bearer: &str, tx: &mpsc::Sender<StreamTweet>) -> Result<()> {
+    let http = reqwest::Client::builder()
+        .user_agent("slugsocial-x-listener/0.0.1")
+        .connect_timeout(Duration::from_secs(20))
+        .build()
+        .context("stream client")?;
+    let url = format!(
+        "{API}/tweets/search/stream?\
+         tweet.fields=author_id,created_at,entities,text&\
+         expansions=author_id&\
+         user.fields=username"
+    );
+    let resp = http
+        .get(&url)
+        .header("Authorization", format!("Bearer {bearer}"))
+        .send()
+        .await
+        .context("connect stream")?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(anyhow!("stream HTTP {status}: {}", body.trim()));
+    }
+    let mut stream = resp.bytes_stream();
+    let mut buf = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.context("stream chunk")?;
+        buf.extend_from_slice(&chunk);
+        while let Some(pos) = buf.iter().position(|&b| b == b'\n') {
+            let line: Vec<u8> = buf.drain(..=pos).collect();
+            let line = String::from_utf8_lossy(&line);
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            match parse_stream_line(line) {
+                Ok((tweet, username)) => {
+                    if tx
+                        .send(StreamTweet { tweet, username })
+                        .await
+                        .is_err()
+                    {
+                        return Ok(());
+                    }
+                }
+                Err(e) => {
+                    eprintln!("x-listener: skip undecodable line ({e}): {line}");
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn resolve_username(payload: &StreamPayload) -> String {
+    let Some(author_id) = payload.data.author_id.as_deref() else {
+        return String::new();
+    };
+    let mut by_id: HashMap<&str, &str> = HashMap::new();
+    if let Some(inc) = &payload.includes {
+        for u in &inc.users {
+            by_id.insert(u.id.as_str(), u.username.as_str());
+        }
+    }
+    by_id.get(author_id).copied().unwrap_or("").to_string()
+}
+
+/// Parse a single stream JSON line (for fixtures / dry-run).
+pub fn parse_stream_line(line: &str) -> Result<(Tweet, String)> {
+    let payload: StreamPayload = serde_json::from_str(line).context("parse stream line")?;
+    let username = resolve_username(&payload);
+    Ok((payload.data, username))
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Out-of-process bot that listens to X and posts everything tagged `#slugsocial` into slug — no gatekeeping.

## Approach
- New workspace crate `x-listener` (sibling to `sorterc`)
- **Raw `reqwest`** against X API v2 filtered stream — Rust Twitter SDKs are abandoned (`egg-mode`) or stale (`twitter-v2` last touched 2022)
- Maps each tweet → `.sorter` text: attribution prose + `https://x.com/…/status/… { … }` item + expanded external URLs as items
- Posts via existing `POST /api/v0/rpc` `Post` (bearer + agent delegate)
- Dedupe via local seen-id file; `--dry-run` and `ingest-file` for fixture testing

## Run
```bash
# map fixtures without X or slug credentials
cargo run -p x-listener -- ingest-file x-listener/fixtures/sample-stream.jsonl --dry-run

# live stream (needs X filtered-stream access + slug agent identity)
export X_BEARER_TOKEN=…
export SLUG_BEARER_TOKEN=slug_…
export SLUG_DELEGATE='uuid:rig:provider/model'
cargo run -p x-listener -- stream
```

Default target: `public` / `#slugsocial`.

## Note
X filtered stream is **not free** — requires a paid X API tier. The crate is ready; credentials are the remaining gate.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83eb8191-fda0-4a9a-a53d-9604d4b25aef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83eb8191-fda0-4a9a-a53d-9604d4b25aef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

