### PR TITLE
Page-scope the forum thread SSE push path and pagination

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -21,6 +21,8 @@ The web app is **not** a SPA with a JSON API for every interaction. Many mutatio
 - The home page (`GET /`) header shows public human/AI post counts from the reducer (`public_post_stats`: no `delegate` → human, `delegate` set → AI; `system:…` and redacted/private omitted). The `npx slugsocial` splash remains the static embedded `GUIDE.sorter` (no network).
 - Forum and garden item bodies use **`~/…` linkification** (`linkify_slugs_with_prefix` in `server/src/html/mod.rs`). When **`item_bodies`** is in scope, matching ontology links get a native **`title`** tooltip with a **truncated body preview** (hover in the browser).
 
+- **Thread pagination and the SSE push path are page-scoped.** Thread pages (`/t/:tag?offset=N`) are **fixed windows aligned to `PAGE_SIZE` boundaries** (`server/src/html/forum/paginator.rs`): the latest page grows by appending until full, so existing posts never shift; arbitrary `?offset=` values snap to the containing page. Live pushes after a post/redact/graduate (`broadcast_web_refresh` in `server/src/api/write_actor.rs` → `thread_region_page_morphs` in `server/src/html/forum/feed.rs`) morph `#thread-feed-region` only behind **client-side page-offset guards** (`JsBuilder::if_page_offset_*`): the latest page, the page before it (its paginator gains the live `newer →` link at rollover), and — for redactions — the page containing the changed post. Viewers reading older pages are never overwritten with the latest posts. The poster's own `POST /ui` response (`post_success_response` in `server/src/api/ui_html.rs`) morphs in place only on the latest page and otherwise redirects to it.
+
 ---
 
 ## `eval` on the frontend (core constraint)

