### PR TITLE
Add garden depth select with ∞ (all descendants)

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -301,8 +301,9 @@ enum GardenCmd {
     /// Multiple paths = merge those scopes (e.g. garden children models ai-models).
     Children {
         /// How many levels deep to resolve (default 1 = direct children only).
-        #[arg(long, value_name = "N")]
-        depth: Option<usize>,
+        /// Pass `all` (or `∞` / `inf`) for every descendant.
+        #[arg(long, value_name = "N|all")]
+        depth: Option<String>,
         /// Output as JSON for agent parsing
         #[arg(long)]
         json: bool,
@@ -789,6 +790,18 @@ fn ontology_path_for_api_query(normalized: &str) -> String {
     }
 }
 
+/// Parse `--depth` for garden children (`all` / `∞` / `inf` → unbounded).
+fn parse_garden_depth_arg(raw: &str) -> usize {
+    let s = raw.trim();
+    if matches!(
+        s,
+        "all" | "∞" | "inf" | "infinity" | "*" | "unlimited"
+    ) {
+        return usize::MAX;
+    }
+    s.parse::<usize>().unwrap_or(1).max(1)
+}
+
 /// Thread name for API; strip leading # so shell users can omit it (# is comment).
 fn normalize_thread_input(name: &str) -> String {
     name.trim().trim_start_matches('#').to_string()
@@ -970,6 +983,7 @@ async fn run_scoped(base: &str, room: &str, sub: ScopedCmd) -> Result<()> {
                     .map(|p| ontology_path_for_api_query(p))
                     .collect::<Vec<_>>()
                     .join(",");
+                let depth = depth.as_deref().map(parse_garden_depth_arg);
                 let batch = send_rpc(
                     &client,
                     base,

--- a/server/src/html/garden/copy.rs
+++ b/server/src/html/garden/copy.rs
@@ -71,7 +71,7 @@ fn rankings_for_copy(
     let parent = ItemId::parse(parent_path.trim())
         .unwrap_or_else(|| ItemId::ontology_root())
         .normalized_storage();
-    let depth = depth.clamp(1, 5);
+    let depth = depth.max(1);
     if depth > 1 {
         let items = resolve_scope_recursive(state_content, &[parent.as_str().to_string()], depth);
         build_rankings_for_item_set(state_content, &items)

--- a/server/src/html/garden/item.rs
+++ b/server/src/html/garden/item.rs
@@ -1,10 +1,14 @@
 use axum::http::Uri;
+use maud::{html, Markup};
 
 use crate::{
     canonical_path::canonicalize_item,
     html::forum::ThreadNav,
     path_types::ItemId,
 };
+
+/// Sentinel for "every descendant" ranking depth (`?depth=all`).
+pub(super) const GARDEN_DEPTH_ALL: usize = usize::MAX;
 
 pub(super) fn item_display_path(item: &str) -> String {
     ItemId::parse(item)
@@ -30,6 +34,60 @@ pub(super) fn login_href_with_next(next: &str) -> String {
     format!("/login?next={}", urlencoding::encode(next))
 }
 
+/// Parse a garden `depth` query/CLI value. Default / invalid → 1.
+/// Accepts `all`, `∞`, `inf`, `infinity`, `*` for unbounded descendant depth.
+pub(super) fn parse_garden_depth(raw: &str) -> usize {
+    let s = raw.trim();
+    if s.is_empty() {
+        return 1;
+    }
+    // Percent-decoding for ∞ (%E2%88%9E) if a client encodes the glyph.
+    let decoded = percent_decode_basic(s);
+    let key = decoded.as_str();
+    if matches!(
+        key,
+        "all" | "∞" | "inf" | "infinity" | "*" | "unlimited"
+    ) {
+        return GARDEN_DEPTH_ALL;
+    }
+    key.parse::<usize>().unwrap_or(1).max(1)
+}
+
+fn percent_decode_basic(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let (Some(hi), Some(lo)) = (from_hex(bytes[i + 1]), from_hex(bytes[i + 2])) {
+                out.push((hi << 4) | lo);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8(out).unwrap_or_else(|_| s.to_string())
+}
+
+fn from_hex(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+pub(super) fn garden_depth_query_value(depth: usize) -> String {
+    if depth == GARDEN_DEPTH_ALL {
+        "all".to_string()
+    } else {
+        depth.to_string()
+    }
+}
+
 pub(super) fn child_depth_from_uri(uri: &Uri) -> usize {
     uri.query()
         .into_iter()
@@ -37,13 +95,84 @@ pub(super) fn child_depth_from_uri(uri: &Uri) -> usize {
         .filter_map(|pair| pair.split_once('='))
         .find_map(|(k, v)| {
             if k == "depth" {
-                v.parse::<usize>().ok()
+                Some(parse_garden_depth(v))
             } else {
                 None
             }
         })
         .unwrap_or(1)
-        .clamp(1, 5)
+}
+
+/// GET navigation depth control. Options: 1, 2, 3, ∞ (`all`).
+pub(super) fn garden_depth_select_markup(current: usize) -> Markup {
+    let current_val = garden_depth_query_value(current);
+    let mut options: Vec<(String, String)> = vec![
+        ("1".into(), "1".into()),
+        ("2".into(), "2".into()),
+        ("3".into(), "3".into()),
+        ("all".into(), "∞".into()),
+    ];
+    if !options.iter().any(|(v, _)| v == &current_val) {
+        let insert_at = options.len().saturating_sub(1);
+        options.insert(insert_at, (current_val.clone(), current_val.clone()));
+    }
+    // Preserve other query params; depth=1 drops the param (default).
+    let onchange = "const u=new URL(location.href);const v=this.value;if(v==='1'){u.searchParams.delete('depth')}else{u.searchParams.set('depth',v)}location.assign(u.pathname+u.search+u.hash)";
+    html! {
+        label class="garden-depth-control" {
+            span class="muted" { "depth" }
+            " "
+            select id="garden-depth-select" aria-label="Garden ranking depth" onchange=(onchange) {
+                @for (val, label) in &options {
+                    @if *val == current_val {
+                        option value=(val) selected { (label) }
+                    } @else {
+                        option value=(val) { (label) }
+                    }
+                }
+            }
+        }
+    }
 }
 
 // re-export for vote module tests that used canonicalize_tag via pick_autothread - not needed here
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::Uri;
+
+    #[test]
+    fn parse_garden_depth_defaults_and_all() {
+        assert_eq!(parse_garden_depth(""), 1);
+        assert_eq!(parse_garden_depth("1"), 1);
+        assert_eq!(parse_garden_depth("3"), 3);
+        assert_eq!(parse_garden_depth("0"), 1);
+        assert_eq!(parse_garden_depth("all"), GARDEN_DEPTH_ALL);
+        assert_eq!(parse_garden_depth("∞"), GARDEN_DEPTH_ALL);
+        assert_eq!(parse_garden_depth("inf"), GARDEN_DEPTH_ALL);
+        assert_eq!(parse_garden_depth("%E2%88%9E"), GARDEN_DEPTH_ALL);
+        assert_eq!(parse_garden_depth("nope"), 1);
+    }
+
+    #[test]
+    fn child_depth_from_uri_reads_query() {
+        let d1: Uri = "/~/topic".parse().unwrap();
+        assert_eq!(child_depth_from_uri(&d1), 1);
+        let d2: Uri = "/~/topic?depth=2".parse().unwrap();
+        assert_eq!(child_depth_from_uri(&d2), 2);
+        let dall: Uri = "/~?depth=all".parse().unwrap();
+        assert_eq!(child_depth_from_uri(&dall), GARDEN_DEPTH_ALL);
+    }
+
+    #[test]
+    fn garden_depth_select_marks_current() {
+        let html = garden_depth_select_markup(2).into_string();
+        assert!(html.contains("id=\"garden-depth-select\""));
+        assert!(html.contains("value=\"2\" selected"));
+        assert!(html.contains("value=\"all\""));
+        assert!(html.contains(">∞<"));
+        let all = garden_depth_select_markup(GARDEN_DEPTH_ALL).into_string();
+        assert!(all.contains("value=\"all\" selected"));
+    }
+}

--- a/server/src/html/garden/item_page.rs
+++ b/server/src/html/garden/item_page.rs
@@ -211,7 +211,7 @@ pub(super) fn build_item_page_view_model(
         .unwrap_or_else(|| ItemId::parse("~/").unwrap())
         .normalized_storage();
     let item_has_parent = item_key.parent().is_some();
-    let child_depth = child_depth.clamp(1, 5);
+    let child_depth = child_depth.max(1);
     let child_rankings = if child_depth > 1 {
         let items = resolve_scope_recursive(content, &[item_key.as_str().to_string()], child_depth);
         build_rankings_for_item_set(content, &items)

--- a/server/src/html/garden/render.rs
+++ b/server/src/html/garden/render.rs
@@ -29,7 +29,10 @@ use super::{
     browse::{garden_layout_meta, scoped_bc_path_for, GardenBrowsePath},
     copy::garden_rank_copy_button_markup,
     external::{external_frame_allowed, external_source_href, github_resolver_controls},
-    item::{child_depth_from_uri, item_code_label, item_display_path, item_href},
+    item::{
+        child_depth_from_uri, garden_depth_select_markup, item_code_label, item_display_path,
+        item_href,
+    },
     item_page::{build_item_page_view_model, sibling_nav_markup},
     pin::{child_row_pin_or_vote, ont_pin_vote_controls, pinned_item_from_jar},
     vote::vote_pool_href,
@@ -208,10 +211,8 @@ pub(super) async fn render_scope_view(
                     + model.child_rankings.unranked_items.len();
                 h3 {
                     "ranked child groups"
-                    @if model.child_depth > 1 {
-                        " "
-                        span class="muted" { (format!("(depth {})", model.child_depth)) }
-                    }
+                    " "
+                    (garden_depth_select_markup(model.child_depth))
                     @if total_children > 0 {
                         " "
                         (garden_rank_copy_button_markup(

--- a/server/src/html/garden/routes.rs
+++ b/server/src/html/garden/routes.rs
@@ -21,6 +21,7 @@ use crate::{
     path_types::ItemId,
     scope_rank::{
         build_children_rankings, build_rankings_for_item_set, external_root_host_items,
+        resolve_scope_recursive,
     },
     state::AppState,
 };
@@ -29,7 +30,7 @@ use super::{
     access::{content_for_garden_view, room_not_found_page, room_scope_has_garden_content, user_can_view_room},
     browse::{GardenBrowsePath, scoped_bc_path_external},
     copy::garden_rank_copy_button_markup,
-    item::{item_display_path, item_href},
+    item::{child_depth_from_uri, garden_depth_select_markup, item_display_path, item_href},
     render::render_scope_view,
 };
 
@@ -39,9 +40,18 @@ pub async fn garden_index(
     uri: Uri,
 ) -> impl IntoResponse {
     let nav = ThreadNav::public();
+    let child_depth = child_depth_from_uri(&uri);
     let child_rankings = {
         let reduced = state.reduced.read().await;
-        build_children_rankings(reduced.public(), &ItemId::ontology_root())
+        let content = reduced.public();
+        let root = ItemId::ontology_root();
+        if child_depth > 1 {
+            let items =
+                resolve_scope_recursive(content, &[root.as_str().to_string()], child_depth);
+            build_rankings_for_item_set(content, &items)
+        } else {
+            build_children_rankings(content, &root)
+        }
     };
 
     let url_key = canonical_view_url(&uri);
@@ -55,9 +65,11 @@ pub async fn garden_index(
             nav class="breadcrumb" { (bc_path(&root_path)) }
             h2 {
                 "paths"
+                " "
+                (garden_depth_select_markup(child_depth))
                 @if !(child_rankings.component_rankings.is_empty() && child_rankings.unranked_items.is_empty()) {
                     " "
-                    (garden_rank_copy_button_markup(&nav, "~/", 1, false))
+                    (garden_rank_copy_button_markup(&nav, "~/", child_depth, false))
                 }
             }
             @if child_rankings.component_rankings.is_empty() && child_rankings.unranked_items.is_empty() {

--- a/server/src/html/garden/tests.rs
+++ b/server/src/html/garden/tests.rs
@@ -338,6 +338,37 @@ fn item_page_model_depth_includes_descendants() {
 }
 
 #[test]
+fn item_page_model_depth_all_includes_deep_descendants() {
+    let mut reduced = ReducerState::default();
+    apply_ingest(
+        &mut reduced,
+        1,
+        "@00000000-0000-0000-0000-000000000000:test:local/test\n\
+         ~/topic {root}\n\
+         ~/topic/a {alpha}\n\
+         ~/topic/a/mid {mid}\n\
+         ~/topic/a/mid/leaf {leaf}\n\
+         ~/topic/b {beta}\n",
+    );
+
+    let model = build_item_page_view_model(
+        &reduced,
+        &ScopeId::Public,
+        "~/topic",
+        super::item::GARDEN_DEPTH_ALL,
+    );
+    assert_eq!(model.child_depth, super::item::GARDEN_DEPTH_ALL);
+    let items: std::collections::HashSet<&str> = model
+        .child_rankings
+        .unranked_items
+        .iter()
+        .map(|u| u.as_str())
+        .collect();
+    assert!(items.contains("https://slug.social/~/topic/a/mid/leaf"));
+    assert!(items.contains("https://slug.social/~/topic/b"));
+}
+
+#[test]
 fn vote_compare_item_card_renders_github_import_markup() {
     let nav = ThreadNav::public();
     let item = ItemId::parse("https://github.com/o/r/issues/1").unwrap();

--- a/server/src/scope_rank.rs
+++ b/server/src/scope_rank.rs
@@ -49,6 +49,7 @@ pub fn resolve_scope(content: &ContentState, specs: &[String]) -> Vec<ItemId> {
 /// Resolve scope specs recursively up to `depth` levels deep.
 /// depth=1 is equivalent to resolve_scope (direct children only).
 /// depth=2 includes grandchildren, etc.
+/// Large depths (including `usize::MAX` for "all") stop early when the frontier empties.
 pub fn resolve_scope_recursive(
     content: &ContentState,
     specs: &[String],

--- a/server/static/theme_default.css
+++ b/server/static/theme_default.css
@@ -790,6 +790,28 @@ details > summary::-webkit-details-marker { display: none; }
   border-color: var(--lo) var(--hi) var(--hi) var(--lo);
   transform: translate(1px, 1px);
 }
+.garden-depth-control {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  font-weight: normal;
+  vertical-align: baseline;
+}
+#garden-depth-select {
+  background: var(--g4);
+  border: var(--bv) solid;
+  border-color: var(--hi) var(--lo) var(--lo) var(--hi);
+  color: var(--ui);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 1px 6px;
+  user-select: none;
+  vertical-align: baseline;
+}
+#garden-depth-select:hover { color: var(--signal); }
+#garden-depth-select:active {
+  border-color: var(--lo) var(--hi) var(--hi) var(--lo);
+}
 #search-btn {
   background: var(--g4);
   border: var(--bv) solid;

--- a/server/static/theme_retro_craft.css
+++ b/server/static/theme_retro_craft.css
@@ -429,6 +429,7 @@ button.cli-panel-row:hover {
   display: contents;
 }
 #theme-select,
+#garden-depth-select,
 #search-btn,
 a#src-link {
   border: 1px solid var(--line);
@@ -440,10 +441,17 @@ a#src-link {
   text-decoration: none;
 }
 #theme-select:hover,
+#garden-depth-select:hover,
 #search-btn:hover,
 a#src-link:hover {
   border-color: var(--accent);
   color: var(--accent);
+}
+.garden-depth-control {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.25rem;
+  font-weight: normal;
 }
 
 /* Ontology / garden — light paper in the shell */

--- a/test/browser_public_garden.clj
+++ b/test/browser_public_garden.clj
@@ -79,6 +79,8 @@
                (is (wait-for-text pg "body" "@alice" 15000) "alice session after login")
                (page/navigate pg (str base-url "/~"))
                (is (wait-for-text pg "body" "paths" 15000) "public garden index shows paths heading")
+               (is (wait-for-text pg "#garden-depth-select" "1" 5000)
+                   "depth select present on garden index")
                (is (wait-for-text pg "body" "ordering" 10000)
                    "ranked child group meta visible")
                (is (wait-for-text pg "body" "~/br-pub-a" 10000) "ranked list shows ~/br-pub-a")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Garden pages now expose ranking depth as a small GET dropdown next to the child rankings heading (and on `/~`).

- **Default `1`** — direct children / siblings only (unchanged)
- **`2` / `3`** — include that many descendant levels
- **`∞` (`?depth=all`)** — every descendant; at root, every garden item
- Changing the select rewrites `?depth=` (drops the param at depth 1) so URLs stay shareable
- Lifts the old hard clamp at 5; CLI `--depth` also accepts `all` / `inf` / `∞`

Depth still means “how deep to *include* in the ranking view,” not a single flat cross-level ranking — disconnected components remain separate orderings.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64e4ca1b-fabb-4ae9-8248-991df804d3a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64e4ca1b-fabb-4ae9-8248-991df804d3a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

