### PR TITLE
Add rank and winner percentile under garden sibling nav

### DIFF
--- a/server/src/html/garden/item_page.rs
+++ b/server/src/html/garden/item_page.rs
@@ -27,6 +27,33 @@ pub(super) struct SiblingNavGroup {
 #[derive(Debug, Clone)]
 pub(super) struct SiblingNavBar {
     pub(super) groups: Vec<SiblingNavGroup>,
+    /// 1-based rank within the largest ranking component, when the current item is in it.
+    pub(super) largest_group_rank: Option<(usize, usize)>,
+    /// For the winner of the largest ranking group: percentile among that group's size
+    /// (`((n - 1) * 100) / n`, e.g. 99 for n=100).
+    pub(super) winner_percentile: Option<u32>,
+}
+
+/// Ordinal suffix for percentile display (`1st`, `2nd`, `3rd`, `99th`, …).
+pub(super) fn ordinal_suffix(n: u32) -> &'static str {
+    let mod100 = n % 100;
+    if (11..=13).contains(&mod100) {
+        return "th";
+    }
+    match n % 10 {
+        1 => "st",
+        2 => "nd",
+        3 => "rd",
+        _ => "th",
+    }
+}
+
+/// Percentile for the winner of a ranking group of size `n` (requires n ≥ 2).
+pub(super) fn winner_percentile_for_group_size(n: usize) -> Option<u32> {
+    if n < 2 {
+        return None;
+    }
+    Some((((n - 1) * 100) / n) as u32)
 }
 
 #[derive(Debug, Clone)]
