### PR TITLE
Highlight current item in garden recent-vote pairs

### DIFF
--- a/server/src/html/garden/render.rs
+++ b/server/src/html/garden/render.rs
@@ -11,7 +11,7 @@ use crate::{
         forum::ThreadNav,
         layout,
         now_ms,
-        format_ratio, ratio_pct,
+        format_ratio_current_markup, ratio_pct,
         recency_color_style,
         render_item_body_in_scope,
         theme_from_jar,
@@ -172,13 +172,30 @@ pub(super) async fn render_scope_view(
                             } @else {
                                 @for v in &e.caused_by {
                                     @let pct = ratio_pct(v.ratio_left, v.ratio_right);
-                                    @let left_class = if v.a.as_str() == model.item { "ratio-left current" } else { "ratio-left" };
-                                    @let right_class = if v.b.as_str() == model.item { "ratio-right current" } else { "ratio-right" };
+                                    @let a_is_current = v.a.as_str() == model.item;
+                                    @let b_is_current = v.b.as_str() == model.item;
+                                    @let left_class = if a_is_current { "ratio-left current" } else { "ratio-left" };
+                                    @let right_class = if b_is_current { "ratio-right current" } else { "ratio-right" };
                                     div class="rank-history-vote" {
                                         div class="ont-vote-header" {
-                                            a class="item-link" href=(item_href(v.a.as_str(), &nav)) { code { (item_code_label(v.a.as_str())) } }
-                                            span class="vote-ratio" { (format_ratio(v.ratio_left, v.ratio_right)) }
-                                            a class="item-link" href=(item_href(v.b.as_str(), &nav)) { code { (item_code_label(v.b.as_str())) } }
+                                            a class="item-link" href=(item_href(v.a.as_str(), &nav)) {
+                                                code { (item_code_label(v.a.as_str())) }
+                                                @if a_is_current {
+                                                    span class="vote-current-star" aria-label="current item" { "⭐" }
+                                                }
+                                            }
+                                            (format_ratio_current_markup(
+                                                v.ratio_left,
+                                                v.ratio_right,
+                                                a_is_current,
+                                                b_is_current,
+                                            ))
+                                            a class="item-link" href=(item_href(v.b.as_str(), &nav)) {
+                                                code { (item_code_label(v.b.as_str())) }
+                                                @if b_is_current {
+                                                    span class="vote-current-star" aria-label="current item" { "⭐" }
+                                                }
+                                            }
                                         }
                                         div class="ratio-bar" {
                                             div class=(left_class) style={(format!("width: {:.3}%;", pct))} {}

--- a/server/src/html/mod.rs
+++ b/server/src/html/mod.rs
@@ -495,6 +495,31 @@ pub(super) fn format_ratio(left: i32, right: i32) -> String {
     format!("{l}:{r}")
 }
 
+/// Vote ratio markup with the side matching the current garden item bolded.
+pub(super) fn format_ratio_current_markup(
+    left: i32,
+    right: i32,
+    bold_left: bool,
+    bold_right: bool,
+) -> Markup {
+    let (l, r) = crate::dsl::reduce_ratio(left, right);
+    html! {
+        span class="vote-ratio" {
+            @if bold_left {
+                strong class="vote-ratio-current" { (l) }
+            } @else {
+                (l)
+            }
+            ":"
+            @if bold_right {
+                strong class="vote-ratio-current" { (r) }
+            } @else {
+                (r)
+            }
+        }
+    }
+}
+
 /// Render a single breadcrumb segment with `/` separator.
 pub(super) fn bc_segment(label: &str, href: &str, is_current: bool) -> Markup {
     html! {
@@ -1109,5 +1134,35 @@ mod linkify_title_tests {
     fn no_title_when_body_missing_or_empty() {
         let html = linkify_slugs_with_prefix("x ~/a/b y", "/~", Some(&HashMap::new()));
         assert!(!html.contains(" title="));
+    }
+}
+
+#[cfg(test)]
+mod vote_ratio_markup_tests {
+    use super::*;
+
+    #[test]
+    fn format_ratio_current_markup_bolds_matching_side() {
+        let left = format_ratio_current_markup(75, 25, true, false).into_string();
+        assert!(
+            left.contains(r#"<strong class="vote-ratio-current">3</strong>:1"#),
+            "expected left side bolded, got {left}"
+        );
+
+        let right = format_ratio_current_markup(75, 25, false, true).into_string();
+        assert!(
+            right.contains(r#"3:<strong class="vote-ratio-current">1</strong>"#),
+            "expected right side bolded, got {right}"
+        );
+
+        let neither = format_ratio_current_markup(50, 50, false, false).into_string();
+        assert!(
+            neither.contains(">1:1<") || neither.contains("1:1"),
+            "expected plain reduced ratio, got {neither}"
+        );
+        assert!(
+            !neither.contains("vote-ratio-current"),
+            "no side should be bold when item is not in the pair: {neither}"
+        );
     }
 }

--- a/server/static/theme_default.css
+++ b/server/static/theme_default.css
@@ -424,6 +424,13 @@ div.vote-meta {
 }
 code.vote-left, code.vote-right { color: var(--signal); }
 span.vote-ratio { color: var(--meta); font-size: 12px; }
+span.vote-ratio strong.vote-ratio-current { color: var(--signal); font-weight: 700; }
+span.vote-current-star {
+  display: inline-block;
+  font-size: 11px;
+  line-height: 1;
+  margin-left: 0.2em;
+}
 
 div.ratio-bar {
   border: var(--bv) solid;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
In the garden item **vote history** panel (recent votes), each pair row now marks the currently selected item:

- ⭐ next to the current item in the pair
- the matching side of the `L:R` ratio is bolded

Ratio bars already used `.current` for the selected side; this makes the same selection obvious in the text pair list.

## Test plan
- [x] `cargo test -p slugsocial-server --lib vote_ratio_markup`
- [x] `cargo test -p slugsocial-server --lib garden::tests`
- [x] Seeded vote `~/langs/rust 3:1 ~/langs/go` and verified HTML:
  - on `/~/langs/rust`: star on rust, bold `**3**:1`
  - on `/~/langs/go`: star on go, bold `3:**1**`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc382fd5-b643-435e-85ca-e5a01e1f22dc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc382fd5-b643-435e-85ca-e5a01e1f22dc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

