### PR TITLE
Reject '/' in forum thread tags on write (#82)

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -37,6 +37,8 @@ Strict **CSP** that blocks `eval` would break the current app. Other projects ma
 
 - **`RpcCommand` / `POST /api/v0/rpc`** (`types/src/lib.rs`, `server/src/api/rpc.rs`): **Bearer-authenticated** JSON API for CLI, automation, and programmatic clients. Durable effects go through here (append to event log, then `apply_event`).
 
+- **Forum thread tags on write:** `validate_thread_tag` (`types/src/paths.rs`) canonicalizes then rejects empty tags and any tag containing `/` (would break `/t/:tag` routing). The new-thread form already constrains the charset client-side (`pattern="[a-z0-9_\\-]{1,64}"`); server write paths (`WriteCmd::Post` / `SystemIngest`, and UI `PostIngest` / `CheckIngest` / `VoteComparePost`) enforce the slash rule. Read/replay still uses `canonicalize_tag` only so historical tags keep resolving. System import tags use `:` instead of `/` (e.g. `import:https:::github.com:org:repo`).
+
 - **`HtmlUiAction` / `POST /ui`** (`server/src/html/ui_action.rs`, `server/src/api/ui_html.rs`): **Browser session** (cookie) UI commands. Payload is `__rpc__` + form fields. Most responses are **JS morphs**; some actions return **HTTP redirects** (see below).
 
 - **Do not add one-off POST routes** for browser mutations. New browser actions belong in **`HtmlUiAction`** behind **`POST /ui`**; new programmatic verbs belong in **`RpcCommand`** behind **`POST /api/v0/rpc`**. Ordinary shareable pages remain normal **`GET`** routes.
@@ -116,7 +118,7 @@ cargo run -p sorterc -- scan path/to/events.jsonl [--pretty]
 
 ### Testing
 
-- **Rust tests:** `cargo nextest run --workspace` (163 tests; requires `cargo-nextest`)
+- **Rust tests:** `cargo nextest run --workspace` (requires `cargo-nextest`)
 - **Clojure integration + browser tests:** `clojure -M:kaocha` (runs both `:http-integration` and `:browser` suites; the test harness builds release binaries, starts its own server instances with mock OAuth, and runs Playwright browser tests)
 - **Lint:** `cargo clippy --workspace` (warnings are expected; zero errors required)
 

--- a/server/src/api/ui_html.rs
+++ b/server/src/api/ui_html.rs
@@ -17,7 +17,7 @@ use crate::{
         handle_rpc_batch,
         rpc::{rpc_post_redact, rpc_post_with_bearer, rpc_room_delete, rpc_thread_graduate},
     },
-    canonical_path::canonicalize_tag,
+    canonical_path::{canonicalize_tag, validate_thread_tag},
     resolvers::resolve_github_children,
     html::vote_compare_post_success_js,
     html::{
@@ -104,7 +104,17 @@ async fn dispatch_ui_action(
                 return js_redirect("/login").into_response();
             };
             let room = room.trim().to_string();
-            let thread_tag = thread_tag.trim().to_string();
+            let thread_tag = match validate_thread_tag(&thread_tag) {
+                Ok(t) => t,
+                Err(msg) => {
+                    return form_js_error(
+                        error_target.as_ref(),
+                        &msg,
+                        "Thread tags are one /t/:tag path segment (no '/').",
+                    )
+                    .into_response();
+                }
+            };
             if text.trim().is_empty() {
                 return form_js_error(
                     error_target.as_ref(),
@@ -156,12 +166,19 @@ async fn dispatch_ui_action(
                 return js_redirect("/login").into_response();
             };
             let room = room.trim().to_string();
-            let thread_tag = canonicalize_tag(&thread_tag);
-            if thread_tag.is_empty() {
+            if let Err(msg) = validate_thread_tag(&thread_tag) {
+                if msg.contains("empty") {
+                    return form_js_error(
+                        error_target.as_ref(),
+                        "missing thread tag",
+                        "Set a thread tag before posting.",
+                    )
+                    .into_response();
+                }
                 return form_js_error(
                     error_target.as_ref(),
-                    "missing thread tag",
-                    "Set a thread tag before posting.",
+                    &msg,
+                    "Thread tags are one /t/:tag path segment (no '/').",
                 )
                 .into_response();
             }
@@ -208,15 +225,25 @@ async fn dispatch_ui_action(
             };
             let err_tgt = Some("vote-compare-errors".to_string());
             let room = room.trim().to_string();
-            let thread_tag = canonicalize_tag(&thread_tag);
-            if thread_tag.is_empty() {
-                return form_js_error(
-                    err_tgt.as_ref(),
-                    "missing thread",
-                    "Thread tag is required.",
-                )
-                .into_response();
-            }
+            let thread_tag = match validate_thread_tag(&thread_tag) {
+                Ok(t) => t,
+                Err(msg) if msg.contains("empty") => {
+                    return form_js_error(
+                        err_tgt.as_ref(),
+                        "missing thread",
+                        "Thread tag is required.",
+                    )
+                    .into_response();
+                }
+                Err(msg) => {
+                    return form_js_error(
+                        err_tgt.as_ref(),
+                        &msg,
+                        "Thread tags are one /t/:tag path segment (no '/').",
+                    )
+                    .into_response();
+                }
+            };
             let exp = explanation.trim();
             if exp.is_empty() {
                 return form_js_error(

--- a/server/src/api/validate.rs
+++ b/server/src/api/validate.rs
@@ -2,7 +2,7 @@ use axum::http::StatusCode;
 use std::collections::HashSet;
 
 use crate::{
-    canonical_path::canonicalize_tag,
+    canonical_path::validate_thread_tag,
     dsl,
     path_types::ItemId,
     reducer::{ReducerState, ScopeId},
@@ -142,9 +142,9 @@ pub fn validate_ingest_document(
     })
 }
 
-pub fn normalize_room_and_thread(room: &str, thread_tag: &str) -> (String, String) {
-    (
+pub fn normalize_room_and_thread(room: &str, thread_tag: &str) -> Result<(String, String), String> {
+    Ok((
         room.trim().to_string(),
-        canonicalize_tag(thread_tag),
-    )
+        validate_thread_tag(thread_tag)?,
+    ))
 }

--- a/server/src/api/write_actor.rs
+++ b/server/src/api/write_actor.rs
@@ -285,7 +285,10 @@ pub async fn writer_actor(mut rx: mpsc::Receiver<WriteCmd>, state: AppState) {
                         ),
                     };
 
-                    let (room_key, thread_id) = normalize_room_and_thread(&room, &thread_tag);
+                    let (room_key, thread_id) = normalize_room_and_thread(&room, &thread_tag)
+                        .map_err(|msg| {
+                            (msg, Some("thread tags are one /t/:tag segment (no '/')".into()))
+                        })?;
                     let scope = scope_from_room_wire(&room_key);
                     let is_private = !matches!(scope, ScopeId::Public);
                     if is_private && !reduced.rooms.contains(&room_key) {
@@ -503,7 +506,8 @@ pub async fn writer_actor(mut rx: mpsc::Receiver<WriteCmd>, state: AppState) {
                 reply,
             } => {
                 let out = async {
-                    let (room_key, thread_id) = normalize_room_and_thread(&room, &thread_tag);
+                    let (room_key, thread_id) = normalize_room_and_thread(&room, &thread_tag)
+                        .map_err(|msg| (msg, Some("system thread tags must not contain '/'".into())))?;
                     let scope = scope_from_room_wire(&room_key);
                     let is_private = !matches!(scope, ScopeId::Public);
                     let mut reduced = state.reduced.write().await;

--- a/server/src/canonical_path.rs
+++ b/server/src/canonical_path.rs
@@ -1,3 +1,5 @@
 //! Re-exports — implementations live in `slug-types` (`paths` module).
 
-pub use slug_types::paths::{canonicalize_item, canonicalize_tag, item_parent_path, item_path_segments};
+pub use slug_types::paths::{
+    canonicalize_item, canonicalize_tag, item_parent_path, item_path_segments, validate_thread_tag,
+};

--- a/server/tests/integration_rpc.rs
+++ b/server/tests/integration_rpc.rs
@@ -3,6 +3,30 @@ mod support;
 use support::*;
 
 #[tokio::test]
+async fn test_post_rejects_thread_tag_with_slash() {
+    let (addr, _tmp, _log, _handle) = create_test_server().await;
+    let client = reqwest::Client::new();
+    let b = test_bearer();
+
+    let batch = serde_json::json!([{
+        "Post": {
+            "room": "public",
+            "thread_tag": "foo/bar",
+            "text": "hello from a bad tag\n",
+            "return_rank_diff": false
+        }
+    }]);
+    let body = rpc_batch(&client, addr, Some(&b), batch).await;
+    let line = &body["results"][0];
+    assert_eq!(line["ok"], false);
+    let err = line["error"].as_str().unwrap_or_default();
+    assert!(
+        err.contains('/') || err.to_lowercase().contains("slash") || err.contains("thread tag"),
+        "expected slash rejection, got: {err}"
+    );
+}
+
+#[tokio::test]
 async fn test_ingest_actor_with_colons_is_detected_and_validated() {
     let (addr, _tmp, _log, _handle) = create_test_server().await;
     let client = reqwest::Client::new();

--- a/server/tests/integration_ui.rs
+++ b/server/tests/integration_ui.rs
@@ -34,6 +34,33 @@ async fn test_post_check_returns_targeted_js_error_for_missing_thread_tag() {
 }
 
 #[tokio::test]
+async fn test_post_check_rejects_thread_tag_with_slash() {
+    let (addr, _tmp, _log, _handle) = create_test_server().await;
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let bearer = test_bearer();
+
+    let rpc = ui_check_ingest_rpc("public", "foo/bar", "hello", "thread-compose-errors");
+    let resp = client
+        .post(format!("http://{addr}/ui"))
+        .header("Authorization", format!("Bearer {bearer}"))
+        .form(&[("__rpc__", rpc.as_str())])
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let js = resp.text().await.unwrap();
+    assert!(js.contains("#thread-compose-errors"));
+    assert!(
+        js.contains("must not contain"),
+        "expected slash rejection morph, got: {js}"
+    );
+}
+
+#[tokio::test]
 async fn test_choose_username_returns_evalable_js() {
     let (addr, _tmp, _log, state, _handle) = create_test_server_with_state().await;
     let client = reqwest::Client::builder()

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -13,7 +13,7 @@ pub use item_wire::{
     repair_collapsed_http_scheme, SLUG_TILDE_ONTOLOGY_ROOT,
 };
 pub use paths::{
-    canonicalize_tag, ForumThreadUrl, GardenItemUrl, RelativePath,
+    canonicalize_tag, validate_thread_tag, ForumThreadUrl, GardenItemUrl, RelativePath,
     room_id_from_route_segment, room_route_segment, ROOM_SHORT_ID_LEN,
     TildeHttpPathTail, TildeOntologyPath, TildePath, tilde_http_path_to_item_id,
 };

--- a/types/src/paths.rs
+++ b/types/src/paths.rs
@@ -70,6 +70,22 @@ pub fn canonicalize_tag(input: &str) -> String {
     input.trim().trim_start_matches('#').to_lowercase()
 }
 
+/// Canonicalize a forum thread tag for **writes**, rejecting values that break `/t/:tag` routing.
+///
+/// Read/replay paths keep using [`canonicalize_tag`] so historical tags still resolve.
+/// System import tags (e.g. `import:https:::github.com:org:repo`) are allowed — they use `:`
+/// instead of `/`.
+pub fn validate_thread_tag(input: &str) -> Result<String, String> {
+    let tag = canonicalize_tag(input);
+    if tag.is_empty() {
+        return Err("thread tag must not be empty".to_string());
+    }
+    if tag.contains('/') {
+        return Err("thread tag must not contain '/'".to_string());
+    }
+    Ok(tag)
+}
+
 // ---------------------------------------------------------------------------
 // Storage + input path newtypes
 // ---------------------------------------------------------------------------
@@ -581,5 +597,21 @@ mod tests {
     #[test]
     fn too_short_room_route_segment_rejected() {
         assert!(room_id_from_route_segment("9ab12cd").is_none());
+    }
+
+    #[test]
+    fn validate_thread_tag_accepts_plain_slugs() {
+        assert_eq!(validate_thread_tag("#Hello-World").unwrap(), "hello-world");
+        assert_eq!(
+            validate_thread_tag("import:https:::github.com:org:repo").unwrap(),
+            "import:https:::github.com:org:repo"
+        );
+    }
+
+    #[test]
+    fn validate_thread_tag_rejects_slash_and_empty() {
+        assert!(validate_thread_tag("foo/bar").is_err());
+        assert!(validate_thread_tag("  ").is_err());
+        assert!(validate_thread_tag("#").is_err());
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #82.

The new-thread form already constrains tags with `pattern="[a-z0-9_\\-]{1,64}"`, but RPC/CLI/`POST /ui` only ran `canonicalize_tag` (trim + lowercase). A tag like `foo/bar` could be stored and break `/t/:tag` routing.

### Changes
- Add `validate_thread_tag` in `types/src/paths.rs`: canonicalize, reject empty, reject `/`
- Enforce on `WriteCmd::Post` / `SystemIngest` via `normalize_room_and_thread`
- Early UI errors for `PostIngest`, `CheckIngest`, and `VoteComparePost`
- Read/replay still uses `canonicalize_tag` only (historical tags keep resolving)
- System import tags that use `:` instead of `/` remain allowed
- Integration + unit tests; brief note in `agents.md`

### Test plan
- [x] `cargo test -p slug-types validate_thread_tag`
- [x] `cargo test -p slugsocial-server --test integration_rpc test_post_rejects_thread_tag_with_slash`
- [x] `cargo test -p slugsocial-server --test integration_ui thread_tag`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d592ea7-c0d1-4814-935d-3bb8a259d54e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d592ea7-c0d1-4814-935d-3bb8a259d54e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

