### PR TITLE
Fix garden vote history links to the right thread page/post

### DIFF
--- a/server/src/html/forum/ingest.rs
+++ b/server/src/html/forum/ingest.rs
@@ -11,7 +11,7 @@ use crate::html::{
 };
 use crate::timeago;
 
-use super::nav::ThreadNav;
+use super::nav::{post_fragment_id, ThreadNav};
 
 /// `POST /ui` + `__rpc__` from an inline link (`onclick`); same-origin credentials as other morph actions.
 pub(super) fn thread_ui_fetch_onclick(rpc_compact_json: &str) -> String {
@@ -158,9 +158,10 @@ pub(crate) fn ingest_entry_markup(
 ) -> Markup {
     let redacted = reduced.redacted_posts.contains(&ing.id);
     let show_delete = viewer == Some(ing.principal.as_str()) && !redacted;
+    let frag = post_fragment_id(post_idx);
     if redacted {
         html! {
-            div class="ingest-entry ingest-redacted" data-ingest-id=(ing.id) {
+            div class="ingest-entry ingest-redacted" id=(frag.as_str()) data-ingest-id=(ing.id) {
                 (redacted_header_row(nav, tag, post_idx, ing, now, false))
             }
         }
@@ -185,7 +186,7 @@ pub(crate) fn ingest_entry_markup(
         };
         let item_bodies = reduced.content_for_scope(&nav.scope()).map(|c| &c.item_bodies);
         html! {
-            div class=(entry_class) data-ingest-id=(ing.id) {
+            div class=(entry_class) id=(frag.as_str()) data-ingest-id=(ing.id) {
                 (post_header_row(nav, tag, post_idx, ing, viewer, now, show_delete))
                 (render_linkified_with_embeds_in_scope(display_body, nav.garden_root_url(), item_bodies))
                 @if truncated {

--- a/server/src/html/forum/nav.rs
+++ b/server/src/html/forum/nav.rs
@@ -136,11 +136,11 @@ mod tests {
 
     #[test]
     fn room_thread_url_for_post_keeps_room_prefix() {
-        let nav = ThreadNav::from_room_id("abcd1234/demo").unwrap();
+        let nav = ThreadNav::from_room_id("abcd123/demo").unwrap();
         assert_eq!(
             nav.thread_url_for_post("topic", 12),
-            "/r/abcd1234demo/t/topic?offset=10#post-12"
+            "/r/abcd123demo/t/topic?offset=10#post-12"
         );
-        assert_eq!(nav.post_url("topic", 12), "/r/abcd1234demo/t/topic/12");
+        assert_eq!(nav.post_url("topic", 12), "/r/abcd123demo/t/topic/12");
     }
 }

--- a/server/src/html/forum/nav.rs
+++ b/server/src/html/forum/nav.rs
@@ -2,6 +2,14 @@ use crate::canonical_path::canonicalize_item;
 use crate::reducer::ScopeId;
 use slug_types::room_route_segment;
 
+/// Posts per page on `/t/:tag` (and room thread) list views.
+pub(crate) const THREAD_PAGE_SIZE: usize = 10;
+
+/// DOM `id` / URL fragment for a chronological post on a thread page (`#post-N`).
+pub(crate) fn post_fragment_id(post_idx: usize) -> String {
+    format!("post-{post_idx}")
+}
+
 /// URL helpers for public `/t/…` and private room threads `/r/{short}{slug}/t/…`.
 #[derive(Clone)]
 pub struct ThreadNav {
@@ -81,6 +89,16 @@ impl ThreadNav {
         }
     }
 
+    /// Thread list URL for the page that contains `post_idx`, with `#post-N` to scroll to it.
+    pub(crate) fn thread_url_for_post(&self, tag: &str, post_idx: usize) -> String {
+        let offset = (post_idx / THREAD_PAGE_SIZE) * THREAD_PAGE_SIZE;
+        format!(
+            "{}#{}",
+            self.thread_page_url(tag, offset),
+            post_fragment_id(post_idx)
+        )
+    }
+
     pub(crate) fn post_url(&self, tag: &str, idx: usize) -> String {
         format!("{}/{}/{}", self.thread_path_prefix, tag, idx)
     }
@@ -94,5 +112,35 @@ impl ThreadNav {
                 format!("/r/{seg}")
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn thread_url_for_post_uses_page_offset_and_fragment() {
+        let nav = ThreadNav::public();
+        assert_eq!(nav.thread_url_for_post("hist-test", 0), "/t/hist-test#post-0");
+        assert_eq!(nav.thread_url_for_post("hist-test", 9), "/t/hist-test#post-9");
+        assert_eq!(
+            nav.thread_url_for_post("hist-test", 10),
+            "/t/hist-test?offset=10#post-10"
+        );
+        assert_eq!(
+            nav.thread_url_for_post("hist-test", 25),
+            "/t/hist-test?offset=20#post-25"
+        );
+    }
+
+    #[test]
+    fn room_thread_url_for_post_keeps_room_prefix() {
+        let nav = ThreadNav::from_room_id("abcd1234/demo").unwrap();
+        assert_eq!(
+            nav.thread_url_for_post("topic", 12),
+            "/r/abcd1234demo/t/topic?offset=10#post-12"
+        );
+        assert_eq!(nav.post_url("topic", 12), "/r/abcd1234demo/t/topic/12");
     }
 }

--- a/server/src/html/forum/page.rs
+++ b/server/src/html/forum/page.rs
@@ -44,7 +44,11 @@ pub(super) fn bc_room(
                 false,
             ))
             @if let Some(idx) = focused_post {
-                (bc_segment(&format!("#{t}"), &nav.thread_url(t), false))
+                (bc_segment(
+                    &format!("#{t}"),
+                    &nav.thread_url_for_post(t, idx),
+                    false,
+                ))
                 (bc_segment(&format!("post #{idx}"), &nav.post_url(t, idx), true))
             } @else {
                 (bc_segment(&format!("#{t}"), &nav.thread_url(t), true))

--- a/server/src/html/forum/paginator.rs
+++ b/server/src/html/forum/paginator.rs
@@ -1,9 +1,9 @@
 use maud::{html, Markup};
 
 use super::copy::thread_copy_button_markup;
-use super::nav::ThreadNav;
+use super::nav::{ThreadNav, THREAD_PAGE_SIZE};
 
-pub(super) const PAGE_SIZE: usize = 10;
+pub(super) const PAGE_SIZE: usize = THREAD_PAGE_SIZE;
 
 /// Prev/next links between chronological posts on a single-post (`/t/tag/N`) page.
 pub(super) fn render_post_permalink_nav(nav: &ThreadNav, tag: &str, index: usize, total: usize) -> Markup {

--- a/server/src/html/forum/thread_morph.rs
+++ b/server/src/html/forum/thread_morph.rs
@@ -7,7 +7,7 @@ use crate::state::AppState;
 
 use super::access::user_can_view_room;
 use super::ingest::{ingest_entry_markup, post_header_row, redacted_header_row};
-use super::nav::ThreadNav;
+use super::nav::{post_fragment_id, ThreadNav};
 use crate::html::{render_linkified_with_embeds_in_scope, JsBuilder, now_ms};
 
 pub(crate) async fn thread_ui_expand_post_full(
@@ -54,8 +54,9 @@ pub(crate) async fn thread_ui_expand_post_full(
     let ing_id = ing.id.clone();
     drop(reduced);
 
+    let frag = post_fragment_id(post_index);
     let full_html = html! {
-        div class="ingest-entry" data-ingest-id=(ing_id) {
+        div class="ingest-entry" id=(frag.as_str()) data-ingest-id=(ing_id) {
             (post_header_row(
                 &nav,
                 &tag,
@@ -122,8 +123,9 @@ pub(crate) async fn thread_ui_expand_redacted_post(
     let ing_id = ing.id.clone();
     drop(reduced);
 
+    let frag = post_fragment_id(post_index);
     let full_html = html! {
-        div class="ingest-entry ingest-redacted-expanded" data-ingest-id=(ing_id) {
+        div class="ingest-entry ingest-redacted-expanded" id=(frag.as_str()) data-ingest-id=(ing_id) {
             (redacted_header_row(&nav, &tag, post_index, &ing, now, true))
             (render_linkified_with_embeds_in_scope(
                 &ing.raw,

--- a/server/src/html/garden/render.rs
+++ b/server/src/html/garden/render.rs
@@ -161,9 +161,9 @@ pub(super) async fn render_scope_view(
                                 span class="ts-recency" style=(ts_style.as_str()) { (ago) }
                                 span class="muted" { (label) }
                                 " · "
-                                a href=(thread_href(&e.thread)) { "#" (e.thread) }
+                                a href=(nav.thread_url_for_post(&e.thread, e.thread_post_index)) { "#" (e.thread) }
                                 " "
-                                a href=(format!("{}/{}", thread_href(&e.thread), e.thread_post_index)) {
+                                a href=(nav.post_url(&e.thread, e.thread_post_index)) {
                                     span class="muted" { "post #" (e.thread_post_index) }
                                 }
                             }

--- a/server/src/html/mod.rs
+++ b/server/src/html/mod.rs
@@ -537,9 +537,11 @@ fn bc_path(path: &OntologyPath) -> Markup {
 
 /// Render the thread path breadcrumb: `slug.social / #tag` or `… / #tag / post #N` on a single post.
 /// Root link toggles to `/~` only at thread-root (`/`).
+/// When focusing a post, `#tag` links to the thread page that contains it (`?offset=` + `#post-N`).
 pub(super) fn bc_threads(thread_tag: Option<&str>, focused_post: Option<usize>) -> Markup {
     let root_href = if thread_tag.is_some() { "/" } else { "/~" };
     let root_is_current = thread_tag.is_none();
+    let nav = ThreadNav::public();
     html! {
         @if root_is_current {
             a href=(root_href) class="bc-current" { "slug.social" }
@@ -548,10 +550,14 @@ pub(super) fn bc_threads(thread_tag: Option<&str>, focused_post: Option<usize>) 
         }
         @if let Some(tag) = thread_tag {
             @if let Some(idx) = focused_post {
-                (bc_segment(&format!("#{tag}"), &format!("/t/{tag}"), false))
-                (bc_segment(&format!("post #{idx}"), &format!("/t/{tag}/{idx}"), true))
+                (bc_segment(
+                    &format!("#{tag}"),
+                    &nav.thread_url_for_post(tag, idx),
+                    false,
+                ))
+                (bc_segment(&format!("post #{idx}"), &nav.post_url(tag, idx), true))
             } @else {
-                (bc_segment(&format!("#{tag}"), &format!("/t/{tag}"), true))
+                (bc_segment(&format!("#{tag}"), &nav.thread_url(tag), true))
             }
         }
     }

--- a/server/static/theme_default.css
+++ b/server/static/theme_default.css
@@ -531,6 +531,7 @@ div.ingest-entry {
   border: var(--bv) solid;
   border-color: var(--hi) var(--lo) var(--lo) var(--hi);
   margin: 0 0 5px;
+  scroll-margin-top: 48px;
   width: 100%;
   min-width: 100%;
   max-width: 100%;

--- a/server/static/theme_retro.css
+++ b/server/static/theme_retro.css
@@ -74,6 +74,9 @@ details.ont-rank-history {
   min-width: 0;
   width: 100%;
 }
+div.ingest-entry {
+  scroll-margin-top: 48px;
+}
 
 .rich-embeds {
   display: flex;

--- a/server/static/theme_retro_craft.css
+++ b/server/static/theme_retro_craft.css
@@ -111,6 +111,7 @@ div.ingest-entry {
   margin: 0 0 0.65rem;
   max-width: 100%;
   min-width: 0;
+  scroll-margin-top: 48px;
   width: 100%;
 }
 div.ingest-entry-truncated {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Garden vote history `#thread` links always went to the oldest thread page (`/t/tag`), even when the vote was on a later post.

### Changes
- `#thread` in garden vote history now links to the thread page that contains the voted post (`?offset=…`) and scrolls to `#post-N`
- muted `post #N` still links to the exact post permalink (`/t/tag/N`)
- exact post breadcrumbs (`#tag`) link back to that same in-thread page + anchor
- thread ingest entries expose `id="post-N"` for fragment scrolling (including morph expand/collapse)

### Merge
- Merged latest `main`; only conflict was in `paginator.rs` (simple): kept this branch’s `PAGE_SIZE = THREAD_PAGE_SIZE` alias and main’s fixed-window `latest_page_offset` / `snap_page_offset` helpers.

### Test plan
- Open a garden item with vote history spanning a multi-page thread
- Click `#thread` → lands on the page that contains the post and scrolls to it
- Click `post #N` → exact post page
- From exact post, click `#tag` breadcrumb → thread page with scroll to that post
- Unit: `thread_url_for_post_*` and `latest_page_offset` / `snap_page_offset` (passing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e7334b8-7e2d-4f00-bffb-267c69af4ce1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e7334b8-7e2d-4f00-bffb-267c69af4ce1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