--- a/server/src/api/ui_html.rs
+++ b/server/src/api/ui_html.rs
@@ -23,7 +23,7 @@ use crate::{
     html::{
         external_resolver_status_markup, fragment_new_thread_slot, login_to_post_hint_markup,
         parse_html_ui_from_form, room_members_section_markup, thread_feed_html,
-        thread_feed_html_for_room, thread_feed_region_markup, thread_ui_collapse_redacted_post,
+        thread_feed_html_for_room, thread_latest_page_region, thread_ui_collapse_redacted_post,
         garden_ui_copy_rank, thread_ui_copy_thread, thread_ui_expand_post_full,
         thread_ui_expand_redacted_post, ui_js_warn, user_can_post_room, user_can_view_room,
         HtmlUiAction, JsBuilder, ThreadNav,
@@ -760,7 +760,7 @@ async fn post_success_response(
         ScopeId::Public => thread_feed_html(state).await,
         ScopeId::Room(_) => thread_feed_html_for_room(state, &room).await,
     };
-    let thread_markup = thread_feed_region_markup(
+    let (latest_offset, thread_markup) = thread_latest_page_region(
         state,
         match &scope {
             ScopeId::Public => None,
@@ -774,18 +774,29 @@ async fn post_success_response(
         ScopeId::Public => "#thread-feed",
         ScopeId::Room(_) => "#room-thread-feed",
     };
+    let latest_page_location = if latest_offset == 0 {
+        thread_location.clone()
+    } else {
+        format!("{thread_location}?offset={latest_offset}")
+    };
 
     let builder = JsBuilder::new()
         .morph_selector(&error_target, empty_error_markup(&error_target))
         .morph_selector(feed_selector, feed_markup)
         .if_current_path_matches(&thread_location, |builder| {
-            let builder = builder.morph_selector("#thread-feed-region", thread_markup);
-            let builder = if !form_id.trim().is_empty() {
-                builder.qs(&format!("#{form_id}")).reset()
-            } else {
-                builder
-            };
-            builder
+            // Poster is viewing the latest page: append in place (page-aligned
+            // windows keep existing posts where they are).
+            let builder = builder.if_page_offset_at_least(latest_offset, |b| {
+                let b = b.morph_selector("#thread-feed-region", thread_markup);
+                if !form_id.trim().is_empty() {
+                    b.qs(&format!("#{form_id}")).reset()
+                } else {
+                    b
+                }
+            });
+            // Poster is on an older page: jump to the latest page so they see
+            // their new post instead of silently rewriting the page they read.
+            builder.if_page_offset_below(latest_offset, |b| b.redirect(&latest_page_location))
         })
         .if_current_path_not_matches(&thread_location, |builder| {
             builder.redirect(&thread_location)

--- a/server/src/api/write_actor.rs
+++ b/server/src/api/write_actor.rs
@@ -53,7 +53,17 @@ fn content_for_room<'a>(reduced: &'a ReducerState, room: &str) -> &'a crate::red
     reduced.content.get(&scope).unwrap_or(empty_content())
 }
 
-async fn broadcast_web_refresh(state: &AppState, room_key: &str, thread_id: &str) {
+/// Push live updates to web subscribers after a thread changed (new post, redaction,
+/// graduation). The `#thread-feed-region` morphs are **page-scoped**: each one is
+/// guarded by the viewer's current `?offset` page, so viewers reading an older page
+/// are never yanked to the latest posts. `changed_post_index` is the chronological
+/// index of a changed existing post (e.g. a redaction) so its page refreshes too.
+async fn broadcast_web_refresh(
+    state: &AppState,
+    room_key: &str,
+    thread_id: &str,
+    changed_post_index: Option<usize>,
+) {
     let feed_id = if room_key == "public" {
         "thread-feed"
     } else {
@@ -73,8 +83,9 @@ async fn broadcast_web_refresh(state: &AppState, room_key: &str, thread_id: &str
         crate::html::thread_feed_html_for_room(state, room_key).await
     };
 
-    let thread_feed_markup =
-        crate::html::thread_feed_region_markup(state, Some(room_key), thread_id, None).await;
+    let morphs: crate::html::ThreadRegionPageMorphs =
+        crate::html::thread_region_page_morphs(state, Some(room_key), thread_id, None, changed_post_index)
+            .await;
 
     // Two SSE payloads: the bump-list morph must not ship private HTML to subscribers who only
     // matched `/` (public) or lack room access — see [`crate::api::stream::get_html_stream`].
@@ -82,8 +93,17 @@ async fn broadcast_web_refresh(state: &AppState, room_key: &str, thread_id: &str
     let feed_builder = feed_builder.qs("#new-thread-compose form").reset();
     let feed_js = feed_builder.build();
 
-    let thread_builder = JsBuilder::new().if_current_path_matches(&thread_url, |builder| {
-        builder.morph_selector("#thread-feed-region", thread_feed_markup)
+    let latest_offset = morphs.latest_offset;
+    let thread_builder = JsBuilder::new().if_current_path_matches(&thread_url, |mut builder| {
+        for page in morphs.pages {
+            let morph = |b: JsBuilder| b.morph_selector("#thread-feed-region", page.markup);
+            builder = if page.offset == latest_offset {
+                builder.if_page_offset_at_least(page.offset, morph)
+            } else {
+                builder.if_page_offset_equals(page.offset, morph)
+            };
+        }
+        builder
     });
     let thread_js = thread_builder.build();
 
@@ -411,7 +431,7 @@ pub async fn writer_actor(mut rx: mpsc::Receiver<WriteCmd>, state: AppState) {
 
                     use crate::canonical_path::canonicalize_tag;
                     let thread_tag_canon = canonicalize_tag(&thread_id);
-                    broadcast_web_refresh(&state, &room_key, &thread_tag_canon).await;
+                    broadcast_web_refresh(&state, &room_key, &thread_tag_canon, None).await;
 
                     let ranking_changes: Option<Vec<slug_types::ScopeRankChanges>> =
                         if return_rank_diff && !voted_parent_scopes.is_empty() {
@@ -522,7 +542,7 @@ pub async fn writer_actor(mut rx: mpsc::Receiver<WriteCmd>, state: AppState) {
 
                     use crate::canonical_path::canonicalize_tag;
                     let thread_tag_canon = canonicalize_tag(&thread_id);
-                    broadcast_web_refresh(&state, &room_key, &thread_tag_canon).await;
+                    broadcast_web_refresh(&state, &room_key, &thread_tag_canon, None).await;
                     let post_index = {
                         let reduced = state.reduced.read().await;
                         reduced.try_thread_post_index_chronological(
@@ -582,11 +602,16 @@ pub async fn writer_actor(mut rx: mpsc::Receiver<WriteCmd>, state: AppState) {
                         .await
                         .map_err(|e| (format!("{e}"), None))?;
                     reduced.apply_event(ev);
+                    let changed_idx = reduced.try_thread_post_index_chronological(
+                        &scope_from_room_wire(&room_key),
+                        &ing.thread_tag,
+                        &post_id,
+                    );
                     drop(reduced);
 
                     use crate::canonical_path::canonicalize_tag;
                     let thread_tag = canonicalize_tag(&ing.thread_tag);
-                    broadcast_web_refresh(&state, &room_key, &thread_tag).await;
+                    broadcast_web_refresh(&state, &room_key, &thread_tag, changed_idx).await;
                     Ok(RpcResult::RedactPostOk {})
                 }
                 .await;
@@ -635,11 +660,16 @@ pub async fn writer_actor(mut rx: mpsc::Receiver<WriteCmd>, state: AppState) {
                         .await
                         .map_err(|e| (format!("{e}"), None))?;
                     reduced.apply_event(ev);
+                    let changed_idx = reduced.try_thread_post_index_chronological(
+                        &scope,
+                        &ing.thread_tag,
+                        &post_id,
+                    );
                     drop(reduced);
 
                     use crate::canonical_path::canonicalize_tag;
                     let thread_tag = canonicalize_tag(&ing.thread_tag);
-                    broadcast_web_refresh(&state, &room_key, &thread_tag).await;
+                    broadcast_web_refresh(&state, &room_key, &thread_tag, changed_idx).await;
                     Ok(RpcResult::RedactPostOk {})
                 }
                 .await;
@@ -842,8 +872,8 @@ pub async fn writer_actor(mut rx: mpsc::Receiver<WriteCmd>, state: AppState) {
                     reduced.apply_event(grad_ev);
                     drop(reduced);
 
-                    broadcast_web_refresh(&state, "public", &thread_tag).await;
-                    broadcast_web_refresh(&state, &room, &thread_tag).await;
+                    broadcast_web_refresh(&state, "public", &thread_tag, None).await;
+                    broadcast_web_refresh(&state, &room, &thread_tag, None).await;
 
                     Ok(RpcResult::ThreadGraduatedOk {
                         thread_tag: thread_tag.clone(),

--- a/server/src/html/forum/feed.rs
+++ b/server/src/html/forum/feed.rs
@@ -17,7 +17,9 @@ use super::ingest::ingest_entry_markup;
 use super::nav::ThreadNav;
 use super::new_thread::{fragment_new_thread_slot, login_to_post_hint_markup};
 use super::page::auth_strip;
-use super::paginator::{render_thread_paginator, PAGE_SIZE};
+use super::paginator::{
+    latest_page_offset, render_thread_paginator, snap_page_offset, PAGE_SIZE,
+};
 use crate::html::{
     bc_threads, cli_panel, layout_with_post_stats, now_ms, recency_class, recency_color_style,
     theme_from_jar, theme_next_from_uri,
@@ -175,48 +177,124 @@ fn render_thread_feed_region_markup(
     }
 }
 
-pub async fn thread_feed_region_markup(
+/// One page-aligned `#thread-feed-region` render, addressed by its start offset.
+pub(crate) struct ThreadRegionPageMorph {
+    pub offset: usize,
+    pub markup: Markup,
+}
+
+/// Region markups for the pages a thread change can affect, first entry = latest page.
+pub(crate) struct ThreadRegionPageMorphs {
+    pub latest_offset: usize,
+    pub pages: Vec<ThreadRegionPageMorph>,
+}
+
+fn thread_not_found_region() -> Markup {
+    html! { div id="thread-feed-region" { p class="muted" { "thread not found" } } }
+}
+
+/// `room_id` is the wire form (`short/slug` or `"public"`). `broadcast_web_refresh` passes
+/// `Some("public")` for the public forum; `ThreadNav::from_room_id` only accepts `short/slug`.
+fn thread_nav_for_room_id(room_id: Option<&str>) -> Option<ThreadNav> {
+    match room_id {
+        Some("public") | None => Some(ThreadNav::public()),
+        Some(room_id) => ThreadNav::from_room_id(room_id),
+    }
+}
+
+/// Region markups for the pages a thread change can affect: the **latest page**
+/// (where new posts append), the page just before it (its paginator gains a live
+/// `newer →` link when a new page starts), and the page containing
+/// `changed_post_index` (redactions of posts on older pages). Offsets are
+/// page-aligned and deduplicated; older pages are never re-rendered, so viewers
+/// reading them are not disturbed.
+pub(crate) async fn thread_region_page_morphs(
     state: &AppState,
     room_id: Option<&str>,
     tag: &str,
     viewer: Option<&str>,
-) -> Markup {
+    changed_post_index: Option<usize>,
+) -> ThreadRegionPageMorphs {
     let tag = canonicalize_tag(tag);
-    // `room_id` is the wire form (`short/slug` or `"public"`). `broadcast_web_refresh` passes
-    // `Some("public")` for the public forum; `ThreadNav::from_room_id` only accepts `short/slug`.
-    let Some(nav) = (match room_id {
-        Some("public") | None => Some(ThreadNav::public()),
-        Some(room_id) => ThreadNav::from_room_id(room_id),
-    }) else {
-        return html! { div id="thread-feed-region" { p class="muted" { "thread not found" } } };
+    let Some(nav) = thread_nav_for_room_id(room_id) else {
+        return ThreadRegionPageMorphs {
+            latest_offset: 0,
+            pages: vec![ThreadRegionPageMorph {
+                offset: 0,
+                markup: thread_not_found_region(),
+            }],
+        };
     };
     let scope = nav.scope();
-    let all_ids: Vec<String> = {
-        let reduced = state.reduced.read().await;
-        reduced
-            .ingests_by_scope_thread
-            .get(&(scope.clone(), tag.clone()))
-            .map(|q| q.iter().rev().cloned().collect())
-            .unwrap_or_default()
-    };
-    let total = all_ids.len();
-    let offset = total.saturating_sub(PAGE_SIZE);
-    let page_ids: Vec<String> = all_ids.into_iter().skip(offset).take(PAGE_SIZE).collect();
+    let now = now_ms();
+
     let reduced = state.reduced.read().await;
-    let display_ingests = page_ids
-        .iter()
-        .filter_map(|id| reduced.ingests_by_id.get(id).cloned())
-        .collect::<Vec<_>>();
-    render_thread_feed_region_markup(
-        &nav,
-        &tag,
-        &display_ingests,
-        offset,
-        total,
-        now_ms(),
-        viewer,
-        &reduced,
-    )
+    let all_ids: Vec<String> = reduced
+        .ingests_by_scope_thread
+        .get(&(scope.clone(), tag.clone()))
+        .map(|q| q.iter().rev().cloned().collect())
+        .unwrap_or_default();
+    let total = all_ids.len();
+    let latest_offset = latest_page_offset(total);
+
+    let mut offsets: Vec<usize> = vec![latest_offset];
+    if latest_offset >= PAGE_SIZE {
+        offsets.push(latest_offset - PAGE_SIZE);
+    }
+    if let Some(idx) = changed_post_index {
+        let page = snap_page_offset(idx, total);
+        if !offsets.contains(&page) {
+            offsets.push(page);
+        }
+    }
+
+    let pages = offsets
+        .into_iter()
+        .map(|offset| {
+            let display_ingests: Vec<crate::events::Ingest> = all_ids
+                .iter()
+                .skip(offset)
+                .take(PAGE_SIZE)
+                .filter_map(|id| reduced.ingests_by_id.get(id).cloned())
+                .collect();
+            ThreadRegionPageMorph {
+                offset,
+                markup: render_thread_feed_region_markup(
+                    &nav,
+                    &tag,
+                    &display_ingests,
+                    offset,
+                    total,
+                    now,
+                    viewer,
+                    &reduced,
+                ),
+            }
+        })
+        .collect();
+
+    ThreadRegionPageMorphs {
+        latest_offset,
+        pages,
+    }
+}
+
+/// Latest-page region markup only — for the poster's own `POST /ui` response.
+pub(crate) async fn thread_latest_page_region(
+    state: &AppState,
+    room_id: Option<&str>,
+    tag: &str,
+    viewer: Option<&str>,
+) -> (usize, Markup) {
+    let morphs = thread_region_page_morphs(state, room_id, tag, viewer, None).await;
+    let latest_offset = morphs.latest_offset;
+    let markup = morphs
+        .pages
+        .into_iter()
+        .next()
+        .map(|p| p.markup)
+        .unwrap_or_else(thread_not_found_region);
+    (latest_offset, markup)
 }
 
 /// Home: private rooms (signed-in), then public bump-ordered threads.

--- a/server/src/html/forum/mod.rs
+++ b/server/src/html/forum/mod.rs
@@ -15,7 +15,11 @@ mod room_members;
 mod thread_morph;
 mod views;
 
-pub use feed::{home, thread_feed_html, thread_feed_html_for_room, thread_feed_region_markup};
+pub use feed::{home, thread_feed_html, thread_feed_html_for_room};
+pub(crate) use feed::{
+    thread_latest_page_region, thread_region_page_morphs, ThreadRegionPageMorphs,
+};
+pub(crate) use paginator::PAGE_SIZE as THREAD_PAGE_SIZE;
 pub use nav::ThreadNav;
 pub use post_single::{room_thread_post_view, thread_post_view};
 pub use profile::user_profile_page;

--- a/server/src/html/forum/paginator.rs
+++ b/server/src/html/forum/paginator.rs
@@ -3,7 +3,26 @@ use maud::{html, Markup};
 use super::copy::thread_copy_button_markup;
 use super::nav::ThreadNav;
 
-pub(super) const PAGE_SIZE: usize = 10;
+pub(crate) const PAGE_SIZE: usize = 10;
+
+/// Start offset of the page containing the newest post.
+///
+/// Thread pages are **fixed windows** aligned to multiples of [`PAGE_SIZE`]
+/// (`0..10`, `10..20`, …), so appending a post never shifts posts already on a
+/// page — the latest page just grows until it is full, then a new page starts.
+pub(crate) fn latest_page_offset(total: usize) -> usize {
+    if total == 0 {
+        0
+    } else {
+        ((total - 1) / PAGE_SIZE) * PAGE_SIZE
+    }
+}
+
+/// Snap a requested `?offset=` value to a valid page boundary for this thread.
+pub(crate) fn snap_page_offset(requested: usize, total: usize) -> usize {
+    let clamped = requested.min(latest_page_offset(total));
+    clamped - (clamped % PAGE_SIZE)
+}
 
 /// Prev/next links between chronological posts on a single-post (`/t/tag/N`) page.
 pub(super) fn render_post_permalink_nav(nav: &ThreadNav, tag: &str, index: usize, total: usize) -> Markup {
@@ -35,7 +54,7 @@ pub(super) fn render_thread_paginator(nav: &ThreadNav, tag: &str, offset: usize,
     } else {
         None
     };
-    let latest_offset = total.saturating_sub(PAGE_SIZE);
+    let latest_offset = latest_page_offset(total);
     let on_latest = offset >= latest_offset;
     let (id, scroll_href, scroll_label) = if top {
         ("top", "#bottom", "↓")
@@ -63,5 +82,29 @@ pub(super) fn render_thread_paginator(nav: &ThreadNav, tag: &str, offset: usize,
             }
             (thread_copy_button_markup(nav, tag, top))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn latest_page_offset_is_page_aligned() {
+        assert_eq!(latest_page_offset(0), 0);
+        assert_eq!(latest_page_offset(1), 0);
+        assert_eq!(latest_page_offset(PAGE_SIZE), 0);
+        assert_eq!(latest_page_offset(PAGE_SIZE + 1), PAGE_SIZE);
+        assert_eq!(latest_page_offset(2 * PAGE_SIZE), PAGE_SIZE);
+        assert_eq!(latest_page_offset(2 * PAGE_SIZE + 1), 2 * PAGE_SIZE);
+    }
+
+    #[test]
+    fn snap_page_offset_clamps_and_aligns() {
+        assert_eq!(snap_page_offset(0, 0), 0);
+        assert_eq!(snap_page_offset(7, 25), 0);
+        assert_eq!(snap_page_offset(PAGE_SIZE + 5, 25), PAGE_SIZE);
+        assert_eq!(snap_page_offset(999, 25), 2 * PAGE_SIZE);
+        assert_eq!(snap_page_offset(PAGE_SIZE, 5), 0);
     }
 }

--- a/server/src/html/forum/views.rs
+++ b/server/src/html/forum/views.rs
@@ -24,7 +24,7 @@ use super::ingest::ingest_entry_markup;
 use super::nav::ThreadNav;
 use super::new_thread::fragment_new_thread_slot;
 use super::page::{auth_strip, bc_room};
-use super::paginator::{render_thread_paginator, PAGE_SIZE};
+use super::paginator::{render_thread_paginator, snap_page_offset, PAGE_SIZE};
 use super::room_members::room_members_section_markup;
 use crate::html::ui_action::UI_RPC_FIELD;
 use crate::html::{
@@ -90,7 +90,9 @@ async fn thread_view_inner(
     };
 
     let total = all_ids.len();
-    let offset = q.offset.unwrap_or(0);
+    // Pages are fixed windows aligned to PAGE_SIZE boundaries (see paginator.rs);
+    // arbitrary `?offset=` values snap to the containing page.
+    let offset = snap_page_offset(q.offset.unwrap_or(0), total);
     let page_ids: Vec<String> = all_ids.into_iter().skip(offset).take(PAGE_SIZE).collect();
 
     let (display_ingests, _subtitle) = {

--- a/server/src/html/mod.rs
+++ b/server/src/html/mod.rs
@@ -27,7 +27,10 @@ pub use auth::{
 pub use editor::{editor_check, editor_page};
 pub use forum::{
     home, room_page, room_thread_post_view, room_thread_view, thread_feed_html,
-    thread_feed_html_for_room, thread_feed_region_markup, thread_post_view, thread_view, ThreadNav,
+    thread_feed_html_for_room, thread_post_view, thread_view, ThreadNav,
+};
+pub(crate) use forum::{
+    thread_latest_page_region, thread_region_page_morphs, ThreadRegionPageMorphs,
 };
 
 pub use forum::user_profile_page;
@@ -255,6 +258,50 @@ impl JsBuilder {
             path = js_string_literal(path),
         ));
         self
+    }
+
+    /// Guard on the viewer's thread-page offset (`?offset=N`, default 0, snapped
+    /// down to a [`forum::THREAD_PAGE_SIZE`] boundary — mirrors the server-side
+    /// snapping in the thread GET view). Used so SSE pushes only touch the pages
+    /// they belong to instead of overwriting whatever page the viewer selected.
+    fn if_page_offset(
+        mut self,
+        cmp: &str,
+        offset: usize,
+        f: impl FnOnce(JsBuilder) -> JsBuilder,
+    ) -> Self {
+        let inner = f(JsBuilder::new()).build();
+        self.snippets.push(format!(
+            "var __slugOffRaw = new URLSearchParams(window.location.search).get('offset'); var __slugOffN = __slugOffRaw ? (parseInt(__slugOffRaw, 10) || 0) : 0; var __slugPageOff = __slugOffN - (__slugOffN % {page}); if (__slugPageOff {cmp} {offset}) {{ {inner} }}",
+            page = forum::THREAD_PAGE_SIZE,
+        ));
+        self
+    }
+
+    /// Viewer is on the latest page (`>=` absorbs offsets past the end, which the
+    /// GET view clamps to the latest page).
+    pub(crate) fn if_page_offset_at_least(
+        self,
+        offset: usize,
+        f: impl FnOnce(JsBuilder) -> JsBuilder,
+    ) -> Self {
+        self.if_page_offset(">=", offset, f)
+    }
+
+    pub(crate) fn if_page_offset_equals(
+        self,
+        offset: usize,
+        f: impl FnOnce(JsBuilder) -> JsBuilder,
+    ) -> Self {
+        self.if_page_offset("===", offset, f)
+    }
+
+    pub(crate) fn if_page_offset_below(
+        self,
+        offset: usize,
+        f: impl FnOnce(JsBuilder) -> JsBuilder,
+    ) -> Self {
+        self.if_page_offset("<", offset, f)
     }
 
     pub(crate) fn redirect(mut self, to: &str) -> Self {

--- a/server/tests/integration_ui.rs
+++ b/server/tests/integration_ui.rs
@@ -426,6 +426,159 @@ async fn test_sse_public_thread_morph_includes_post_body_not_thread_not_found() 
     );
 }
 
+/// The SSE thread-region push must be page-scoped: guarded morphs for the latest
+/// page (append target) and the page before it, never an unguarded rewrite that
+/// would overwrite whatever `?offset=` page a viewer selected.
+#[tokio::test]
+async fn test_sse_thread_morph_is_page_scoped_after_rollover() {
+    let (addr, _tmp, _log, _state, _handle) = create_test_server_with_state().await;
+    let client = reqwest::Client::new();
+    let bearer = test_bearer();
+
+    let thread_tag = "sse-page-scope";
+    // 11 posts → posts 0..=9 fill page offset 0, post 10 starts the latest page (offset 10).
+    for i in 0..11 {
+        let commands = serde_json::json!([{
+            "Post": { "room": "public", "thread_tag": thread_tag, "text": format!("seed post {i}") }
+        }]);
+        let resp = rpc_batch(&client, addr, Some(&bearer), commands).await;
+        assert_eq!(resp["results"][0]["ok"], serde_json::json!(true));
+    }
+
+    let thread_path = format!("/t/{thread_tag}");
+    let sse_resp = client
+        .get(format!(
+            "http://{addr}/sse?path={}",
+            urlencoding::encode(&thread_path)
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert!(sse_resp.status().is_success());
+
+    let reply_text = "post eleven lands on the latest page";
+    let rpc = ui_post_ingest_rpc("public", thread_tag, reply_text);
+    let _post = client
+        .post(format!("http://{addr}/ui"))
+        .header("Authorization", format!("Bearer {bearer}"))
+        .form(&[("__rpc__", rpc.as_str())])
+        .send()
+        .await
+        .unwrap();
+
+    let mut body = String::new();
+    let mut sse_resp = sse_resp;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while std::time::Instant::now() < deadline {
+        match tokio::time::timeout(std::time::Duration::from_millis(500), sse_resp.chunk()).await {
+            Ok(Ok(Some(chunk))) => {
+                body.push_str(&String::from_utf8_lossy(&chunk));
+                if body.contains(reply_text) {
+                    break;
+                }
+            }
+            Ok(Ok(None)) => break,
+            Ok(Err(err)) => panic!("sse read failed: {err}"),
+            Err(_) => {}
+        }
+    }
+
+    assert!(
+        body.contains(reply_text),
+        "latest-page morph should include new post text"
+    );
+    assert!(
+        body.contains("__slugPageOff >= 10"),
+        "thread morph must be guarded to the latest page (offset 10); got: {}",
+        &body[..body.len().min(2000)]
+    );
+    assert!(
+        body.contains("__slugPageOff === 0"),
+        "previous page (offset 0) should get a guarded refresh so its paginator sees the newer page"
+    );
+    assert!(
+        body.contains("seed post 0"),
+        "previous-page refresh should re-render page-0 posts"
+    );
+    // The new post must only appear inside the latest-page morph, after its guard —
+    // never before the first page guard (which would be an unguarded rewrite).
+    let first_guard = body.find("__slugPageOff").unwrap();
+    let reply_at = body.find(reply_text).unwrap();
+    assert!(
+        reply_at > first_guard,
+        "new post markup must be inside a page-offset guard"
+    );
+}
+
+/// Arbitrary `?offset=` values snap to fixed page windows so post positions are
+/// stable as a thread grows.
+#[tokio::test]
+async fn test_thread_view_offset_snaps_to_page_boundaries() {
+    let (addr, _tmp, _log, _state, _handle) = create_test_server_with_state().await;
+    let client = reqwest::Client::new();
+    let bearer = test_bearer();
+
+    let thread_tag = "page-snap";
+    for i in 0..11 {
+        let commands = serde_json::json!([{
+            "Post": { "room": "public", "thread_tag": thread_tag, "text": format!("chrono post {i}") }
+        }]);
+        let resp = rpc_batch(&client, addr, Some(&bearer), commands).await;
+        assert_eq!(resp["results"][0]["ok"], serde_json::json!(true));
+    }
+
+    // Default page = oldest window 0..10.
+    let first = client
+        .get(format!("http://{addr}/t/{thread_tag}"))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    assert!(first.contains("1–10 / 11"), "first page shows fixed window");
+    assert!(first.contains("chrono post 0"));
+    assert!(!first.contains("chrono post 10"));
+
+    // Mid-page offset snaps down to the containing page.
+    let snapped = client
+        .get(format!("http://{addr}/t/{thread_tag}?offset=7"))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    assert!(
+        snapped.contains("1–10 / 11"),
+        "offset=7 snaps to page starting at 0"
+    );
+
+    // Latest page is the short, page-aligned tail window.
+    let latest = client
+        .get(format!("http://{addr}/t/{thread_tag}?offset=10"))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    assert!(latest.contains("11–11 / 11"), "latest page is offset 10");
+    assert!(latest.contains("chrono post 10"));
+    assert!(!latest.contains("chrono post 9"));
+
+    // Offsets past the end clamp to the latest page.
+    let clamped = client
+        .get(format!("http://{addr}/t/{thread_tag}?offset=999"))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    assert!(clamped.contains("11–11 / 11"), "huge offset clamps to latest");
+}
+
 fn ui_vote_compare_post_rpc(
     room: &str,
     thread_tag: &str,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The live-push path for the thread forum view (`broadcast_web_refresh` → morph of `#thread-feed-region`) always rendered a **sliding "last PAGE_SIZE posts" window** (`offset = total - PAGE_SIZE`) and delivered it to **every** subscriber whose URL matched the thread path — including `?offset=N` pages.

1. On the latest page, each new post slid the window by one, so old posts shifted position instead of the new post simply appending.
2. On a non-latest page, the SSE morph replaced the viewer's page with the latest posts, making it impossible to read older pages while the thread was being posted to.

## Design

- **Fixed page windows.** Thread pages are now aligned to `PAGE_SIZE` boundaries (`0..10`, `10..20`, …). The latest page grows by appending until full, then a new page starts — posts never move once placed. Arbitrary `?offset=` values snap to the containing page (`latest_page_offset` / `snap_page_offset` in `server/src/html/forum/paginator.rs`).
- **Page-scoped push.** `thread_region_page_morphs` (`server/src/html/forum/feed.rs`) renders only the pages a change can affect: the latest page, the page before it (its paginator gains a live `newer →` link when a new page starts), and — for redactions — the page containing the changed post. Each morph is wrapped in a client-side guard on the viewer's effective `?offset` page (`JsBuilder::if_page_offset_*`), so viewers on older pages are never overwritten.
- **Poster response.** `post_success_response` morphs in place only when the poster is on the latest page; from an older page it redirects to the latest page so they see their post.
- Redact paths now pass the redacted post's chronological index so the page containing it refreshes live for its viewers.

## Testing

- New Rust integration tests: `test_sse_thread_morph_is_page_scoped_after_rollover`, `test_thread_view_offset_snaps_to_page_boundaries`; unit tests for the page-offset helpers.
- `cargo nextest run --workspace`: 293 tests pass; `cargo clippy --workspace`: warning set identical to baseline.
- Full Clojure suite `clojure -M:kaocha` (integration + Playwright browser tests, incl. `browser-sse` and `browser-ui-morph`): 22 tests, 587 assertions, 0 failures.
- Manual two-tab browser demo against a dev server with mock OAuth (25-post seeded thread): posts append at the bottom of the latest page (`?offset=20`) with no reshuffle of the posts above, and a second tab parked on page 1 (`/t/push-demo`) keeps showing posts #0–#9 while the thread is posted to — verified live SSE payloads carry only guarded morphs (`__slugPageOff >= 20`, `__slugPageOff === 10`) and nothing for page 0.

[forum_sse_append_and_old_page_isolation_demo.mp4](https://cursor.com/agents/bc-48a1a841-b241-413c-93f2-4974a639a3e4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fforum_sse_append_and_old_page_isolation_demo.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48a1a841-b241-413c-93f2-4974a639a3e4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48a1a841-b241-413c-93f2-4974a639a3e4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