@@ -88,29 +115,72 @@ fn build_sibling_nav(
     if sibling_total <= 1 {
         return None;
     }
-    Some(SiblingNavBar { groups })
+
+    // Components are already sorted largest-first; only the first is the "largest ranking group".
+    let current_path = current.to_storage_string();
+    let (largest_group_rank, winner_percentile) =
+        match rankings.component_rankings.first() {
+            Some(largest) if largest.ranked.len() >= 2 => {
+                let of = largest.ranked.len();
+                match largest.ranked.iter().position(|r| {
+                    r.item.clone().normalized_storage().as_str() == current_path
+                }) {
+                    Some(idx) => {
+                        let rank = idx + 1;
+                        let pct = if rank == 1 {
+                            winner_percentile_for_group_size(of)
+                        } else {
+                            None
+                        };
+                        (Some((rank, of)), pct)
+                    }
+                    None => (None, None),
+                }
+            }
+            _ => (None, None),
+        };
+
+    Some(SiblingNavBar {
+        groups,
+        largest_group_rank,
+        winner_percentile,
+    })
 }
 
 pub(super) fn sibling_nav_markup(nav: &ThreadNav, bar: &SiblingNavBar, current_item: &str) -> maud::Markup {
     html! {
-        nav class="breadcrumb ont-sibling-nav" aria-label="siblings under same parent" {
-            @for (gi, group) in bar.groups.iter().enumerate() {
-                @if gi > 0 {
-                    span class="ont-sibling-nav-group-sep" aria-hidden="true" { "·" }
-                }
-                span class="ont-sibling-nav-group" {
-                    @for (i, link) in group.links.iter().enumerate() {
-                        @if i > 0 {
-                            span class="bc-sep ont-sibling-nav-intra" aria-hidden="true" { " " }
+        div class="ont-sibling-nav-wrap" {
+            nav class="breadcrumb ont-sibling-nav" aria-label="siblings under same parent" {
+                @for (gi, group) in bar.groups.iter().enumerate() {
+                    @if gi > 0 {
+                        span class="ont-sibling-nav-group-sep" aria-hidden="true" { "·" }
+                    }
+                    span class="ont-sibling-nav-group" {
+                        @for (i, link) in group.links.iter().enumerate() {
+                            @if i > 0 {
+                                span class="bc-sep ont-sibling-nav-intra" aria-hidden="true" { " " }
+                            }
+                            @let n = i + 1;
+                            @let href = item_href(&link.path, nav);
+                            @let tip = item_display_path(&link.path);
+                            @let is_current = link.path == current_item;
+                            @if is_current {
+                                a href=(href) title=(tip) aria-current="page" { "[" (n) "]" }
+                            } @else {
+                                a href=(href) title=(tip) { (n) }
+                            }
                         }
-                        @let n = i + 1;
-                        @let href = item_href(&link.path, nav);
-                        @let tip = item_display_path(&link.path);
-                        @let is_current = link.path == current_item;
-                        @if is_current {
-                            a href=(href) title=(tip) aria-current="page" { "[" (n) "]" }
-                        } @else {
-                            a href=(href) title=(tip) { (n) }
+                    }
+                }
+            }
+            @if let Some((rank, of)) = bar.largest_group_rank {
+                div class="ont-sibling-nav-score muted" {
+                    span class="ont-sibling-nav-rank" {
+                        (format!("rank: {}/{}", rank, of))
+                    }
+                    @if let Some(pct) = bar.winner_percentile {
+                        span class="ont-sibling-nav-percentile" {
+                            (format!("top {}{} percentile", pct, ordinal_suffix(pct)))
                         }
                     }
                 }
@@ -198,6 +268,32 @@ fn build_rank_history(
             }
         })
         .collect()
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::{ordinal_suffix, winner_percentile_for_group_size};
+
+    #[test]
+    fn ordinal_suffix_handles_teens_and_units() {
+        assert_eq!(ordinal_suffix(1), "st");
+        assert_eq!(ordinal_suffix(2), "nd");
+        assert_eq!(ordinal_suffix(3), "rd");
+        assert_eq!(ordinal_suffix(4), "th");
+        assert_eq!(ordinal_suffix(11), "th");
+        assert_eq!(ordinal_suffix(12), "th");
+        assert_eq!(ordinal_suffix(13), "th");
+        assert_eq!(ordinal_suffix(21), "st");
+        assert_eq!(ordinal_suffix(99), "th");
+    }
+
+    #[test]
+    fn winner_percentile_matches_group_size() {
+        assert_eq!(winner_percentile_for_group_size(1), None);
+        assert_eq!(winner_percentile_for_group_size(2), Some(50));
+        assert_eq!(winner_percentile_for_group_size(5), Some(80));
+        assert_eq!(winner_percentile_for_group_size(100), Some(99));
+    }
 }
 
 pub(super) fn build_item_page_view_model(

--- a/server/src/html/garden/tests.rs
+++ b/server/src/html/garden/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     access::content_for_garden_view,
     external::{external_frame_allowed, external_resolver_status_markup, external_source_href},
-    item_page::build_item_page_view_model,
+    item_page::{build_item_page_view_model, sibling_nav_markup},
     pin::ont_pin_vote_controls,
     vote::{
         canonical_edge_items, edge_vote_count_for_pair, edge_vote_entries_for_pair,
@@ -182,6 +182,80 @@ fn item_page_model_computes_sibling_nav_in_component() {
     assert_eq!(nav.groups.len(), 2);
     assert_eq!(nav.groups[0].links.len(), 2);
     assert_eq!(nav.groups[1].links.len(), 1);
+    // Winner of the largest ranking group (size 2): rank 1/2 + top 50th percentile.
+    assert_eq!(nav.largest_group_rank, Some((1, 2)));
+    assert_eq!(nav.winner_percentile, Some(50));
+}
+
+#[test]
+fn sibling_nav_rank_score_only_for_largest_group_member() {
+    let mut reduced = ReducerState::default();
+    apply_ingest(
+        &mut reduced,
+        1,
+        "@00000000-0000-0000-0000-000000000000:test:local/test\n\
+         ~/topic {topic body}\n\
+         ~/topic/a {alpha}\n\
+         ~/topic/b {beta}\n\
+         ~/topic/c {gamma}\n\
+         ~/topic/d {delta}\n\
+         ~/topic/e {epsilon}\n\
+         {a beats b}\n             ~/topic/a 2:1 ~/topic/b\n\
+         {b beats c}\n             ~/topic/b 2:1 ~/topic/c\n\
+         {d beats e}\n             ~/topic/d 2:1 ~/topic/e\n",
+    );
+
+    // Largest component is a/b/c (size 3); d/e is size 2.
+    let winner = build_item_page_view_model(&reduced, &ScopeId::Public, "~/topic/a", 1);
+    let winner_nav = winner.sibling_nav.expect("sibling nav");
+    assert_eq!(winner_nav.largest_group_rank, Some((1, 3)));
+    assert_eq!(winner_nav.winner_percentile, Some(66)); // (3-1)*100/3
+
+    let mid = build_item_page_view_model(&reduced, &ScopeId::Public, "~/topic/b", 1);
+    let mid_nav = mid.sibling_nav.expect("sibling nav");
+    assert_eq!(mid_nav.largest_group_rank, Some((2, 3)));
+    assert_eq!(mid_nav.winner_percentile, None);
+
+    // Member of the smaller ranking group: no rank/percentile score.
+    let small = build_item_page_view_model(&reduced, &ScopeId::Public, "~/topic/d", 1);
+    let small_nav = small.sibling_nav.expect("sibling nav");
+    assert_eq!(small_nav.largest_group_rank, None);
+    assert_eq!(small_nav.winner_percentile, None);
+}
+
+#[test]
+fn sibling_nav_markup_includes_rank_and_winner_percentile() {
+    let mut reduced = ReducerState::default();
+    apply_ingest(
+        &mut reduced,
+        1,
+        "@00000000-0000-0000-0000-000000000000:test:local/test\n\
+         ~/topic {topic body}\n\
+         ~/topic/a {alpha}\n\
+         ~/topic/b {beta}\n\
+         ~/topic/c {gamma}\n\
+         {a beats b}\n             ~/topic/a 2:1 ~/topic/b\n\
+         {b beats c}\n             ~/topic/b 2:1 ~/topic/c\n",
+    );
+
+    let winner = build_item_page_view_model(&reduced, &ScopeId::Public, "~/topic/a", 1);
+    let winner_nav = winner.sibling_nav.expect("sibling nav");
+    let nav = ThreadNav::public();
+    let html = sibling_nav_markup(&nav, &winner_nav, "~/topic/a").into_string();
+    assert!(html.contains("rank: 1/3"), "missing rank in {html}");
+    assert!(
+        html.contains("top 66th percentile"),
+        "missing winner percentile in {html}"
+    );
+
+    let mid = build_item_page_view_model(&reduced, &ScopeId::Public, "~/topic/b", 1);
+    let mid_nav = mid.sibling_nav.expect("sibling nav");
+    let mid_html = sibling_nav_markup(&nav, &mid_nav, "~/topic/b").into_string();
+    assert!(mid_html.contains("rank: 2/3"), "missing mid rank in {mid_html}");
+    assert!(
+        !mid_html.contains("percentile"),
+        "non-winner should omit percentile: {mid_html}"
+    );
 }
 
 #[test]

--- a/server/static/theme_default.css
+++ b/server/static/theme_default.css
@@ -1317,6 +1317,19 @@ nav.breadcrumb.ont-sibling-nav span.ont-sibling-nav-group-sep {
   padding: 0 6px;
   user-select: none;
 }
+.ont-sibling-nav-wrap {
+  width: 100%;
+  max-width: 100%;
+}
+.ont-sibling-nav-score {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.55em;
+  margin-top: 0.15rem;
+  font-size: 0.9em;
+  line-height: 1.3;
+}
 
 /* ================================================================
    ONTOLOGY ITEM PAGE — DARK VARIANT (opt-in via body class)

--- a/server/static/theme_retro.css
+++ b/server/static/theme_retro.css
@@ -242,6 +242,19 @@ nav.breadcrumb.ont-sibling-nav span.ont-sibling-nav-group-sep {
   padding: 0 6px;
   user-select: none;
 }
+.ont-sibling-nav-wrap {
+  width: 100%;
+  max-width: 100%;
+}
+.ont-sibling-nav-score {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.55em;
+  margin-top: 0.15rem;
+  font-size: 0.9em;
+  line-height: 1.3;
+}
 
 #detail-pane {
   background: #f5f0e8;

--- a/server/static/theme_retro_craft.css
+++ b/server/static/theme_retro_craft.css
@@ -532,6 +532,19 @@ nav.breadcrumb.ont-sibling-nav span.ont-sibling-nav-group-sep {
   padding: 0 6px;
   user-select: none;
 }
+.ont-sibling-nav-wrap {
+  width: 100%;
+  max-width: 100%;
+}
+.ont-sibling-nav-score {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.55em;
+  margin-top: 0.15rem;
+  font-size: 0.9em;
+  line-height: 1.3;
+}
 
 body.view-ontology {
   background: #ebe6dc;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Under the garden sibling number row (`1 2 3 [4] 5 · 1 · …`), show a compact score line when the current item is in the **largest ranking group**:

- `rank: 4/5` — 1-based position within that component
- `top 99th percentile` — only for the winner (rank 1), using `((n - 1) * 100) / n` for group size `n`

Items in smaller components or unranked isolates still get the sibling nav numbers, but no score line.

## Test plan
- [x] `cargo test -p slugsocial-server --lib html::garden::`
- [ ] Open a garden item in the largest sibling component and confirm `rank: k/n` appears under the nav
- [ ] Open the #1 item and confirm `top Nth percentile` appears
- [ ] Open an item in a smaller component / isolate and confirm no score line

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f6adb96-7a56-4c81-a1a3-2e16605a8df3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f6adb96-7a56-4c81-a1a3-2e16605a8df3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

